### PR TITLE
feat: run background tasks immediately on startup

### DIFF
--- a/src/crypto_news_aggregator/main.py
+++ b/src/crypto_news_aggregator/main.py
@@ -100,6 +100,7 @@ async def lifespan(app: FastAPI):
             schedule_narrative_updates,
             schedule_alert_checks
         )
+        # Lazy import to avoid triggering tasks/__init__.py which imports celery
         from .tasks.price_monitor import get_price_monitor
         
         # Create background tasks with immediate execution for data availability

--- a/src/crypto_news_aggregator/main.py
+++ b/src/crypto_news_aggregator/main.py
@@ -102,16 +102,16 @@ async def lifespan(app: FastAPI):
         )
         from .tasks.price_monitor import get_price_monitor
         
-        # Create background tasks
+        # Create background tasks with immediate execution for data availability
         price_monitor = get_price_monitor()
         background_tasks.extend([
             asyncio.create_task(price_monitor.start(), name="price_monitor"),
-            asyncio.create_task(schedule_rss_fetch(1800), name="rss_fetcher"),
-            asyncio.create_task(update_signal_scores(), name="signal_scores"),
-            asyncio.create_task(schedule_narrative_updates(600), name="narratives"),
-            asyncio.create_task(schedule_alert_checks(120), name="alerts")
+            asyncio.create_task(schedule_rss_fetch(1800, run_immediately=True), name="rss_fetcher"),
+            asyncio.create_task(update_signal_scores(run_immediately=True), name="signal_scores"),
+            asyncio.create_task(schedule_narrative_updates(600, run_immediately=True), name="narratives"),
+            asyncio.create_task(schedule_alert_checks(120, run_immediately=True), name="alerts")
         ])
-        logger.info(f"Started {len(background_tasks)} background worker tasks")
+        logger.info(f"Started {len(background_tasks)} background worker tasks with immediate data fetch")
     
     yield
     

--- a/src/crypto_news_aggregator/worker.py
+++ b/src/crypto_news_aggregator/worker.py
@@ -23,14 +23,21 @@ logging.basicConfig(
 )
 
 
-async def update_signal_scores():
+async def update_signal_scores(run_immediately: bool = False):
     """
     Update signal scores for trending entities.
     
     Runs every 2 minutes to calculate signal scores for entities
     mentioned in the last 30 minutes.
+    
+    Args:
+        run_immediately: If True, run first update immediately on startup
     """
     logger.info("Starting signal score update task")
+    
+    if not run_immediately:
+        # Wait before first run if not immediate
+        await asyncio.sleep(120)
     
     while True:
         try:
@@ -146,18 +153,31 @@ async def update_narratives():
         logger.exception(f"Error updating narratives: {e}")
 
 
-async def schedule_narrative_updates(interval_seconds: int) -> None:
-    """Continuously run narrative updates on a fixed interval."""
+async def schedule_narrative_updates(interval_seconds: int, run_immediately: bool = False) -> None:
+    """Continuously run narrative updates on a fixed interval.
+    
+    Args:
+        interval_seconds: Time to wait between narrative update cycles
+        run_immediately: If True, run first update immediately on startup
+    """
     logger.info("Starting narrative update schedule with interval %s seconds", interval_seconds)
+    
+    if run_immediately:
+        logger.info("Running initial narrative detection on startup...")
+        try:
+            await update_narratives()
+        except Exception as exc:
+            logger.exception("Initial narrative update failed: %s", exc)
+    
     while True:
         try:
+            await asyncio.sleep(interval_seconds)
             await update_narratives()
         except asyncio.CancelledError:
             logger.info("Narrative update schedule cancelled")
             raise
         except Exception as exc:
             logger.exception("Narrative update cycle failed: %s", exc)
-        await asyncio.sleep(interval_seconds)
 
 
 async def check_alerts():
@@ -179,18 +199,31 @@ async def check_alerts():
         logger.exception(f"Error checking alerts: {e}")
 
 
-async def schedule_alert_checks(interval_seconds: int) -> None:
-    """Continuously run alert checks on a fixed interval."""
+async def schedule_alert_checks(interval_seconds: int, run_immediately: bool = False) -> None:
+    """Continuously run alert checks on a fixed interval.
+    
+    Args:
+        interval_seconds: Time to wait between alert check cycles
+        run_immediately: If True, run first check immediately on startup
+    """
     logger.info("Starting alert check schedule with interval %s seconds", interval_seconds)
+    
+    if run_immediately:
+        logger.info("Running initial alert check on startup...")
+        try:
+            await check_alerts()
+        except Exception as exc:
+            logger.exception("Initial alert check failed: %s", exc)
+    
     while True:
         try:
+            await asyncio.sleep(interval_seconds)
             await check_alerts()
         except asyncio.CancelledError:
             logger.info("Alert check schedule cancelled")
             raise
         except Exception as exc:
             logger.exception("Alert check cycle failed: %s", exc)
-        await asyncio.sleep(interval_seconds)
 
 
 async def main():

--- a/src/crypto_news_aggregator/worker.py
+++ b/src/crypto_news_aggregator/worker.py
@@ -7,7 +7,6 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from crypto_news_aggregator.tasks.price_monitor import get_price_monitor
 from crypto_news_aggregator.background.rss_fetcher import schedule_rss_fetch
 from crypto_news_aggregator.core.config import get_settings
 from crypto_news_aggregator.db.mongodb import initialize_mongodb, mongo_manager
@@ -235,6 +234,9 @@ async def main():
 
     tasks = []
     if not settings.TESTING:
+        # Lazy import to avoid triggering tasks/__init__.py which imports celery
+        from crypto_news_aggregator.tasks.price_monitor import get_price_monitor
+        
         price_monitor = get_price_monitor()
         logger.info("Starting price monitor task...")
         tasks.append(asyncio.create_task(price_monitor.start()))


### PR DESCRIPTION
- Add run_immediately flag to RSS fetcher, signal scores, narratives, and alerts
- Execute initial data fetch/processing on server startup for immediate data availability
- Ensures fresh data is available right after deployment without waiting for first interval
- RSS fetch runs immediately (30 min interval)
- Signal scores run immediately (2 min interval)
- Narratives run immediately (10 min interval)
- Alerts run immediately (2 min interval)