### PR TITLE
fix: update Procfile to use root main.py for proper Python path

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn crypto_news_aggregator.main:app --host 0.0.0.0 --port $PORT
+web: uvicorn main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
- Change from crypto_news_aggregator.main:app to main:app
- Root main.py handles src/ directory path setup
- Fixes ModuleNotFoundError on Railway deployment