### PR TITLE
fix: add missing OPENAI_API_KEY to Settings class

### DIFF
--- a/src/crypto_news_aggregator/core/config.py
+++ b/src/crypto_news_aggregator/core/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
 
     # API Keys (these will be loaded from environment variables)
     LLM_PROVIDER: str = "openai"  # Default provider, will be overridden by .env
+    OPENAI_API_KEY: str = ""  # OpenAI API key for LLM operations
     NEWS_API_KEY: str = ""  # Kept for backward compatibility
     TWITTER_BEARER_TOKEN: str = ""
     ANTHROPIC_API_KEY: str = ""


### PR DESCRIPTION
Critical bug fix: RSS fetcher was failing in Railway because OPENAI_API_KEY was not defined in the Settings class, causing LLM provider initialization to fail.

Error: 'Settings' object has no attribute 'OPENAI_API_KEY'

This prevented the RSS fetcher from running, resulting in no new articles being fetched for the past 20 hours.

Impact:
- RSS fetcher now works correctly
- Articles will be fetched every 30 minutes
- LLM enrichment (sentiment, entities, themes) will resume