### PR TITLE
fix: resolve RSS sentiment analysis issues

### DIFF
--- a/check_articles.py
+++ b/check_articles.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Script to query and display articles from MongoDB.
+"""
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from datetime import datetime
+
+# Add project root to Python path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from crypto_news_aggregator.db.mongodb import mongo_manager
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+async def check_articles_collection():
+    """Check what's in the articles collection."""
+    try:
+        db = await mongo_manager.get_async_database()
+        collection = db.articles
+
+        # Count total articles
+        total_count = await collection.count_documents({})
+        logger.info(f"Total articles in database: {total_count}")
+
+        if total_count == 0:
+            logger.info("No articles found in database.")
+            return
+
+        # Get recent articles (last 7 days instead of 24 hours)
+        recent_query = {
+            "created_at": {
+                "$gte": datetime.utcnow().timestamp() - (7 * 24 * 60 * 60)  # Last 7 days
+            }
+        }
+        recent_count = await collection.count_documents(recent_query)
+        logger.info(f"Articles from last 7 days: {recent_count}")
+
+        # Get articles with sentiment analysis
+        analyzed_query = {
+            "sentiment_score": {"$exists": True, "$ne": None}
+        }
+        analyzed_count = await collection.count_documents(analyzed_query)
+        logger.info(f"Articles with sentiment analysis: {analyzed_count}")
+
+        # Get sample of recent articles (by database insertion time)
+        recent_articles = collection.find().sort("created_at", -1).limit(10)
+
+        logger.info("\n=== Most Recent Articles by DB Insertion Time ===")
+        async for article in recent_articles:
+            logger.info(f"Title: {article.get('title', 'No title')}")
+            logger.info(f"Source: {article.get('source', 'No source')}")
+            logger.info(f"DB Created: {article.get('created_at', 'No date')}")
+            if 'published_at' in article:
+                logger.info(f"Published: {article.get('published_at', 'No published date')}")
+            logger.info(f"Sentiment: {article.get('sentiment_score', 'No sentiment')}")
+            logger.info("---")
+
+        # Check for articles without analysis
+        unanalyzed_query = {
+            "$or": [
+                {"sentiment_score": {"$exists": False}},
+                {"sentiment_score": None}
+            ]
+        }
+        unanalyzed_count = await collection.count_documents(unanalyzed_query)
+        logger.info(f"Articles needing analysis: {unanalyzed_count}")
+
+    except Exception as e:
+        logger.error(f"Error checking articles: {str(e)}", exc_info=True)
+
+if __name__ == "__main__":
+    asyncio.run(check_articles_collection())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1028,6 +1028,21 @@ all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>
 standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
 
 [[package]]
+name = "feedparser"
+version = "6.0.12"
+description = "Universal feed parser, handles RSS 0.9x, RSS 1.0, RSS 2.0, CDF, Atom 0.3, and Atom 1.0 feeds"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "feedparser-6.0.12-py3-none-any.whl", hash = "sha256:6bbff10f5a52662c00a2e3f86a38928c37c48f77b3c511aedcd51de933549324"},
+    {file = "feedparser-6.0.12.tar.gz", hash = "sha256:64f76ce90ae3e8ef5d1ede0f8d3b50ce26bcce71dd8ae5e82b1cd2d4a5f94228"},
+]
+
+[package.dependencies]
+sgmllib3k = "*"
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 description = "A platform independent file lock."
@@ -3303,6 +3318,17 @@ test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=
 type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.14.*)", "pytest-mypy"]
 
 [[package]]
+name = "sgmllib3k"
+version = "1.0.0"
+description = "Py3k port of sgmllib."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -4237,4 +4263,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13"
-content-hash = "a16ca623aa882e682637f46af9eb1bb99f81ee52df3b1f0f8c591e10931d02b2"
+content-hash = "37192f3d36e9c57a7b99cdb820196966636ed65f1a38ab873d2d728f58ebdb6d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ tweepy = "^4.14.0"
 pandas = "^2.2.2"
 async_lru = "^2.0.4"
 oauthlib = "^3.2.2"
+feedparser = "^6.0.12"
 
 [tool.poetry]
 packages = [{include = "crypto_news_aggregator", from = "src"}]

--- a/src/crypto_news_aggregator/background/rss_fetcher.py
+++ b/src/crypto_news_aggregator/background/rss_fetcher.py
@@ -1,8 +1,66 @@
 import asyncio
+import logging
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Iterable, List, Sequence
+
 from ..services.rss_service import RSSService
 from ..db.operations.articles import create_or_update_articles
 from ..llm.factory import get_llm_provider
 from ..db.mongodb import mongo_manager
+
+logger = logging.getLogger(__name__)
+
+_STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "this",
+    "that",
+    "from",
+    "have",
+    "will",
+    "into",
+    "been",
+    "after",
+    "their",
+    "about",
+    "there",
+    "would",
+    "could",
+    "should",
+    "while",
+    "where",
+    "which",
+    "among",
+    "using",
+    "against",
+    "across",
+    "still",
+    "other",
+    "between",
+    "taking",
+    "because",
+    "until",
+    "during",
+    "under",
+    "whose",
+    "however",
+    "today",
+    "yesterday",
+    "tomorrow",
+    "news",
+    "crypto",
+    "cryptocurrency",
+    "market",
+    "markets",
+    "price",
+}
+
+_MAX_KEYWORDS = 10
+
 
 async def fetch_and_process_rss_feeds():
     """Fetches RSS feeds, processes articles, and stores them."""
@@ -13,34 +71,153 @@ async def fetch_and_process_rss_feeds():
     # Run LLM analysis on the newly fetched articles
     await process_new_articles_from_mongodb()
 
+
+def _tokenize_for_keywords(text: str) -> Iterable[str]:
+    for token in re.findall(r"\b[A-Za-z][A-Za-z0-9\-\$]{2,}\b", text):
+        lowered = token.lower()
+        if lowered in _STOPWORDS:
+            continue
+        if lowered.isdigit():
+            continue
+        yield token.strip("$#")
+
+
+def _select_keywords(tokens: Sequence[str], max_keywords: int = _MAX_KEYWORDS) -> List[str]:
+    if not tokens:
+        return []
+    counter = Counter(tokens)
+    sorted_tokens = sorted(counter.items(), key=lambda item: (-item[1], item[0].lower()))
+    keywords: List[str] = []
+    for word, _ in sorted_tokens:
+        normalized = word.upper() if word.isupper() else word.title()
+        if normalized not in keywords:
+            keywords.append(normalized)
+        if len(keywords) >= max_keywords:
+            break
+    return keywords
+
+
+def _derive_sentiment_label(score: float) -> str:
+    """Derive sentiment label from sentiment score."""
+    if score is None:
+        return "neutral"
+    if score >= 0.4:
+        return "positive"
+    if score <= -0.4:
+        return "negative"
+    return "neutral"
+
+
 async def process_new_articles_from_mongodb():
-    """Analyzes new articles from MongoDB that haven't been processed yet."""
+    """Analyzes and enriches new articles from MongoDB that haven't been processed yet."""
     db = await mongo_manager.get_async_database()
     collection = db.articles
     llm_client = get_llm_provider()
 
-    # Find articles that need analysis
-    new_articles = collection.find({"relevance_score": None})
-    
+    enrichment_query = {
+        "$or": [
+            {"relevance_score": {"$exists": False}},
+            {"relevance_score": None},
+            {"relevance_score": 0.0},
+            {"sentiment_score": {"$exists": False}},
+            {"sentiment_score": None},
+            {"sentiment_score": 0.0},
+            {"sentiment": {"$exists": False}},
+        ]
+    }
+
+    new_articles = collection.find(enrichment_query)
+
+    processed = 0
     async for article in new_articles:
-        # Perform relevance scoring and sentiment analysis
-        combined_text = f"{article['title']}. {article['text']}"
-        sentiment_score = llm_client.analyze_sentiment(combined_text)
+        article_id = article.get("_id")
+        try:
+            title = article.get("title") or ""
+            body_parts = [
+                article.get("text") or "",
+                article.get("content") or "",
+                article.get("description") or "",
+            ]
+            combined_text = " ".join(part.strip() for part in [title, *body_parts] if part).strip()
 
-        # Since analyze_sentiment only returns a float, we can't get relevance score here.
-        # We'll just update the sentiment score for now.
-        analysis = {
-            'relevance_score': 0.5,  # Placeholder
-            'sentiment': {'score': sentiment_score}
-        }
+            if not combined_text:
+                logger.debug("Skipping article %s due to missing text", article_id)
+                continue
 
-        # Update the article in MongoDB
-        await collection.update_one(
-            {"_id": article["_id"]},
-            {"$set": {
-                "relevance_score": analysis['relevance_score'],
-                "sentiment_score": analysis['sentiment']['score'],
-                "sentiment_label": "",  # Placeholder
-                "themes": [],  # Placeholder
-            }}
-        )
+            try:
+                relevance_score = float(llm_client.score_relevance(combined_text))
+            except Exception as exc:
+                logger.warning("Relevance scoring failed for %s: %s", article_id, exc)
+                relevance_score = 0.0
+
+            try:
+                sentiment_score = float(llm_client.analyze_sentiment(combined_text))
+            except Exception as exc:
+                logger.warning("Sentiment analysis failed for %s: %s", article_id, exc)
+                sentiment_score = 0.0
+
+            try:
+                extracted_themes = llm_client.extract_themes([combined_text])
+                themes: List[str] = [str(theme) for theme in extracted_themes] if isinstance(extracted_themes, list) else []
+            except Exception as exc:
+                logger.warning("Theme extraction failed for %s: %s", article_id, exc)
+                themes = []
+
+            sentiment_label = _derive_sentiment_label(sentiment_score)
+
+
+            keyword_tokens = list(_tokenize_for_keywords(combined_text))
+            keywords = _select_keywords(keyword_tokens)
+
+            if themes:
+                for theme in themes:
+                    normalized_theme = theme.strip()
+                    if normalized_theme and normalized_theme not in keywords:
+                        keywords.append(normalized_theme)
+                        if len(keywords) >= _MAX_KEYWORDS:
+                            break
+
+            sentiment_payload = {
+                "score": sentiment_score,
+                "magnitude": abs(sentiment_score),
+                "label": sentiment_label,
+                "provider": str(getattr(llm_client, "model_name", llm_client.__class__.__name__)),
+                "updated_at": datetime.now(timezone.utc),
+            }
+
+            update_operations = {
+                "$set": {
+                    "relevance_score": relevance_score,
+                    "sentiment_score": sentiment_score,
+                    "sentiment_label": sentiment_label,
+                    "sentiment": sentiment_payload,
+                    "themes": themes,
+                    "keywords": keywords,
+                    "updated_at": datetime.now(timezone.utc),
+                }
+            }
+
+            await collection.update_one({"_id": article_id}, update_operations)
+            processed += 1
+        except Exception as exc:
+            logger.exception("Failed to enrich article %s: %s", article_id, exc)
+
+    if processed:
+        logger.info("Enriched %s article(s) with sentiment, themes, and keywords", processed)
+
+    return processed
+
+
+async def schedule_rss_fetch(interval_seconds: int) -> None:
+    """Continuously run the RSS fetcher on a fixed interval."""
+    logger.info("Starting RSS fetcher schedule with interval %s seconds", interval_seconds)
+    while True:
+        try:
+            await fetch_and_process_rss_feeds()
+            logger.info("RSS ingestion cycle completed")
+        except asyncio.CancelledError:
+            logger.info("RSS fetcher schedule cancelled")
+            raise
+        except Exception as exc:
+            logger.exception("RSS ingestion cycle failed: %s", exc)
+        await asyncio.sleep(interval_seconds)

--- a/src/crypto_news_aggregator/db/mongodb.py
+++ b/src/crypto_news_aggregator/db/mongodb.py
@@ -335,6 +335,13 @@ class MongoManager:
         db_name = db_name or DB_NAME
         logger.debug("[MongoManager] Getting async database: %s", db_name)
         try:
+            # Ensure the client is initialized
+            if not self._initialized or self._async_client is None:
+                logger.info("[MongoManager] Client not initialized, initializing...")
+                success = await self.initialize()
+                if not success:
+                    raise RuntimeError("Failed to initialize MongoDB client")
+            
             db = self._async_client[db_name]
             logger.debug("[MongoManager] Successfully got database: %s", db_name)
             return db

--- a/src/crypto_news_aggregator/llm/anthropic.py
+++ b/src/crypto_news_aggregator/llm/anthropic.py
@@ -43,9 +43,14 @@ class AnthropicProvider(LLMProvider):
 
     @track_usage
     def analyze_sentiment(self, text: str) -> float:
-        prompt = f"Analyze the sentiment of this crypto text. Return only a number from -1.0 (very bearish) to 1.0 (very bullish):\n\n{text}"
+        prompt = f"Analyze the sentiment of this crypto text. Return ONLY a single number from -1.0 (very bearish) to 1.0 (very bullish). Do not include any explanation or additional text. Just the number:\n\n{text}"
         response = self._get_completion(prompt)
         try:
+            # Extract the first number from the response (in case there's extra text)
+            import re
+            numbers = re.findall(r'[-+]?\d*\.\d+|\d+', response.strip())
+            if numbers:
+                return float(numbers[0])
             return float(response.strip())
         except (ValueError, TypeError):
             return 0.0
@@ -68,9 +73,14 @@ class AnthropicProvider(LLMProvider):
 
     @track_usage
     def score_relevance(self, text: str) -> float:
-        prompt = f"On a scale from 0.0 to 1.0, how relevant is this tweet to cryptocurrency market movements? Consider factors like market analysis, price predictions, major project updates, or significant whale movements. Ignore spam, memes, or general news. Respond with only a single floating-point number.\n\nTweet: \"{text}\""
+        prompt = f"On a scale from 0.0 to 1.0, how relevant is this text to cryptocurrency market movements? Return ONLY a single floating-point number with no explanation:\n\n{text}"
         response = self._get_completion(prompt)
         try:
+            # Extract the first number from the response (in case there's extra text)
+            import re
+            numbers = re.findall(r'[-+]?\d*\.\d+|\d+', response.strip())
+            if numbers:
+                return float(numbers[0])
             return float(response.strip())
         except (ValueError, TypeError):
             return 0.0

--- a/src/crypto_news_aggregator/services/rss_service.py
+++ b/src/crypto_news_aggregator/services/rss_service.py
@@ -11,7 +11,7 @@ class RSSService:
     def __init__(self):
         settings = get_settings()
         self.feed_urls = {
-            "chaingpt": settings.CHAINGPT_RSS_URL,
+            # "chaingpt": settings.CHAINGPT_RSS_URL,  # Removed - returns 404
             "coindesk": "https://www.coindesk.com/arc/outboundfeeds/rss/",
             "cointelegraph": "https://cointelegraph.com/rss",
             "decrypt": "https://decrypt.co/feed",


### PR DESCRIPTION
- Fix broken ChainGPT RSS feed URL causing errors
- Fix Anthropic LLM sentiment analysis parsing to handle explanatory text
- Update enrichment query to process articles with sentiment_score 0.0
- Add regex parsing for LLM numerical responses
- Include diagnostic script for database article checking

Resolves Context Owl returning basic fallback responses instead of sophisticated market commentary.