### PR TITLE
fix(ui): improve entity type display with formatted labels and colore…

### DIFF
--- a/ENTITY_TYPE_DISPLAY_FIX.md
+++ b/ENTITY_TYPE_DISPLAY_FIX.md
@@ -1,0 +1,100 @@
+# Entity Type Display Fix
+
+## Issue
+The frontend was displaying entity types like "CRYPTO_ENTITY" instead of proper, user-friendly labels like "Cryptocurrency", "Company", etc.
+
+## Root Cause Analysis
+
+### Data Flow
+1. **LLM Extraction** (`src/crypto_news_aggregator/llm/anthropic.py`)
+   - Claude returns detailed entity types: `cryptocurrency`, `blockchain`, `protocol`, `company`, `organization`, `event`, `concept`, `person`, `location`
+   
+2. **Entity Mentions Storage** (`src/crypto_news_aggregator/background/rss_fetcher.py`)
+   - Entity types from LLM are stored as-is in `entity_mentions` collection
+   
+3. **Signal Calculation** (`src/crypto_news_aggregator/worker.py`)
+   - Worker reads entity_type from `entity_mentions` and passes it to `signal_scores`
+   
+4. **API Response** (`src/crypto_news_aggregator/api/v1/endpoints/signals.py`)
+   - API returns entity_type directly from `signal_scores`
+   
+5. **Frontend Display** (`context-owl-ui/src/pages/Signals.tsx`)
+   - Frontend was using simple string replacement: `entity_type.replace(/_/g, ' ')`
+   - This worked for snake_case but didn't provide proper capitalization or formatting
+
+### What Was Happening
+- If MongoDB had "CRYPTO_ENTITY" (which shouldn't happen with current LLM), it would display as "CRYPTO ENTITY"
+- Proper LLM types like "cryptocurrency" would display as "cryptocurrency" (lowercase, not ideal)
+- The display lacked visual distinction between different entity types
+
+## Solution
+
+### Frontend Improvements
+Added two new formatter functions in `context-owl-ui/src/lib/formatters.ts`:
+
+1. **`formatEntityType(entityType: string)`**
+   - Maps technical entity types to user-friendly labels
+   - Handles all expected types from the LLM
+   - Falls back to smart capitalization for unknown types
+
+2. **`getEntityTypeColor(entityType: string)`**
+   - Returns Tailwind CSS classes for colored badges
+   - Each entity type gets a distinct color scheme
+   - Improves visual scanning and recognition
+
+### Updated Display
+Modified `context-owl-ui/src/pages/Signals.tsx`:
+- Changed from plain text to colored badge display
+- Uses `formatEntityType()` for proper labeling
+- Uses `getEntityTypeColor()` for visual distinction
+
+## Entity Type Mapping
+
+| LLM Type | Display Label | Color |
+|----------|---------------|-------|
+| cryptocurrency | Cryptocurrency | Blue |
+| blockchain | Blockchain | Purple |
+| protocol | Protocol | Indigo |
+| company | Company | Green |
+| organization | Organization | Orange |
+| event | Event | Red |
+| concept | Concept | Gray |
+| person | Person | Pink |
+| location | Location | Teal |
+
+## Testing
+
+### Local Testing
+```bash
+cd context-owl-ui
+npm run dev
+```
+
+Visit http://localhost:5173/signals and verify:
+- Entity types display with proper capitalization
+- Each type has a colored badge
+- Unknown types fall back to smart formatting
+
+### Production Verification
+After deployment to Vercel:
+1. Check https://context-owl-5zwt1nrjk-mikes-projects-92d90cb6.vercel.app/signals
+2. Verify entity types display correctly
+3. Check that colors render properly
+
+## Notes
+
+### Why Not Change Backend?
+- The detailed entity types from the LLM are valuable metadata
+- They provide more granular classification than simplified types
+- Frontend formatting is more flexible and easier to iterate on
+- No database migration needed
+
+### Future Enhancements
+- Add entity type filtering in the UI
+- Group signals by entity type
+- Add entity type icons alongside colors
+- Create entity type legend/documentation
+
+## Files Changed
+- `context-owl-ui/src/lib/formatters.ts` - Added formatEntityType() and getEntityTypeColor()
+- `context-owl-ui/src/pages/Signals.tsx` - Updated to use new formatters with badge display

--- a/context-owl-ui/src/lib/formatters.ts
+++ b/context-owl-ui/src/lib/formatters.ts
@@ -92,3 +92,46 @@ export function truncate(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength) + '...';
 }
+
+/**
+ * Format entity type for display
+ * Maps technical entity types to user-friendly labels
+ */
+export function formatEntityType(entityType: string): string {
+  const typeMap: Record<string, string> = {
+    'cryptocurrency': 'Cryptocurrency',
+    'blockchain': 'Blockchain',
+    'protocol': 'Protocol',
+    'company': 'Company',
+    'organization': 'Organization',
+    'event': 'Event',
+    'concept': 'Concept',
+    'person': 'Person',
+    'location': 'Location',
+    'ticker': 'Ticker',
+    'project': 'Project',
+  };
+
+  return typeMap[entityType.toLowerCase()] || entityType.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+}
+
+/**
+ * Get color class for entity type
+ */
+export function getEntityTypeColor(entityType: string): string {
+  const colorMap: Record<string, string> = {
+    'cryptocurrency': 'text-blue-600 bg-blue-50',
+    'blockchain': 'text-purple-600 bg-purple-50',
+    'protocol': 'text-indigo-600 bg-indigo-50',
+    'company': 'text-green-600 bg-green-50',
+    'organization': 'text-orange-600 bg-orange-50',
+    'event': 'text-red-600 bg-red-50',
+    'concept': 'text-gray-600 bg-gray-50',
+    'person': 'text-pink-600 bg-pink-50',
+    'location': 'text-teal-600 bg-teal-50',
+    'ticker': 'text-blue-600 bg-blue-50',
+    'project': 'text-indigo-600 bg-indigo-50',
+  };
+
+  return colorMap[entityType.toLowerCase()] || 'text-gray-600 bg-gray-50';
+}

--- a/context-owl-ui/src/pages/Signals.tsx
+++ b/context-owl-ui/src/pages/Signals.tsx
@@ -3,7 +3,7 @@ import { signalsAPI } from '../api';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/Card';
 import { Loading } from '../components/Loading';
 import { ErrorMessage } from '../components/ErrorMessage';
-import { formatRelativeTime, getSignalStrengthColor, formatPercentage, formatSentiment, getSentimentColor } from '../lib/formatters';
+import { formatRelativeTime, getSignalStrengthColor, formatPercentage, formatSentiment, getSentimentColor, formatEntityType, getEntityTypeColor } from '../lib/formatters';
 
 export function Signals() {
   const { data, isLoading, error, refetch, dataUpdatedAt } = useQuery({
@@ -55,8 +55,8 @@ export function Signals() {
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-gray-500">Type:</span>
-                  <span className="font-medium text-gray-900 capitalize">
-                    {signal.entity_type.replace(/_/g, ' ')}
+                  <span className={`px-2 py-1 rounded-full text-xs font-medium ${getEntityTypeColor(signal.entity_type)}`}>
+                    {formatEntityType(signal.entity_type)}
                   </span>
                 </div>
                 <div className="flex items-center justify-between text-sm">

--- a/scripts/check_all_signals.py
+++ b/scripts/check_all_signals.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Check all signals in MongoDB to see what data exists.
+"""
+import os
+import asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+from datetime import datetime
+
+async def main():
+    mongo_uri = os.getenv('MONGODB_URI')
+    db_name = os.getenv('MONGODB_DB_NAME', 'crypto_news')
+    
+    print(f"Connecting to: {mongo_uri}")
+    print(f"Database: {db_name}")
+    print()
+    
+    client = AsyncIOMotorClient(mongo_uri)
+    db = client[db_name]
+    
+    # List all collections
+    print("=" * 70)
+    print("AVAILABLE COLLECTIONS")
+    print("=" * 70)
+    collections = await db.list_collection_names()
+    for coll in collections:
+        count = await db[coll].count_documents({})
+        print(f"  {coll}: {count} documents")
+    print()
+    
+    # Get all signal_scores
+    print("=" * 70)
+    print("ALL SIGNAL_SCORES (showing all)")
+    print("=" * 70)
+    print()
+    
+    signals = await db.signal_scores.find({}).sort("signal_strength", -1).to_list(length=100)
+    
+    if signals:
+        print(f"Found {len(signals)} signal scores:")
+        for i, signal in enumerate(signals, 1):
+            print(f"\n{i}. {signal.get('normalized_name', 'UNKNOWN')}")
+            print(f"   - entity_type: {signal.get('entity_type')}")
+            print(f"   - signal_strength: {signal.get('signal_strength')}")
+            print(f"   - mention_count: {signal.get('mention_count')}")
+            print(f"   - last_updated: {signal.get('last_updated')}")
+            if signal.get('sources'):
+                print(f"   - sources: {list(signal['sources'].keys())}")
+    else:
+        print("No signal scores found")
+    
+    print()
+    print("=" * 70)
+    print("SAMPLE ENTITY_MENTIONS (showing first 10)")
+    print("=" * 70)
+    print()
+    
+    mentions = await db.entity_mentions.find({}).limit(10).to_list(length=10)
+    
+    if mentions:
+        print(f"Found entity mentions (showing first 10):")
+        for i, mention in enumerate(mentions, 1):
+            print(f"\n{i}. {mention.get('entity_name', 'UNKNOWN')}")
+            print(f"   - normalized_name: {mention.get('normalized_name')}")
+            print(f"   - entity_type: {mention.get('entity_type')}")
+            print(f"   - article_id: {mention.get('article_id')}")
+    else:
+        print("No entity mentions found")
+    
+    client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/check_entity_type_display.py
+++ b/scripts/check_entity_type_display.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Check entity_type values in MongoDB signal_scores collection.
+This script queries production MongoDB to see what entity_type values are stored.
+"""
+import os
+import asyncio
+from motor.motor_asyncio import AsyncIOMotorClient
+from datetime import datetime
+
+async def main():
+    client = AsyncIOMotorClient(os.getenv('MONGODB_URI'))
+    db = client[os.getenv('MONGODB_DB_NAME', 'crypto_news')]
+    
+    print("=" * 70)
+    print("CHECKING ENTITY_TYPE VALUES IN SIGNAL_SCORES")
+    print("=" * 70)
+    print()
+    
+    # Query for Bitcoin
+    print("🔍 Searching for Bitcoin...")
+    bitcoin_signals = await db.signal_scores.find({
+        "normalized_name": "bitcoin"
+    }).sort("last_updated", -1).limit(1).to_list(length=1)
+    
+    if bitcoin_signals:
+        signal = bitcoin_signals[0]
+        print(f"✓ Found Bitcoin signal:")
+        print(f"  - normalized_name: {signal.get('normalized_name')}")
+        print(f"  - entity_type: {signal.get('entity_type')}")
+        print(f"  - signal_strength: {signal.get('signal_strength')}")
+        print(f"  - mention_count: {signal.get('mention_count')}")
+        print(f"  - last_updated: {signal.get('last_updated')}")
+        print()
+    else:
+        print("✗ No Bitcoin signal found")
+        print()
+    
+    # Query for FTX
+    print("🔍 Searching for FTX...")
+    ftx_signals = await db.signal_scores.find({
+        "normalized_name": "ftx"
+    }).sort("last_updated", -1).limit(1).to_list(length=1)
+    
+    if ftx_signals:
+        signal = ftx_signals[0]
+        print(f"✓ Found FTX signal:")
+        print(f"  - normalized_name: {signal.get('normalized_name')}")
+        print(f"  - entity_type: {signal.get('entity_type')}")
+        print(f"  - signal_strength: {signal.get('signal_strength')}")
+        print(f"  - mention_count: {signal.get('mention_count')}")
+        print(f"  - last_updated: {signal.get('last_updated')}")
+        print()
+    else:
+        print("✗ No FTX signal found")
+        print()
+    
+    # Get a sample of all entity_type values in the collection
+    print("=" * 70)
+    print("ENTITY_TYPE DISTRIBUTION IN SIGNAL_SCORES")
+    print("=" * 70)
+    print()
+    
+    pipeline = [
+        {"$group": {
+            "_id": "$entity_type",
+            "count": {"$sum": 1}
+        }},
+        {"$sort": {"count": -1}}
+    ]
+    
+    entity_type_counts = await db.signal_scores.aggregate(pipeline).to_list(length=100)
+    
+    for item in entity_type_counts:
+        entity_type = item['_id'] if item['_id'] else "NULL"
+        count = item['count']
+        print(f"  {entity_type}: {count}")
+    
+    print()
+    print("=" * 70)
+    print("CHECKING ENTITY_MENTIONS FOR COMPARISON")
+    print("=" * 70)
+    print()
+    
+    # Check entity_mentions for Bitcoin
+    print("🔍 Checking entity_mentions for Bitcoin...")
+    bitcoin_mentions = await db.entity_mentions.find({
+        "normalized_name": "bitcoin"
+    }).limit(3).to_list(length=3)
+    
+    if bitcoin_mentions:
+        print(f"✓ Found {len(bitcoin_mentions)} Bitcoin mentions (showing first 3):")
+        for i, mention in enumerate(bitcoin_mentions, 1):
+            print(f"  Mention {i}:")
+            print(f"    - entity_name: {mention.get('entity_name')}")
+            print(f"    - normalized_name: {mention.get('normalized_name')}")
+            print(f"    - entity_type: {mention.get('entity_type')}")
+            print(f"    - article_id: {mention.get('article_id')}")
+        print()
+    else:
+        print("✗ No Bitcoin mentions found")
+        print()
+    
+    # Check entity_mentions for FTX
+    print("🔍 Checking entity_mentions for FTX...")
+    ftx_mentions = await db.entity_mentions.find({
+        "normalized_name": "ftx"
+    }).limit(3).to_list(length=3)
+    
+    if ftx_mentions:
+        print(f"✓ Found {len(ftx_mentions)} FTX mentions (showing first 3):")
+        for i, mention in enumerate(ftx_mentions, 1):
+            print(f"  Mention {i}:")
+            print(f"    - entity_name: {mention.get('entity_name')}")
+            print(f"    - normalized_name: {mention.get('normalized_name')}")
+            print(f"    - entity_type: {mention.get('entity_type')}")
+            print(f"    - article_id: {mention.get('article_id')}")
+        print()
+    else:
+        print("✗ No FTX mentions found")
+        print()
+    
+    client.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
…d badges

- Add formatEntityType() to map technical types to user-friendly labels
- Add getEntityTypeColor() for visual distinction with colored badges
- Update Signals page to use badge-style display for entity types
- Support all LLM entity types: cryptocurrency, company, organization, etc.
- Add fallback formatting for unknown types
- Document root cause and solution in ENTITY_TYPE_DISPLAY_FIX.md