### PR TITLE
feat: add narrative timeline tracking infrastructure

### DIFF
--- a/NARRATIVE_TIMELINE_TRACKING.md
+++ b/NARRATIVE_TIMELINE_TRACKING.md
@@ -1,0 +1,249 @@
+# Narrative Timeline Tracking Implementation
+
+**Date:** 2025-10-06  
+**Status:** ✅ Complete - Data infrastructure ready
+
+## Overview
+
+Implemented timeline tracking infrastructure for narratives to capture daily snapshots of narrative evolution. This enables future charting of narrative growth, velocity changes, and entity involvement over time.
+
+## What Was Built
+
+### 1. Database Schema Updates
+
+**New fields added to narrative documents:**
+
+```python
+{
+  "timeline_data": [
+    {
+      "date": "2025-10-06",           # ISO date string (YYYY-MM-DD)
+      "article_count": 15,             # Articles on this day
+      "entities": ["SEC", "Bitcoin"],  # Top entities (max 10)
+      "velocity": 7.5                  # Articles per day rate
+    }
+  ],
+  "peak_activity": {
+    "date": "2025-10-05",              # Date of peak activity
+    "article_count": 18,               # Highest article count
+    "velocity": 4.2                    # Velocity at peak
+  },
+  "days_active": 6                     # Days since first_seen
+}
+```
+
+### 2. Smart Daily Snapshot Logic
+
+**File:** `src/crypto_news_aggregator/db/operations/narratives.py`
+
+- **One snapshot per day:** Only appends new snapshot if date changes
+- **Same-day updates:** Replaces last snapshot if updated multiple times in one day
+- **Peak tracking:** Automatically updates `peak_activity` when article count exceeds previous peak
+- **Days active:** Auto-calculates from `first_seen` timestamp
+
+**Helper functions:**
+- `_should_append_timeline_snapshot()` - Determines if new snapshot needed
+- `_calculate_days_active()` - Calculates days since narrative started
+
+### 3. API Endpoint
+
+**New endpoint:** `GET /api/v1/narratives/{id}/timeline`
+
+**Response:**
+```json
+[
+  {
+    "date": "2025-10-01",
+    "article_count": 3,
+    "entities": ["SEC", "Bitcoin"],
+    "velocity": 1.5
+  },
+  {
+    "date": "2025-10-02",
+    "article_count": 5,
+    "entities": ["SEC", "Bitcoin", "Coinbase"],
+    "velocity": 2.5
+  }
+]
+```
+
+**Use case:** Perfect for charting narrative growth over time
+
+### 4. Updated Response Models
+
+**File:** `src/crypto_news_aggregator/api/v1/endpoints/narratives.py`
+
+**New Pydantic models:**
+- `TimelineSnapshot` - Single day snapshot
+- `PeakActivity` - Peak metrics
+
+**Updated `NarrativeResponse`:**
+- Added `days_active: int`
+- Added `peak_activity: Optional[PeakActivity]`
+
+**Backward compatible:** Handles old narratives without timeline fields
+
+## Test Coverage
+
+**20 new tests added:**
+
+### Database Tests (`tests/db/test_narrative_timeline.py`)
+- ✅ Helper function tests (7 tests)
+- ✅ Timeline creation and updates (4 tests)
+- ✅ Peak activity tracking (1 test)
+- ✅ Timeline retrieval (3 tests)
+
+### API Tests (`tests/api/test_narrative_timeline_endpoint.py`)
+- ✅ Timeline endpoint tests (4 tests)
+- ✅ Response model validation (2 tests)
+
+**All tests passing:** 20/20 ✅
+
+## How It Works
+
+### Daily Snapshot Flow
+
+1. **Narrative detection runs** (via `detect_narratives()`)
+2. **For each narrative:**
+   - Check if narrative exists in DB
+   - Create today's snapshot with current metrics
+   - If new day: append to `timeline_data`
+   - If same day: replace last snapshot
+   - Update `peak_activity` if count increased
+   - Calculate `days_active` from `first_seen`
+
+### Example Timeline Evolution
+
+**Day 1 (2025-10-01):**
+```json
+{
+  "timeline_data": [
+    {"date": "2025-10-01", "article_count": 3, "velocity": 1.5}
+  ],
+  "peak_activity": {"date": "2025-10-01", "article_count": 3},
+  "days_active": 1
+}
+```
+
+**Day 2 (2025-10-02):**
+```json
+{
+  "timeline_data": [
+    {"date": "2025-10-01", "article_count": 3, "velocity": 1.5},
+    {"date": "2025-10-02", "article_count": 5, "velocity": 2.5}
+  ],
+  "peak_activity": {"date": "2025-10-02", "article_count": 5},
+  "days_active": 2
+}
+```
+
+**Day 2 (later same day):**
+```json
+{
+  "timeline_data": [
+    {"date": "2025-10-01", "article_count": 3, "velocity": 1.5},
+    {"date": "2025-10-02", "article_count": 7, "velocity": 3.5}  // Updated
+  ],
+  "peak_activity": {"date": "2025-10-02", "article_count": 7},
+  "days_active": 2
+}
+```
+
+## Data Collection Strategy
+
+**Starting now:** Timeline data begins accumulating automatically
+**After 7 days:** Sufficient data for meaningful charts
+**No UI yet:** Data infrastructure only - charting comes later
+
+## API Usage Examples
+
+### Get Active Narratives (with timeline fields)
+```bash
+curl http://localhost:8000/api/v1/narratives/active?limit=10
+```
+
+Response includes new fields:
+```json
+{
+  "theme": "regulatory",
+  "title": "SEC Enforcement Actions",
+  "days_active": 5,
+  "peak_activity": {
+    "date": "2025-10-05",
+    "article_count": 18,
+    "velocity": 4.2
+  }
+}
+```
+
+### Get Timeline for Specific Narrative
+```bash
+curl http://localhost:8000/api/v1/narratives/{narrative_id}/timeline
+```
+
+Returns array of daily snapshots for charting.
+
+## Next Steps (Future Work)
+
+### Phase 1: Data Collection (Current)
+- ✅ Timeline infrastructure implemented
+- ✅ Daily snapshots collecting automatically
+- ⏳ Wait 7 days for meaningful data
+
+### Phase 2: Visualization (After 7 days)
+- [ ] Add timeline chart component to UI
+- [ ] Show narrative growth over time
+- [ ] Visualize velocity changes
+- [ ] Display entity evolution
+- [ ] Add trend indicators (↑ growing, ↓ declining)
+
+### Phase 3: Analytics (Future)
+- [ ] Narrative lifecycle predictions
+- [ ] Anomaly detection (sudden spikes)
+- [ ] Comparative timeline views
+- [ ] Export timeline data
+
+## Files Modified
+
+### Core Logic
+- `src/crypto_news_aggregator/db/operations/narratives.py` - Timeline tracking logic
+- `src/crypto_news_aggregator/api/v1/endpoints/narratives.py` - API endpoint + models
+
+### Tests
+- `tests/db/test_narrative_timeline.py` - Database operations tests
+- `tests/api/test_narrative_timeline_endpoint.py` - API endpoint tests
+
+## Technical Notes
+
+### Performance
+- Timeline data stored as array in MongoDB (efficient)
+- No additional queries needed for timeline retrieval
+- Snapshots limited to 10 entities to control size
+
+### Data Retention
+- Timeline data persists with narrative
+- Old narratives cleaned up by existing `delete_old_narratives()` function
+- No separate cleanup needed for timeline data
+
+### Backward Compatibility
+- Old narratives without timeline fields handled gracefully
+- API returns defaults: `days_active=1`, `peak_activity=None`
+- No migration needed - fields added on next update
+
+## Deployment Notes
+
+**No special deployment steps required:**
+- Schema changes are additive (no breaking changes)
+- Existing narratives continue working
+- Timeline data starts accumulating on next narrative detection run
+- No database migration needed
+
+**Monitor after deployment:**
+- Check narrative detection runs successfully
+- Verify timeline_data arrays are populating
+- Confirm daily snapshots append correctly
+
+---
+
+**Implementation complete!** 🎉  
+Timeline data will begin accumulating automatically. Check back in 7 days for charting implementation.

--- a/tests/api/test_narrative_timeline_endpoint.py
+++ b/tests/api/test_narrative_timeline_endpoint.py
@@ -1,0 +1,235 @@
+"""
+Tests for narrative timeline API endpoint.
+
+Tests the GET /api/v1/narratives/{id}/timeline endpoint.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+from bson import ObjectId
+
+
+@pytest.fixture
+def mock_timeline_data():
+    """Sample timeline data for testing."""
+    return [
+        {
+            "date": "2025-10-01",
+            "article_count": 3,
+            "entities": ["SEC", "Bitcoin"],
+            "velocity": 1.5
+        },
+        {
+            "date": "2025-10-02",
+            "article_count": 5,
+            "entities": ["SEC", "Bitcoin", "Coinbase"],
+            "velocity": 2.5
+        },
+        {
+            "date": "2025-10-03",
+            "article_count": 7,
+            "entities": ["SEC", "Bitcoin", "Coinbase", "Gary Gensler"],
+            "velocity": 3.5
+        }
+    ]
+
+
+class TestNarrativeTimelineEndpoint:
+    """Test the narrative timeline API endpoint."""
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_success(self, mock_timeline_data):
+        """Test successfully retrieving timeline data."""
+        from crypto_news_aggregator.api.v1.endpoints.narratives import router
+        from fastapi import FastAPI
+        
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        
+        narrative_id = str(ObjectId())
+        
+        with patch('crypto_news_aggregator.api.v1.endpoints.narratives.get_narrative_timeline') as mock_get:
+            mock_get.return_value = mock_timeline_data
+            
+            response = client.get(f"/{narrative_id}/timeline")
+            
+            assert response.status_code == 200
+            data = response.json()
+            
+            assert len(data) == 3
+            assert data[0]["date"] == "2025-10-01"
+            assert data[0]["article_count"] == 3
+            assert data[0]["velocity"] == 1.5
+            assert "SEC" in data[0]["entities"]
+            
+            assert data[2]["article_count"] == 7
+            assert data[2]["velocity"] == 3.5
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_not_found(self):
+        """Test retrieving timeline for non-existent narrative."""
+        from crypto_news_aggregator.api.v1.endpoints.narratives import router
+        from fastapi import FastAPI
+        
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        
+        narrative_id = str(ObjectId())
+        
+        with patch('crypto_news_aggregator.api.v1.endpoints.narratives.get_narrative_timeline') as mock_get:
+            mock_get.return_value = None
+            
+            response = client.get(f"/{narrative_id}/timeline")
+            
+            assert response.status_code == 404
+            assert "not found" in response.json()["detail"].lower()
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_empty(self):
+        """Test retrieving timeline when narrative has no timeline data."""
+        from crypto_news_aggregator.api.v1.endpoints.narratives import router
+        from fastapi import FastAPI
+        
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        
+        narrative_id = str(ObjectId())
+        
+        with patch('crypto_news_aggregator.api.v1.endpoints.narratives.get_narrative_timeline') as mock_get:
+            mock_get.return_value = []
+            
+            response = client.get(f"/{narrative_id}/timeline")
+            
+            assert response.status_code == 200
+            data = response.json()
+            assert data == []
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_database_error(self):
+        """Test handling database errors gracefully."""
+        from crypto_news_aggregator.api.v1.endpoints.narratives import router
+        from fastapi import FastAPI
+        
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        
+        narrative_id = str(ObjectId())
+        
+        with patch('crypto_news_aggregator.api.v1.endpoints.narratives.get_narrative_timeline') as mock_get:
+            mock_get.side_effect = Exception("Database connection failed")
+            
+            response = client.get(f"/{narrative_id}/timeline")
+            
+            assert response.status_code == 500
+            assert "failed" in response.json()["detail"].lower()
+
+
+class TestNarrativeResponseWithTimeline:
+    """Test that active narratives endpoint includes timeline fields."""
+    
+    @pytest.mark.asyncio
+    async def test_active_narratives_includes_timeline_fields(self):
+        """Test that /active endpoint includes new timeline tracking fields."""
+        from crypto_news_aggregator.api.v1.endpoints.narratives import router
+        from fastapi import FastAPI
+        from datetime import datetime, timezone
+        
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        
+        mock_narratives = [
+            {
+                "theme": "regulatory",
+                "title": "SEC Enforcement Actions",
+                "summary": "Test summary",
+                "entities": ["SEC", "Bitcoin"],
+                "article_count": 10,
+                "mention_velocity": 3.5,
+                "lifecycle": "hot",
+                "first_seen": datetime.now(timezone.utc),
+                "last_updated": datetime.now(timezone.utc),
+                "days_active": 5,
+                "peak_activity": {
+                    "date": "2025-10-05",
+                    "article_count": 12,
+                    "velocity": 4.0
+                },
+                "timeline_data": [
+                    {"date": "2025-10-01", "article_count": 3, "entities": ["SEC"], "velocity": 1.5},
+                    {"date": "2025-10-02", "article_count": 5, "entities": ["SEC", "Bitcoin"], "velocity": 2.5}
+                ]
+            }
+        ]
+        
+        with patch('crypto_news_aggregator.api.v1.endpoints.narratives.get_active_narratives') as mock_get:
+            mock_get.return_value = mock_narratives
+            
+            with patch('crypto_news_aggregator.api.v1.endpoints.narratives.redis_client') as mock_redis:
+                mock_redis.enabled = False
+                
+                response = client.get("/active?limit=10")
+                
+                assert response.status_code == 200
+                data = response.json()
+                
+                assert len(data) == 1
+                narrative = data[0]
+                
+                # Check timeline fields are present
+                assert "days_active" in narrative
+                assert narrative["days_active"] == 5
+                
+                assert "peak_activity" in narrative
+                assert narrative["peak_activity"]["article_count"] == 12
+                assert narrative["peak_activity"]["date"] == "2025-10-05"
+    
+    @pytest.mark.asyncio
+    async def test_active_narratives_handles_missing_timeline_fields(self):
+        """Test that endpoint handles narratives without timeline fields (backward compatibility)."""
+        from crypto_news_aggregator.api.v1.endpoints.narratives import router
+        from fastapi import FastAPI
+        from datetime import datetime, timezone
+        
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+        
+        # Old narrative without timeline fields
+        mock_narratives = [
+            {
+                "theme": "regulatory",
+                "title": "SEC Enforcement Actions",
+                "summary": "Test summary",
+                "entities": ["SEC", "Bitcoin"],
+                "article_count": 10,
+                "mention_velocity": 3.5,
+                "lifecycle": "hot",
+                "first_seen": datetime.now(timezone.utc),
+                "last_updated": datetime.now(timezone.utc)
+                # No days_active, peak_activity, or timeline_data
+            }
+        ]
+        
+        with patch('crypto_news_aggregator.api.v1.endpoints.narratives.get_active_narratives') as mock_get:
+            mock_get.return_value = mock_narratives
+            
+            with patch('crypto_news_aggregator.api.v1.endpoints.narratives.redis_client') as mock_redis:
+                mock_redis.enabled = False
+                
+                response = client.get("/active?limit=10")
+                
+                assert response.status_code == 200
+                data = response.json()
+                
+                assert len(data) == 1
+                narrative = data[0]
+                
+                # Check defaults are applied
+                assert narrative["days_active"] == 1
+                assert narrative["peak_activity"] is None

--- a/tests/db/test_narrative_timeline.py
+++ b/tests/db/test_narrative_timeline.py
@@ -1,0 +1,365 @@
+"""
+Tests for narrative timeline tracking functionality.
+
+Tests the daily snapshot system that tracks narrative evolution over time.
+"""
+
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from crypto_news_aggregator.db.operations.narratives import (
+    upsert_narrative,
+    get_narrative_timeline,
+    _should_append_timeline_snapshot,
+    _calculate_days_active
+)
+
+
+class TestTimelineHelpers:
+    """Test helper functions for timeline tracking."""
+    
+    def test_calculate_days_active_same_day(self):
+        """Test days_active calculation for same day."""
+        now = datetime.now(timezone.utc)
+        days = _calculate_days_active(now)
+        assert days == 1
+    
+    def test_calculate_days_active_multiple_days(self):
+        """Test days_active calculation for multiple days."""
+        five_days_ago = datetime.now(timezone.utc) - timedelta(days=5)
+        days = _calculate_days_active(five_days_ago)
+        assert days == 6  # 5 full days + today
+    
+    def test_should_append_no_existing(self):
+        """Test should append when no existing narrative."""
+        assert _should_append_timeline_snapshot(None) is True
+    
+    def test_should_append_no_timeline_data(self):
+        """Test should append when no timeline data exists."""
+        existing = {"theme": "test"}
+        assert _should_append_timeline_snapshot(existing) is True
+    
+    def test_should_append_empty_timeline(self):
+        """Test should append when timeline is empty."""
+        existing = {"timeline_data": []}
+        assert _should_append_timeline_snapshot(existing) is True
+    
+    def test_should_append_different_day(self):
+        """Test should append when last snapshot is from different day."""
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
+        existing = {
+            "timeline_data": [
+                {"date": yesterday, "article_count": 5}
+            ]
+        }
+        assert _should_append_timeline_snapshot(existing) is True
+    
+    def test_should_not_append_same_day(self):
+        """Test should not append when last snapshot is from today."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        existing = {
+            "timeline_data": [
+                {"date": today, "article_count": 5}
+            ]
+        }
+        assert _should_append_timeline_snapshot(existing) is False
+
+
+class TestUpsertNarrativeTimeline:
+    """Test timeline tracking in upsert_narrative."""
+    
+    @pytest.mark.asyncio
+    async def test_create_narrative_with_timeline(self):
+        """Test creating new narrative includes initial timeline snapshot."""
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        # No existing narrative
+        mock_collection.find_one = AsyncMock(return_value=None)
+        mock_collection.insert_one = AsyncMock(return_value=MagicMock(inserted_id="test_id"))
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            narrative_id = await upsert_narrative(
+                theme="regulatory",
+                title="Test Narrative",
+                summary="Test summary",
+                entities=["SEC", "Bitcoin"],
+                article_ids=["1", "2", "3"],
+                article_count=3,
+                mention_velocity=1.5,
+                lifecycle="emerging"
+            )
+            
+            # Verify insert was called
+            assert mock_collection.insert_one.called
+            call_args = mock_collection.insert_one.call_args[0][0]
+            
+            # Check timeline_data was created
+            assert "timeline_data" in call_args
+            assert len(call_args["timeline_data"]) == 1
+            
+            snapshot = call_args["timeline_data"][0]
+            assert "date" in snapshot
+            assert snapshot["article_count"] == 3
+            assert snapshot["entities"] == ["SEC", "Bitcoin"]
+            assert snapshot["velocity"] == 1.5
+            
+            # Check peak_activity was created
+            assert "peak_activity" in call_args
+            assert call_args["peak_activity"]["article_count"] == 3
+            
+            # Check days_active was set
+            assert "days_active" in call_args
+            assert call_args["days_active"] == 1
+    
+    @pytest.mark.asyncio
+    async def test_update_narrative_appends_timeline(self):
+        """Test updating narrative appends new timeline snapshot for new day."""
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
+        first_seen = datetime.now(timezone.utc) - timedelta(days=1)
+        
+        existing_narrative = {
+            "_id": "test_id",
+            "theme": "regulatory",
+            "first_seen": first_seen,
+            "timeline_data": [
+                {
+                    "date": yesterday,
+                    "article_count": 3,
+                    "entities": ["SEC"],
+                    "velocity": 1.5
+                }
+            ],
+            "peak_activity": {
+                "date": yesterday,
+                "article_count": 3,
+                "velocity": 1.5
+            }
+        }
+        
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        mock_collection.find_one = AsyncMock(return_value=existing_narrative)
+        mock_collection.update_one = AsyncMock()
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            await upsert_narrative(
+                theme="regulatory",
+                title="Updated Narrative",
+                summary="Updated summary",
+                entities=["SEC", "Bitcoin", "Coinbase"],
+                article_ids=["1", "2", "3", "4", "5"],
+                article_count=5,
+                mention_velocity=2.5,
+                lifecycle="hot"
+            )
+            
+            # Verify update was called
+            assert mock_collection.update_one.called
+            update_data = mock_collection.update_one.call_args[0][1]["$set"]
+            
+            # Check timeline_data was appended
+            assert len(update_data["timeline_data"]) == 2
+            new_snapshot = update_data["timeline_data"][1]
+            assert new_snapshot["article_count"] == 5
+            assert new_snapshot["velocity"] == 2.5
+            
+            # Check peak_activity was updated (5 > 3)
+            assert update_data["peak_activity"]["article_count"] == 5
+            
+            # Check days_active was calculated
+            assert update_data["days_active"] == 2
+    
+    @pytest.mark.asyncio
+    async def test_update_narrative_same_day_replaces_snapshot(self):
+        """Test updating narrative on same day replaces last snapshot."""
+        today = datetime.now(timezone.utc).date().isoformat()
+        first_seen = datetime.now(timezone.utc)
+        
+        existing_narrative = {
+            "_id": "test_id",
+            "theme": "regulatory",
+            "first_seen": first_seen,
+            "timeline_data": [
+                {
+                    "date": today,
+                    "article_count": 3,
+                    "entities": ["SEC"],
+                    "velocity": 1.5
+                }
+            ],
+            "peak_activity": {
+                "date": today,
+                "article_count": 3,
+                "velocity": 1.5
+            }
+        }
+        
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        mock_collection.find_one = AsyncMock(return_value=existing_narrative)
+        mock_collection.update_one = AsyncMock()
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            await upsert_narrative(
+                theme="regulatory",
+                title="Updated Narrative",
+                summary="Updated summary",
+                entities=["SEC", "Bitcoin"],
+                article_ids=["1", "2", "3", "4"],
+                article_count=4,
+                mention_velocity=2.0,
+                lifecycle="emerging"
+            )
+            
+            # Verify update was called
+            assert mock_collection.update_one.called
+            update_data = mock_collection.update_one.call_args[0][1]["$set"]
+            
+            # Check timeline_data still has only 1 entry (replaced, not appended)
+            assert len(update_data["timeline_data"]) == 1
+            snapshot = update_data["timeline_data"][0]
+            assert snapshot["article_count"] == 4
+            assert snapshot["velocity"] == 2.0
+    
+    @pytest.mark.asyncio
+    async def test_peak_activity_not_updated_if_lower(self):
+        """Test peak_activity is not updated if current count is lower."""
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
+        first_seen = datetime.now(timezone.utc) - timedelta(days=1)
+        
+        existing_narrative = {
+            "_id": "test_id",
+            "theme": "regulatory",
+            "first_seen": first_seen,
+            "timeline_data": [
+                {
+                    "date": yesterday,
+                    "article_count": 10,
+                    "entities": ["SEC"],
+                    "velocity": 5.0
+                }
+            ],
+            "peak_activity": {
+                "date": yesterday,
+                "article_count": 10,
+                "velocity": 5.0
+            }
+        }
+        
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        mock_collection.find_one = AsyncMock(return_value=existing_narrative)
+        mock_collection.update_one = AsyncMock()
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            await upsert_narrative(
+                theme="regulatory",
+                title="Updated Narrative",
+                summary="Updated summary",
+                entities=["SEC"],
+                article_ids=["1", "2", "3"],
+                article_count=3,
+                mention_velocity=1.5,
+                lifecycle="declining"
+            )
+            
+            # Verify update was called
+            assert mock_collection.update_one.called
+            update_data = mock_collection.update_one.call_args[0][1]["$set"]
+            
+            # Check peak_activity was NOT updated (still 10)
+            assert update_data["peak_activity"]["article_count"] == 10
+            assert update_data["peak_activity"]["date"] == yesterday
+
+
+class TestGetNarrativeTimeline:
+    """Test retrieving narrative timeline data."""
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_success(self):
+        """Test successfully retrieving timeline data."""
+        from bson import ObjectId
+        
+        narrative_id = str(ObjectId())
+        timeline_data = [
+            {"date": "2025-10-01", "article_count": 3, "entities": ["SEC"], "velocity": 1.5},
+            {"date": "2025-10-02", "article_count": 5, "entities": ["SEC", "Bitcoin"], "velocity": 2.5}
+        ]
+        
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        mock_collection.find_one = AsyncMock(return_value={
+            "_id": ObjectId(narrative_id),
+            "timeline_data": timeline_data
+        })
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            result = await get_narrative_timeline(narrative_id)
+            
+            assert result == timeline_data
+            assert len(result) == 2
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_not_found(self):
+        """Test retrieving timeline for non-existent narrative."""
+        from bson import ObjectId
+        
+        narrative_id = str(ObjectId())
+        
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        mock_collection.find_one = AsyncMock(return_value=None)
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            result = await get_narrative_timeline(narrative_id)
+            
+            assert result is None
+    
+    @pytest.mark.asyncio
+    async def test_get_timeline_empty(self):
+        """Test retrieving timeline when no timeline_data exists."""
+        from bson import ObjectId
+        
+        narrative_id = str(ObjectId())
+        
+        mock_db = MagicMock()
+        mock_collection = AsyncMock()
+        mock_db.narratives = mock_collection
+        
+        mock_collection.find_one = AsyncMock(return_value={
+            "_id": ObjectId(narrative_id),
+            "theme": "regulatory"
+            # No timeline_data field
+        })
+        
+        with patch('crypto_news_aggregator.db.operations.narratives.mongo_manager') as mock_mongo:
+            mock_mongo.get_async_database = AsyncMock(return_value=mock_db)
+            
+            result = await get_narrative_timeline(narrative_id)
+            
+            assert result == []


### PR DESCRIPTION
- Add timeline_data array to store daily snapshots
- Add peak_activity tracking for highest article counts
- Add days_active calculation from first_seen
- Implement smart daily snapshot logic (one per day)
- Add GET /api/v1/narratives/{id}/timeline endpoint
- Update NarrativeResponse model with timeline fields
- Add comprehensive test coverage (20 tests)
- Backward compatible with existing narratives