### PR TITLE
feat: integrate background workers into FastAPI lifespan

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,1 @@
-web: gunicorn --pythonpath src -c gunicorn.conf.py crypto_news_aggregator.main:app
-worker: python src/crypto_news_aggregator/worker.py
+web: uvicorn crypto_news_aggregator.main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
- Move all background tasks (RSS, signals, narratives, alerts, price monitor) into web process
- Remove separate worker process from Procfile (Railway doesn't support long-running release commands)
- Background tasks now start during FastAPI lifespan startup
- Graceful shutdown cancels all background tasks
- Reduces Railway resource usage (single process instead of two)