### PR TITLE
chore(ui): add .vite directory to gitignore

### DIFF
--- a/context-owl-ui/.gitignore
+++ b/context-owl-ui/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
- Ignore Vite build cache directory
- Prevents build artifacts from being tracked