### PR TITLE
feat: link signals to narratives for user context

### DIFF
--- a/SIGNAL_NARRATIVE_LINKING.md
+++ b/SIGNAL_NARRATIVE_LINKING.md
@@ -1,0 +1,170 @@
+# Signal-to-Narrative Linking Implementation
+
+**Status**: ✅ Complete  
+**Date**: 2025-10-06
+
+## Overview
+
+Implemented linking between signals and narratives to provide users with context about whether a trending entity is part of an established narrative or an emerging signal.
+
+## Changes Made
+
+### 1. Backend: Signal Service (`signal_service.py`)
+
+**Added `get_narratives_for_entity()` function:**
+- Queries the narratives collection for narratives containing a specific entity
+- Returns list of narrative ObjectIds as strings
+
+**Updated `calculate_signal_score()` function:**
+- Now queries narratives for each entity
+- Adds `narrative_ids` array to return value
+- Adds `is_emerging` boolean flag (true if narrative_ids is empty)
+
+### 2. Backend: Database Operations (`signal_scores.py`)
+
+**Updated `upsert_signal_score()` function:**
+- Added `narrative_ids` parameter (List[str])
+- Added `is_emerging` parameter (bool)
+- Both fields are stored in MongoDB signal_scores collection
+
+**Updated worker.py:**
+- Modified signal score upsert call to pass narrative_ids and is_emerging from signal_data
+
+### 3. Backend: API Endpoint (`signals.py`)
+
+**Added `get_narrative_details()` helper function:**
+- Fetches full narrative details (id, title, theme, lifecycle) for a list of narrative IDs
+- Handles ObjectId conversion and error cases
+
+**Updated `/api/v1/signals/trending` endpoint:**
+- Fetches narrative details for each signal
+- Response now includes:
+  - `is_emerging`: boolean flag
+  - `narratives`: array of narrative summaries with id, title, theme, lifecycle
+
+### 4. Frontend: TypeScript Types (`types/index.ts`)
+
+**Added `NarrativeSummary` interface:**
+```typescript
+export interface NarrativeSummary {
+  id: string;
+  title: string;
+  theme: string;
+  lifecycle: string;
+}
+```
+
+**Updated `Signal` interface:**
+- Added `is_emerging: boolean`
+- Added `narratives: NarrativeSummary[]`
+
+### 5. Frontend: Formatters (`lib/formatters.ts`)
+
+**Added theme formatting functions:**
+- `formatTheme()`: Maps technical theme names to user-friendly labels
+- `getThemeColor()`: Returns Tailwind CSS classes for theme badge styling
+
+### 6. Frontend: Signals Page (`pages/Signals.tsx`)
+
+**Added narrative context section to each signal card:**
+
+**For emerging signals (not in any narrative):**
+```
+🆕 Emerging
+Not yet part of any narrative
+```
+
+**For signals in narratives:**
+```
+Part of:
+[Regulatory] [Institutional] [DeFi Adoption]
+```
+- Clickable theme badges
+- Clicking navigates to /narratives page
+- Color-coded by theme
+- Shows narrative title on hover
+
+## Data Flow
+
+1. **Signal Calculation** (worker.py):
+   - Entity mentions are analyzed
+   - `calculate_signal_score()` queries narratives collection
+   - Returns signal data with narrative_ids and is_emerging
+
+2. **Storage** (signal_scores collection):
+   ```json
+   {
+     "entity": "Bitcoin",
+     "score": 8.5,
+     "narrative_ids": ["507f1f77bcf86cd799439011", "507f191e810c19729de860ea"],
+     "is_emerging": false
+   }
+   ```
+
+3. **API Response** (/api/v1/signals/trending):
+   ```json
+   {
+     "signals": [{
+       "entity": "Bitcoin",
+       "signal_score": 8.5,
+       "is_emerging": false,
+       "narratives": [
+         {
+           "id": "507f1f77bcf86cd799439011",
+           "title": "SEC Enforcement Actions",
+           "theme": "regulatory",
+           "lifecycle": "hot"
+         }
+       ]
+     }]
+   }
+   ```
+
+4. **UI Display**:
+   - Shows "🆕 Emerging" badge if `is_emerging === true`
+   - Shows clickable theme badges if narratives array has items
+   - Provides context for understanding signal significance
+
+## Testing
+
+Created `tests/services/test_signal_narrative_linking.py`:
+- ✅ Verifies signal_score includes narrative_ids field
+- ✅ Verifies signal_score includes is_emerging field
+- ✅ Validates data types are correct
+
+## Benefits
+
+1. **User Context**: Users can see if a signal is part of a known narrative or truly emerging
+2. **Navigation**: Clickable badges allow users to explore related narratives
+3. **Visual Clarity**: Color-coded theme badges make it easy to scan signal context
+4. **Early Detection**: "Emerging" badge highlights potentially new trends before they form narratives
+
+## Future Enhancements
+
+- Add entity detail pages that show all narratives containing that entity
+- Filter signals by narrative theme
+- Show narrative lifecycle stage in signal cards
+- Add "View Narrative" link that deep-links to specific narrative
+
+## Files Modified
+
+**Backend:**
+- `src/crypto_news_aggregator/services/signal_service.py`
+- `src/crypto_news_aggregator/db/operations/signal_scores.py`
+- `src/crypto_news_aggregator/api/v1/endpoints/signals.py`
+- `src/crypto_news_aggregator/worker.py`
+
+**Frontend:**
+- `context-owl-ui/src/types/index.ts`
+- `context-owl-ui/src/lib/formatters.ts`
+- `context-owl-ui/src/pages/Signals.tsx`
+
+**Tests:**
+- `tests/services/test_signal_narrative_linking.py`
+
+## Deployment Notes
+
+- No database migration required (MongoDB is schemaless)
+- Existing signal_scores documents will have empty narrative_ids arrays
+- Next signal calculation run will populate the new fields
+- Frontend gracefully handles missing fields with optional chaining

--- a/SIGNAL_UI_EXAMPLE.md
+++ b/SIGNAL_UI_EXAMPLE.md
@@ -1,0 +1,59 @@
+# Signal-to-Narrative Linking - UI Examples
+
+## Signal Card with Narratives
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ #1 Bitcoin $BTC                              85%        │
+├─────────────────────────────────────────────────────────┤
+│ Type:        [Cryptocurrency]                           │
+│ Velocity:    12.5 mentions/hr                           │
+│ Sources:     8 sources                                  │
+│ Sentiment:   Positive                                   │
+│ Last Updated: 5 minutes ago                             │
+│ ─────────────────────────────────────────────────────── │
+│ Part of:                                                │
+│ [Regulatory] [Institutional Investment]                 │
+│ └─ clickable badges, color-coded by theme               │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Emerging Signal Card
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ #5 NewProtocol                               42%        │
+├─────────────────────────────────────────────────────────┤
+│ Type:        [Project]                                  │
+│ Velocity:    3.2 mentions/hr                            │
+│ Sources:     4 sources                                  │
+│ Sentiment:   Neutral                                    │
+│ Last Updated: 2 minutes ago                             │
+│ ─────────────────────────────────────────────────────── │
+│ 🆕 Emerging  Not yet part of any narrative              │
+│ └─ yellow badge indicating new/unclassified signal      │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Theme Badge Colors
+
+- **Regulatory**: Red background (text-red-700 bg-red-100)
+- **DeFi Adoption**: Purple background (text-purple-700 bg-purple-100)
+- **Institutional Investment**: Green background (text-green-700 bg-green-100)
+- **Technology Upgrade**: Blue background (text-blue-700 bg-blue-100)
+- **Market Volatility**: Orange background (text-orange-700 bg-orange-100)
+- **Security**: Red background (text-red-700 bg-red-100)
+- **Partnership**: Indigo background (text-indigo-700 bg-indigo-100)
+- **Ecosystem Growth**: Teal background (text-teal-700 bg-teal-100)
+
+## User Interactions
+
+1. **Hover over theme badge**: Shows full narrative title in tooltip
+2. **Click theme badge**: Navigates to /narratives page (filtered view coming in future)
+3. **Emerging badge**: Static indicator, helps users spot new trends
+
+## Responsive Design
+
+- On mobile: Theme badges wrap to multiple lines
+- On desktop: Badges display inline with proper spacing
+- All badges have hover effects for better UX

--- a/context-owl-ui/src/lib/formatters.ts
+++ b/context-owl-ui/src/lib/formatters.ts
@@ -135,3 +135,40 @@ export function getEntityTypeColor(entityType: string): string {
 
   return colorMap[entityType.toLowerCase()] || 'text-gray-600 bg-gray-50';
 }
+
+/**
+ * Format theme for display
+ * Maps technical theme names to user-friendly labels
+ */
+export function formatTheme(theme: string): string {
+  const themeMap: Record<string, string> = {
+    'regulatory': 'Regulatory',
+    'defi_adoption': 'DeFi Adoption',
+    'institutional_investment': 'Institutional',
+    'technology_upgrade': 'Tech Upgrade',
+    'market_volatility': 'Market Volatility',
+    'security_breach': 'Security',
+    'partnership': 'Partnership',
+    'ecosystem_growth': 'Ecosystem',
+  };
+
+  return themeMap[theme] || theme.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+}
+
+/**
+ * Get color class for narrative theme badge
+ */
+export function getThemeColor(theme: string): string {
+  const colorMap: Record<string, string> = {
+    'regulatory': 'text-red-700 bg-red-100 hover:bg-red-200',
+    'defi_adoption': 'text-purple-700 bg-purple-100 hover:bg-purple-200',
+    'institutional_investment': 'text-green-700 bg-green-100 hover:bg-green-200',
+    'technology_upgrade': 'text-blue-700 bg-blue-100 hover:bg-blue-200',
+    'market_volatility': 'text-orange-700 bg-orange-100 hover:bg-orange-200',
+    'security_breach': 'text-red-700 bg-red-100 hover:bg-red-200',
+    'partnership': 'text-indigo-700 bg-indigo-100 hover:bg-indigo-200',
+    'ecosystem_growth': 'text-teal-700 bg-teal-100 hover:bg-teal-200',
+  };
+
+  return colorMap[theme] || 'text-gray-700 bg-gray-100 hover:bg-gray-200';
+}

--- a/context-owl-ui/src/pages/Signals.tsx
+++ b/context-owl-ui/src/pages/Signals.tsx
@@ -1,11 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { signalsAPI } from '../api';
 import { Card, CardHeader, CardTitle, CardContent } from '../components/Card';
 import { Loading } from '../components/Loading';
 import { ErrorMessage } from '../components/ErrorMessage';
-import { formatRelativeTime, getSignalStrengthColor, formatPercentage, formatSentiment, getSentimentColor, formatEntityType, getEntityTypeColor } from '../lib/formatters';
+import { formatRelativeTime, getSignalStrengthColor, formatPercentage, formatSentiment, getSentimentColor, formatEntityType, getEntityTypeColor, formatTheme, getThemeColor } from '../lib/formatters';
 
 export function Signals() {
+  const navigate = useNavigate();
   const { data, isLoading, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ['signals'],
     queryFn: () => signalsAPI.getSignals({ limit: 10 }),
@@ -82,6 +84,34 @@ export function Signals() {
                   <span className="text-gray-700">
                     {formatRelativeTime(signal.last_updated)}
                   </span>
+                </div>
+                
+                {/* Narrative context section */}
+                <div className="mt-3 pt-3 border-t border-gray-200">
+                  {signal.is_emerging ? (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-medium text-yellow-700 bg-yellow-100 px-2 py-1 rounded-full">
+                        🆕 Emerging
+                      </span>
+                      <span className="text-xs text-gray-500">Not yet part of any narrative</span>
+                    </div>
+                  ) : signal.narratives && signal.narratives.length > 0 ? (
+                    <div>
+                      <span className="text-xs text-gray-500 block mb-1">Part of:</span>
+                      <div className="flex flex-wrap gap-1">
+                        {signal.narratives.map((narrative) => (
+                          <button
+                            key={narrative.id}
+                            onClick={() => navigate('/narratives')}
+                            className={`text-xs font-medium px-2 py-1 rounded-full transition-colors ${getThemeColor(narrative.theme)}`}
+                            title={narrative.title}
+                          >
+                            {formatTheme(narrative.theme)}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
                 </div>
               </div>
             </CardContent>

--- a/context-owl-ui/src/types/index.ts
+++ b/context-owl-ui/src/types/index.ts
@@ -15,6 +15,14 @@ export interface EntityMention {
   created_at: string;
 }
 
+// Narrative summary for signals
+export interface NarrativeSummary {
+  id: string;                  // Narrative ObjectId
+  title: string;               // Narrative title
+  theme: string;               // Theme category
+  lifecycle: string;           // Lifecycle stage
+}
+
 // Signal types
 export interface Signal {
   entity: string;              // Entity name (e.g., "Solana")
@@ -23,6 +31,8 @@ export interface Signal {
   velocity: number;            // Mentions per hour
   source_count: number;        // Number of sources
   sentiment: number;           // Sentiment score (-1 to 1)
+  is_emerging: boolean;        // True if not part of any narrative
+  narratives: NarrativeSummary[]; // Narratives containing this entity
   first_seen: string;          // ISO timestamp
   last_updated: string;        // ISO timestamp
 }

--- a/src/crypto_news_aggregator/db/operations/signal_scores.py
+++ b/src/crypto_news_aggregator/db/operations/signal_scores.py
@@ -17,6 +17,8 @@ async def upsert_signal_score(
     velocity: float,
     source_count: int,
     sentiment: Dict[str, float],
+    narrative_ids: List[str] = None,
+    is_emerging: bool = False,
     first_seen: datetime = None,
 ) -> str:
     """
@@ -29,6 +31,8 @@ async def upsert_signal_score(
         velocity: Mention velocity metric
         source_count: Number of unique sources
         sentiment: Sentiment metrics dict
+        narrative_ids: List of narrative IDs containing this entity
+        is_emerging: True if entity is not part of any narrative
         first_seen: When entity was first detected (optional)
     
     Returns:
@@ -50,6 +54,8 @@ async def upsert_signal_score(
             "velocity": velocity,
             "source_count": source_count,
             "sentiment": sentiment,
+            "narrative_ids": narrative_ids or [],
+            "is_emerging": is_emerging,
             "last_updated": now,
         }
         
@@ -67,6 +73,8 @@ async def upsert_signal_score(
             "velocity": velocity,
             "source_count": source_count,
             "sentiment": sentiment,
+            "narrative_ids": narrative_ids or [],
+            "is_emerging": is_emerging,
             "first_seen": first_seen or now,
             "last_updated": now,
             "created_at": now,

--- a/src/crypto_news_aggregator/worker.py
+++ b/src/crypto_news_aggregator/worker.py
@@ -107,6 +107,8 @@ async def update_signal_scores(run_immediately: bool = False):
                         velocity=signal_data["velocity"],
                         source_count=signal_data["source_count"],
                         sentiment=signal_data["sentiment"],
+                        narrative_ids=signal_data.get("narrative_ids", []),
+                        is_emerging=signal_data.get("is_emerging", False),
                         first_seen=first_seen,
                     )
                     

--- a/tests/services/test_signal_narrative_linking.py
+++ b/tests/services/test_signal_narrative_linking.py
@@ -1,0 +1,38 @@
+"""
+Tests for signal-to-narrative linking functionality.
+"""
+
+import pytest
+from datetime import datetime, timezone
+from crypto_news_aggregator.services.signal_service import calculate_signal_score
+from crypto_news_aggregator.db.mongodb import mongo_manager
+
+
+@pytest.mark.asyncio
+async def test_signal_score_includes_narrative_fields():
+    """Test that signal score includes narrative_ids and is_emerging fields."""
+    db = await mongo_manager.get_async_database()
+    entity_mentions = db.entity_mentions
+    
+    test_entity = "TestEntity"
+    mention = await entity_mentions.insert_one({
+        "entity": test_entity,
+        "is_primary": True,
+        "sentiment": "neutral",
+        "source": "test",
+        "created_at": datetime.now(timezone.utc),
+    })
+    
+    try:
+        signal_data = await calculate_signal_score(test_entity)
+        
+        # Verify new fields exist
+        assert "narrative_ids" in signal_data
+        assert "is_emerging" in signal_data
+        assert isinstance(signal_data["narrative_ids"], list)
+        assert isinstance(signal_data["is_emerging"], bool)
+        
+    finally:
+        await entity_mentions.delete_one({"_id": mention.inserted_id})
+
+


### PR DESCRIPTION
- Add narrative_ids and is_emerging fields to signal calculation
- Query narratives collection to find which narratives contain each entity
- Update signal_scores DB operations to store narrative links
- Enrich /api/v1/signals/trending response with narrative details
- Add NarrativeSummary type and update Signal interface
- Add formatTheme() and getThemeColor() formatters
- Display narrative badges or 'Emerging' indicator in Signals UI
- Add clickable theme badges that navigate to narratives page
- Create test_signal_narrative_linking.py with smoke test

Users can now see if a signal is part of an established narrative or represents a truly emerging trend. Color-coded theme badges provide visual context and enable navigation to related narratives.