### PR TITLE
fix: configure LLM provider to use only Anthropic

### DIFF
--- a/src/crypto_news_aggregator/core/config.py
+++ b/src/crypto_news_aggregator/core/config.py
@@ -37,8 +37,8 @@ class Settings(BaseSettings):
     DATABASE_URL: Optional[str] = None
 
     # API Keys (these will be loaded from environment variables)
-    LLM_PROVIDER: str = "openai"  # Default provider, will be overridden by .env
-    OPENAI_API_KEY: str = ""  # OpenAI API key for LLM operations
+    LLM_PROVIDER: str = "anthropic"  # Default provider, will be overridden by .env
+    OPENAI_API_KEY: str = ""  # OpenAI API key for LLM operations (deprecated)
     NEWS_API_KEY: str = ""  # Kept for backward compatibility
     TWITTER_BEARER_TOKEN: str = ""
     ANTHROPIC_API_KEY: str = ""

--- a/src/crypto_news_aggregator/llm/factory.py
+++ b/src/crypto_news_aggregator/llm/factory.py
@@ -3,13 +3,11 @@ from typing import List, Optional
 from .base import LLMProvider
 from .sentient import SentientProvider
 from .anthropic import AnthropicProvider
-from .openai import OpenAIProvider
 from ..core.config import get_settings
 
 PROVIDER_MAP = {
     "sentient": SentientProvider,
     "anthropic": AnthropicProvider,
-    "openai": OpenAIProvider,
 }
 
 
@@ -22,7 +20,7 @@ def get_llm_provider() -> LLMProvider:
     :return: An instance of the LLM provider.
     """
     settings = get_settings()
-    provider_name = getattr(settings, "LLM_PROVIDER", "openai").lower()
+    provider_name = getattr(settings, "LLM_PROVIDER", "anthropic").lower()
     providers_to_try = [provider_name]
 
     last_exception = None
@@ -33,8 +31,9 @@ def get_llm_provider() -> LLMProvider:
                 api_key = None
                 if name == "anthropic":
                     api_key = settings.ANTHROPIC_API_KEY
-                elif name == "openai":
-                    api_key = settings.OPENAI_API_KEY
+                elif name == "sentient":
+                    # Sentient provider may have its own API key handling
+                    api_key = getattr(settings, "SENTIENT_API_KEY", None)
 
                 return provider_class(api_key=api_key)
             except Exception as e:


### PR DESCRIPTION
- Changed default LLM_PROVIDER from 'openai' to 'anthropic' in config.py
- Removed OpenAI provider from factory.py imports and PROVIDER_MAP
- Updated provider initialization to handle only anthropic and sentient
- Removed OpenAI-specific API key handling from factory

This fixes the AttributeError where OpenAIProvider was missing the extract_entities_batch method. The system now exclusively uses AnthropicProvider which has full implementation.

Fixes RSS fetcher entity extraction failures.