### PR TITLE
feat: expand RSS sources from 4 to 10 feeds

### DIFF
--- a/src/crypto_news_aggregator/services/rss_service.py
+++ b/src/crypto_news_aggregator/services/rss_service.py
@@ -23,12 +23,13 @@ class RSSService:
             "decrypt": "https://decrypt.co/feed",
             "bitcoinmagazine": "https://bitcoinmagazine.com/.rss/full/",
             
-            # News & General (5 new sources)
+            # News & General (6 new sources)
             "theblock": "https://www.theblock.co/rss.xml",
             "cryptoslate": "https://cryptoslate.com/feed/",
             "benzinga": "https://www.benzinga.com/feed",
             "bitcoincom": "https://news.bitcoin.com/feed/",
             "dlnews": "https://www.dlnews.com/arc/outboundfeeds/rss/",
+            "watcherguru": "https://watcher.guru/news/feed",
             
             # Research & Analysis (2 working sources)
             "glassnode": "https://insights.glassnode.com/feed/",

--- a/src/crypto_news_aggregator/services/rss_service.py
+++ b/src/crypto_news_aggregator/services/rss_service.py
@@ -23,11 +23,12 @@ class RSSService:
             "decrypt": "https://decrypt.co/feed",
             "bitcoinmagazine": "https://bitcoinmagazine.com/.rss/full/",
             
-            # News & General (4 new sources)
+            # News & General (5 new sources)
             "theblock": "https://www.theblock.co/rss.xml",
             "cryptoslate": "https://cryptoslate.com/feed/",
             "benzinga": "https://www.benzinga.com/feed",
             "bitcoincom": "https://news.bitcoin.com/feed/",
+            "dlnews": "https://www.dlnews.com/arc/outboundfeeds/rss/",
             
             # Research & Analysis (1 working source)
             "glassnode": "https://insights.glassnode.com/feed/",

--- a/src/crypto_news_aggregator/services/rss_service.py
+++ b/src/crypto_news_aggregator/services/rss_service.py
@@ -16,11 +16,26 @@ class RSSService:
     def __init__(self):
         settings = get_settings()
         self.feed_urls = {
+            # Original 4 feeds
             # "chaingpt": settings.CHAINGPT_RSS_URL,  # Removed - returns 404
             "coindesk": "https://www.coindesk.com/arc/outboundfeeds/rss/",
             "cointelegraph": "https://cointelegraph.com/rss",
             "decrypt": "https://decrypt.co/feed",
             "bitcoinmagazine": "https://bitcoinmagazine.com/.rss/full/",
+            
+            # News & General (4 new sources)
+            "theblock": "https://www.theblock.co/rss.xml",
+            "cryptoslate": "https://cryptoslate.com/feed/",
+            "benzinga": "https://www.benzinga.com/feed",
+            "bitcoincom": "https://news.bitcoin.com/feed/",
+            
+            # Research & Analysis (1 working source)
+            "glassnode": "https://insights.glassnode.com/feed/",
+            # Note: messari, delphidigital, bankless, galaxy feeds have technical issues (SSL/XML)
+            
+            # DeFi-Focused (1 working source)
+            "thedefiant": "https://thedefiant.io/feed",
+            # Note: defillama returns HTML, dune has malformed XML
         }
 
     async def fetch_feed(self, url: str) -> Optional[feedparser.FeedParserDict]:

--- a/src/crypto_news_aggregator/services/rss_service.py
+++ b/src/crypto_news_aggregator/services/rss_service.py
@@ -30,9 +30,10 @@ class RSSService:
             "bitcoincom": "https://news.bitcoin.com/feed/",
             "dlnews": "https://www.dlnews.com/arc/outboundfeeds/rss/",
             
-            # Research & Analysis (1 working source)
+            # Research & Analysis (2 working sources)
             "glassnode": "https://insights.glassnode.com/feed/",
-            # Note: messari, delphidigital, bankless, galaxy feeds have technical issues (SSL/XML)
+            "messari": "https://messari.io/rss",
+            # Note: delphidigital, bankless, galaxy feeds have technical issues (SSL/XML)
             
             # DeFi-Focused (1 working source)
             "thedefiant": "https://thedefiant.io/feed",

--- a/tests/background/test_rss_fetcher.py
+++ b/tests/background/test_rss_fetcher.py
@@ -131,17 +131,17 @@ def test_rss_service_has_correct_feed_count():
     """Verify that RSSService has the expected number of RSS feeds configured."""
     rss_service = RSSService()
     
-    # Should have 12 total feeds:
+    # Should have 13 total feeds:
     # - 4 original (coindesk, cointelegraph, decrypt, bitcoinmagazine)
-    # - 5 News & General (theblock, cryptoslate, benzinga, bitcoincom, dlnews)
+    # - 6 News & General (theblock, cryptoslate, benzinga, bitcoincom, dlnews, watcherguru)
     # - 2 Research & Analysis (glassnode, messari)
     # - 1 DeFi-Focused (thedefiant)
-    assert len(rss_service.feed_urls) == 12, f"Expected 12 RSS feeds, got {len(rss_service.feed_urls)}"
+    assert len(rss_service.feed_urls) == 13, f"Expected 13 RSS feeds, got {len(rss_service.feed_urls)}"
     
     # Verify key sources are present
     expected_sources = [
         "coindesk", "cointelegraph", "decrypt", "bitcoinmagazine",  # Original
-        "theblock", "cryptoslate", "benzinga", "bitcoincom", "dlnews",  # News & General
+        "theblock", "cryptoslate", "benzinga", "bitcoincom", "dlnews", "watcherguru",  # News & General
         "glassnode", "messari",  # Research
         "thedefiant",  # DeFi
     ]

--- a/tests/background/test_rss_fetcher.py
+++ b/tests/background/test_rss_fetcher.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 import pytest
 
 from src.crypto_news_aggregator.background import rss_fetcher
+from src.crypto_news_aggregator.services.rss_service import RSSService
 from src.crypto_news_aggregator.models.article import (
     ArticleCreate,
     ArticleMetrics,
@@ -124,3 +125,31 @@ async def test_fetch_and_process_rss_feeds_persists_and_enriches(mongo_db, monke
     assert stored["sentiment_score"] == pytest.approx(0.6)
     assert stored["sentiment_label"] == "positive"
     assert stored["themes"] == ["ETFs", "Institutional"]
+
+
+def test_rss_service_has_correct_feed_count():
+    """Verify that RSSService has the expected number of RSS feeds configured."""
+    rss_service = RSSService()
+    
+    # Should have 10 total feeds:
+    # - 4 original (coindesk, cointelegraph, decrypt, bitcoinmagazine)
+    # - 4 News & General (theblock, cryptoslate, benzinga, bitcoincom)
+    # - 1 Research & Analysis (glassnode)
+    # - 1 DeFi-Focused (thedefiant)
+    assert len(rss_service.feed_urls) == 10, f"Expected 10 RSS feeds, got {len(rss_service.feed_urls)}"
+    
+    # Verify key sources are present
+    expected_sources = [
+        "coindesk", "cointelegraph", "decrypt", "bitcoinmagazine",  # Original
+        "theblock", "cryptoslate", "benzinga", "bitcoincom",  # News & General
+        "glassnode",  # Research
+        "thedefiant",  # DeFi
+    ]
+    
+    for source in expected_sources:
+        assert source in rss_service.feed_urls, f"Expected source '{source}' not found in feed_urls"
+    
+    # Verify all URLs are valid strings
+    for source, url in rss_service.feed_urls.items():
+        assert isinstance(url, str), f"URL for {source} is not a string"
+        assert url.startswith("http"), f"URL for {source} does not start with http"

--- a/tests/background/test_rss_fetcher.py
+++ b/tests/background/test_rss_fetcher.py
@@ -131,18 +131,18 @@ def test_rss_service_has_correct_feed_count():
     """Verify that RSSService has the expected number of RSS feeds configured."""
     rss_service = RSSService()
     
-    # Should have 11 total feeds:
+    # Should have 12 total feeds:
     # - 4 original (coindesk, cointelegraph, decrypt, bitcoinmagazine)
     # - 5 News & General (theblock, cryptoslate, benzinga, bitcoincom, dlnews)
-    # - 1 Research & Analysis (glassnode)
+    # - 2 Research & Analysis (glassnode, messari)
     # - 1 DeFi-Focused (thedefiant)
-    assert len(rss_service.feed_urls) == 11, f"Expected 11 RSS feeds, got {len(rss_service.feed_urls)}"
+    assert len(rss_service.feed_urls) == 12, f"Expected 12 RSS feeds, got {len(rss_service.feed_urls)}"
     
     # Verify key sources are present
     expected_sources = [
         "coindesk", "cointelegraph", "decrypt", "bitcoinmagazine",  # Original
         "theblock", "cryptoslate", "benzinga", "bitcoincom", "dlnews",  # News & General
-        "glassnode",  # Research
+        "glassnode", "messari",  # Research
         "thedefiant",  # DeFi
     ]
     

--- a/tests/background/test_rss_fetcher.py
+++ b/tests/background/test_rss_fetcher.py
@@ -131,17 +131,17 @@ def test_rss_service_has_correct_feed_count():
     """Verify that RSSService has the expected number of RSS feeds configured."""
     rss_service = RSSService()
     
-    # Should have 10 total feeds:
+    # Should have 11 total feeds:
     # - 4 original (coindesk, cointelegraph, decrypt, bitcoinmagazine)
-    # - 4 News & General (theblock, cryptoslate, benzinga, bitcoincom)
+    # - 5 News & General (theblock, cryptoslate, benzinga, bitcoincom, dlnews)
     # - 1 Research & Analysis (glassnode)
     # - 1 DeFi-Focused (thedefiant)
-    assert len(rss_service.feed_urls) == 10, f"Expected 10 RSS feeds, got {len(rss_service.feed_urls)}"
+    assert len(rss_service.feed_urls) == 11, f"Expected 11 RSS feeds, got {len(rss_service.feed_urls)}"
     
     # Verify key sources are present
     expected_sources = [
         "coindesk", "cointelegraph", "decrypt", "bitcoinmagazine",  # Original
-        "theblock", "cryptoslate", "benzinga", "bitcoincom",  # News & General
+        "theblock", "cryptoslate", "benzinga", "bitcoincom", "dlnews",  # News & General
         "glassnode",  # Research
         "thedefiant",  # DeFi
     ]


### PR DESCRIPTION
- Add 4 News & General sources: The Block, CryptoSlate, Benzinga, Bitcoin.com
- Add 1 Research source: Glassnode Insights
- Add 1 DeFi source: The Defiant
- Add test to verify RSS feed count and configuration
- Document feeds with technical issues (SSL/XML errors) for future investigation

Total feeds: 10 (4 original + 6 new working feeds)

Note: Messari, Delphi Digital, Bankless, Galaxy, DefiLlama, and Dune feeds have technical issues and were excluded from this release.