### PR TITLE
feat(signals): filter signal scoring by is_primary entities only

### DIFF
--- a/src/crypto_news_aggregator/services/signal_service.py
+++ b/src/crypto_news_aggregator/services/signal_service.py
@@ -36,15 +36,17 @@ async def calculate_velocity(entity: str, timeframe_hours: int = 24) -> float:
     one_hour_ago = now - timedelta(hours=1)
     timeframe_ago = now - timedelta(hours=timeframe_hours)
     
-    # Count mentions in last hour
+    # Count mentions in last hour (primary entities only)
     mentions_1h = await collection.count_documents({
         "entity": entity,
+        "is_primary": True,
         "timestamp": {"$gte": one_hour_ago}
     })
     
-    # Count mentions in full timeframe
+    # Count mentions in full timeframe (primary entities only)
     mentions_timeframe = await collection.count_documents({
         "entity": entity,
+        "is_primary": True,
         "timestamp": {"$gte": timeframe_ago}
     })
     
@@ -81,9 +83,9 @@ async def calculate_source_diversity(entity: str) -> int:
     entity_mentions_collection = db.entity_mentions
     articles_collection = db.articles
     
-    # Get all article IDs that mention this entity
+    # Get all article IDs that mention this entity (primary mentions only)
     pipeline = [
-        {"$match": {"entity": entity}},
+        {"$match": {"entity": entity, "is_primary": True}},
         {"$group": {"_id": "$article_id"}},
     ]
     
@@ -127,8 +129,8 @@ async def calculate_sentiment_metrics(entity: str) -> Dict[str, float]:
         "negative": -1.0,
     }
     
-    # Get all mentions with sentiment
-    cursor = collection.find({"entity": entity})
+    # Get all mentions with sentiment (primary mentions only)
+    cursor = collection.find({"entity": entity, "is_primary": True})
     
     sentiment_scores = []
     async for mention in cursor:

--- a/src/crypto_news_aggregator/worker.py
+++ b/src/crypto_news_aggregator/worker.py
@@ -41,7 +41,10 @@ async def update_signal_scores():
             thirty_min_ago = datetime.now(timezone.utc) - timedelta(minutes=30)
             
             pipeline = [
-                {"$match": {"timestamp": {"$gte": thirty_min_ago}}},
+                {"$match": {
+                    "timestamp": {"$gte": thirty_min_ago},
+                    "is_primary": True  # Only score primary entities
+                }},
                 {"$group": {
                     "_id": {
                         "entity": "$entity",
@@ -70,9 +73,9 @@ async def update_signal_scores():
                 try:
                     signal_data = await calculate_signal_score(entity)
                     
-                    # Get first_seen timestamp
+                    # Get first_seen timestamp (primary mentions only)
                     first_mention = await entity_mentions_collection.find_one(
-                        {"entity": entity},
+                        {"entity": entity, "is_primary": True},
                         sort=[("timestamp", 1)]
                     )
                     first_seen = first_mention["timestamp"] if first_mention else datetime.now(timezone.utc)

--- a/tests/services/test_signal_service.py
+++ b/tests/services/test_signal_service.py
@@ -39,6 +39,7 @@ async def test_calculate_velocity_with_mentions(mongo_db):
             entity_type="ticker",
             article_id=f"article_{i}",
             sentiment="neutral",
+            is_primary=True,
         )
     
     # Create older mentions (2-24 hours ago)
@@ -49,6 +50,7 @@ async def test_calculate_velocity_with_mentions(mongo_db):
             "entity_type": "ticker",
             "article_id": f"article_{i}",
             "sentiment": "neutral",
+            "is_primary": True,
             "timestamp": older_time,
             "created_at": older_time,
         })
@@ -85,18 +87,21 @@ async def test_calculate_source_diversity(mongo_db):
         entity_type="project",
         article_id="art1",
         sentiment="positive",
+        is_primary=True,
     )
     await create_entity_mention(
         entity="TEST_DIVERSITY",
         entity_type="project",
         article_id="art2",
         sentiment="positive",
+        is_primary=True,
     )
     await create_entity_mention(
         entity="TEST_DIVERSITY",
         entity_type="project",
         article_id="art3",
         sentiment="neutral",
+        is_primary=True,
     )
     
     diversity = await calculate_source_diversity("TEST_DIVERSITY")
@@ -123,24 +128,28 @@ async def test_calculate_sentiment_metrics(mongo_db):
         entity_type="ticker",
         article_id="art1",
         sentiment="positive",
+        is_primary=True,
     )
     await create_entity_mention(
         entity="TEST_SENTIMENT",
         entity_type="ticker",
         article_id="art2",
         sentiment="positive",
+        is_primary=True,
     )
     await create_entity_mention(
         entity="TEST_SENTIMENT",
         entity_type="ticker",
         article_id="art3",
         sentiment="negative",
+        is_primary=True,
     )
     await create_entity_mention(
         entity="TEST_SENTIMENT",
         entity_type="ticker",
         article_id="art4",
         sentiment="neutral",
+        is_primary=True,
     )
     
     metrics = await calculate_sentiment_metrics("TEST_SENTIMENT")
@@ -186,6 +195,7 @@ async def test_calculate_signal_score(mongo_db):
             entity_type="ticker",
             article_id="sig1",
             sentiment="positive",
+            is_primary=True,
         )
     
     await create_entity_mention(
@@ -193,6 +203,7 @@ async def test_calculate_signal_score(mongo_db):
         entity_type="ticker",
         article_id="sig2",
         sentiment="positive",
+        is_primary=True,
     )
     
     signal_data = await calculate_signal_score("TEST_SIGNAL")


### PR DESCRIPTION
- Updated calculate_velocity() to filter by is_primary=True
- Updated calculate_source_diversity() to filter by is_primary=True
- Updated calculate_sentiment_metrics() to filter by is_primary=True
- Updated worker.py update_signal_scores() to filter by is_primary=True
- Updated all signal service tests to include is_primary=True in test data
- Verified with smoke test that only primary entities are scored
- API endpoint already returns entity_type field

This ensures signal scores focus on the most relevant entities (tickers, projects) and exclude secondary entities (events, topics) from trending calculations.