### PR TITLE
fix: resolve narrative save bugs (timezone and field mismatch)

### DIFF
--- a/src/crypto_news_aggregator/db/operations/narratives.py
+++ b/src/crypto_news_aggregator/db/operations/narratives.py
@@ -54,6 +54,9 @@ def _calculate_days_active(first_seen: datetime) -> int:
         Number of days (minimum 1)
     """
     now = datetime.now(timezone.utc)
+    # Ensure first_seen is timezone-aware
+    if first_seen.tzinfo is None:
+        first_seen = first_seen.replace(tzinfo=timezone.utc)
     delta = now - first_seen
     return max(1, delta.days + 1)  # +1 to count partial days
 

--- a/src/crypto_news_aggregator/worker.py
+++ b/src/crypto_news_aggregator/worker.py
@@ -168,7 +168,7 @@ async def update_narratives():
             await upsert_narrative(
                 theme=narrative["theme"],
                 entities=narrative["entities"],
-                story=narrative["story"],
+                story=narrative.get("summary") or narrative.get("story", ""),
                 article_count=narrative["article_count"]
             )
         


### PR DESCRIPTION
- Fix datetime timezone mismatch in narratives.py _calculate_days_active()
- Add timezone-awareness check to handle naive datetimes
- Fix missing 'story' field in worker.py by supporting both 'summary' and 'story'
- Ensures backward compatibility with old narrative format