### PR TITLE
docs(task-095): Add fresh-start narrative trust addendum to investiga…

### DIFF
--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/decisions/decide-20260510-fresh-start-narrative-trust.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/decisions/decide-20260510-fresh-start-narrative-trust.md
@@ -1,0 +1,62 @@
+# Decision: Fresh-Start Narrative Trust Layer
+
+**Date:** 2026-05-10  
+**Status:** Accepted  
+**Sprint:** 019  
+
+---
+
+## Decision
+
+For Sprint 019, we will not mass-refresh or repair all legacy narratives. Instead, we will separate trusted generated summaries from recent article activity.
+
+Briefings will only use narratives whose generated summaries are trusted. The narratives page will remain activity-based and show recent article clusters even when generated summaries are stale or missing.
+
+For untrusted summaries, the public UI will render deterministic article-cluster fallback copy. It will not show stale generated summary text as authoritative, and it will not expose internal labels like stale, missing, untrusted, or needs refresh.
+
+---
+
+## Rationale
+
+TASK-095 found 341 active narratives missing `last_summary_generated_at`, but only 4 narratives flagged with `needs_summary_update=true`. The refresh task works for flagged narratives, but legacy narratives missing the timestamp are not being selected for refresh.
+
+Mass-refreshing all legacy narratives would add cost, consume daily LLM budget, and risk broad user-facing churn. However, ignoring recent article activity would make the narratives page sparse and hide useful information.
+
+This decision preserves recent activity while avoiding stale generated summaries in high-risk synthesis paths.
+
+---
+
+## Consequences
+
+### Positive
+
+- Briefings stop synthesizing from untrusted summaries.
+- The narratives page remains populated using recent article activity.
+- No LLM spend is required for fallback card copy.
+- Legacy narratives remain available for future repair.
+- The sprint avoids broad data migration and mass refresh risk.
+
+### Negative
+
+- Historical narrative continuity is not fully repaired in Sprint 019.
+- Some long-running narratives may be excluded from briefings until refreshed or validated.
+- API and UI need a display-mode contract to avoid leaking internal freshness state.
+
+---
+
+## Non-Goals
+
+- Do not delete legacy narratives.
+- Do not mark all old narratives dormant.
+- Do not refresh all 341 legacy narratives.
+- Do not use LLM calls for fallback card copy.
+- Do not change article-to-narrative matching behavior in this sprint.
+
+---
+
+## Follow-Up Options
+
+- Selectively refresh high-value legacy narratives later.
+- Add admin tooling to validate or reactivate selected legacy narratives.
+- Add a controlled batch repair sprint when cost budget permits.
+- Revisit article-to-narrative matching if old legacy narratives continue absorbing new articles in harmful ways.

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/sprint-019-fresh-start-narrative-trust.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/sprint-019-fresh-start-narrative-trust.md
@@ -1,0 +1,140 @@
+# Sprint 019 — Fresh-Start Narrative Trust Layer
+
+**Status:** Planned  
+**Started:** 2026-05-10  
+**Target:** Protect user-facing briefings from untrusted narrative summaries while keeping the narratives page useful through deterministic article-activity fallbacks.
+
+---
+
+## Sprint Goal
+
+Sprint 019 creates a trust boundary between generated narrative summaries and recent article activity. Briefings should only synthesize from trusted summaries, while the narratives page should remain populated by recent article clusters even when a generated summary is stale or missing.
+
+The sprint also prevents malformed LLM refinement output from publishing and repairs the refinement prompt so it has actual source context when self-refine runs.
+
+---
+
+## Scope Boundary
+
+### In Scope
+- [ ] Prevent invalid, low-confidence, non-JSON, or model-meta briefing output from publishing.
+- [ ] Add trusted-summary eligibility for briefing narrative inputs.
+- [ ] Add backend narrative display-mode fields for public narrative cards.
+- [ ] Add deterministic, zero-LLM article-cluster fallback display for untrusted summaries.
+- [ ] Ground briefing refinement prompts with source context so refinement can repair rather than ask for missing data.
+- [ ] Add Sprint 019 verification queries and runbook notes.
+
+### Out of Scope / Non-Goals
+- [ ] Do not refresh all 341 legacy narratives in this sprint.
+- [ ] Do not delete old narratives.
+- [ ] Do not mark old narratives dormant as part of this sprint.
+- [ ] Do not expose internal labels like stale, missing, untrusted, or needs refresh to public users.
+- [ ] Do not use LLM calls to generate narrative-card fallback copy.
+- [ ] Do not change narrative clustering or article-to-narrative matching behavior.
+- [ ] Do not increase narrative refresh batch size or LLM budget.
+
+---
+
+## Sprint Order
+
+| # | Ticket | Title | Status | Est | Actual |
+|---|--------|-------|--------|-----|--------|
+| 0 | TASK-095 | Briefing and Narrative Refresh Investigation | ✅ COMPLETE | medium | |
+| 1 | BUG-099 | Prevent Invalid Briefings From Publishing | 🔲 OPEN | medium | |
+| 2 | FEATURE-060 | Add Trusted Summary Eligibility for Briefings | 🔲 OPEN | medium | |
+| 3 | FEATURE-061 | Add Narrative Display Mode API Fields | 🔲 OPEN | medium | |
+| 4 | FEATURE-062 | Add Deterministic Article Cluster Fallback | 🔲 OPEN | medium | |
+| 5 | BUG-100 | Ground Briefing Refinement With Source Context | 🔲 OPEN | medium | |
+| 6 | TASK-096 | Add Sprint 019 Verification Queries | 🔲 OPEN | small | |
+
+---
+
+## Success Criteria
+
+- [ ] A briefing with raw non-JSON model output cannot publish to the public briefing page.
+- [ ] A briefing with `confidence_score < 0.5` cannot publish unless explicitly saved as an unpublished failure record.
+- [ ] A briefing with empty `key_insights` cannot publish.
+- [ ] Briefing generation uses only narratives with trusted summaries.
+- [ ] The public narratives page remains populated by recent article activity, even when generated summaries are not trusted.
+- [ ] Public users never see internal system-state language such as stale, missing, untrusted, or needs refresh.
+- [ ] Untrusted narrative cards render deterministic fallback copy from recent article data without LLM calls.
+- [ ] Briefing refinement prompt includes source context and cannot reference unavailable `AVAILABLE DATA`.
+- [ ] No mass legacy narrative refresh is triggered by this sprint.
+- [ ] LLM spend does not increase except for the small expected increase from refinement prompt context when refinement runs.
+
+---
+
+## Agent Safety Notes
+
+These constraints apply to all implementation agents working this sprint:
+
+- Do not modify production data.
+- Do not introduce broad database, shell, or filesystem access when a narrow tool/API is sufficient.
+- Do not change unrelated files.
+- Do not add autonomous destructive actions.
+- Keep implementation bounded to the ticket's listed files unless a blocker is documented.
+- If the implementation requires a new file/path not listed in the ticket, stop and document why before proceeding.
+- Do not trigger production briefing generation unless explicitly approved.
+- Do not trigger narrative refresh jobs unless explicitly approved.
+- Do not add LLM calls for narrative-card fallback display.
+- Do not expose internal summary trust labels to public users.
+
+---
+
+## Implementation Notes
+
+### Expected Branch Naming
+
+```text
+feature/[short-description]
+task/[short-description]
+fix/[short-description]
+```
+
+### Expected Commit Format
+
+```text
+feat(scope): description
+fix(scope): description
+task(scope): description
+```
+
+### Test Expectations
+
+- Unit tests should be added or updated for every logic change.
+- Integration/manual verification steps must be documented in the ticket completion summary.
+- If a test cannot be automated, document the reason and provide a manual verification path.
+
+---
+
+## Key Decisions
+
+| Date | Decision | Rationale | Impact |
+|------|----------|-----------|--------|
+| 2026-05-10 | Use fresh-start narrative trust instead of mass legacy repair. | 341 active legacy narratives are missing `last_summary_generated_at`; repairing all of them would cost money and add operational risk. | Briefings will only use trusted summaries. Old narratives stay in MongoDB for optional later repair. |
+| 2026-05-10 | Keep the narratives page activity-based. | Recent article clusters remain useful even when generated summaries are stale. | The narratives page should not go sparse just because a summary is untrusted. |
+| 2026-05-10 | Use deterministic article-cluster fallback copy. | Avoid LLM cost and avoid presenting stale generated summaries as authoritative. | Public users see polished article activity cards, not system-state labels. |
+| 2026-05-10 | Do not change clustering/matching behavior in Sprint 019. | Matching changes could create duplicate narratives and are riskier than query/display fixes. | Matching behavior remains a future follow-up if needed. |
+
+---
+
+## Discovered Work
+
+_Tickets created mid-sprint for issues found during implementation._
+
+| Ticket | Title | Reason Created | Status |
+|--------|-------|----------------|--------|
+| | | | |
+
+---
+
+## Session Log
+
+### Session 1 (2026-05-10) — TASK-095 ✅
+**Briefing and Narrative Refresh Investigation**
+- Confirmed invalid briefing output was published because raw non-JSON LLM text can become `content.narrative` with `confidence_score=0.3`.
+- Confirmed `_save_briefing()` publishes non-smoke briefings without confidence, empty-insight, parse-failure, or meta-output validation.
+- Confirmed refinement prompt references `AVAILABLE DATA` but only includes counts, not the actual narrative context.
+- Confirmed 341 active narratives are missing `last_summary_generated_at`, while only 4 were flagged for refresh.
+- Confirmed narrative refresh task exists, is batched, and converts string article IDs to ObjectId correctly.
+- Branch: `task/briefing-narrative-refresh-investigation` | Commit: `[fill in]`

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/bug-099-prevent-invalid-briefings-from-publishing.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/bug-099-prevent-invalid-briefings-from-publishing.md
@@ -1,0 +1,270 @@
+---
+id: BUG-099
+type: bug
+status: backlog
+priority: high
+severity: high
+created: 2026-05-10
+updated: 2026-05-10
+branch: fix/prevent-invalid-briefings-publishing
+---
+
+# BUG-099: Prevent Invalid Briefings From Publishing
+
+## Problem
+
+A production morning briefing published invalid model meta-output instead of a valid briefing. The saved `content.narrative` asked for narrative titles, summaries, and entity names.
+
+TASK-095 confirmed that `_parse_briefing_response()` can fall back to raw LLM text as `narrative` when JSON parsing fails, assigning `confidence_score=0.3`. `_save_briefing()` then publishes non-smoke briefings without validating confidence, empty insights, parse failure, or model meta-output.
+
+---
+
+## Expected Behavior
+
+Malformed, low-confidence, empty, or model-meta briefing output must not be published to public users.
+
+If a briefing generation/refinement result is invalid, the system should either:
+
+1. not save it, or
+2. save it as an unpublished failure/debug record with metadata indicating why it was rejected.
+
+The public briefing API should continue returning the latest valid published briefing.
+
+---
+
+## Actual Behavior
+
+A bad briefing was saved with:
+
+```text
+confidence_score: 0.3
+key_insights: []
+content.narrative: request for missing narrative data
+published: true
+```
+
+The public briefing page then displayed it until it was manually unpublished.
+
+---
+
+## Impact
+
+- Environment: production
+- User impact: high
+- Operational impact: public briefing page can show model meta-output instead of a briefing
+- Cost/performance/data impact: no direct cost increase, but failed generations can still consume LLM budget and produce unusable artifacts
+
+---
+
+## Evidence
+
+### Logs / Trace IDs / Screenshots
+
+```text
+Bad briefing:
+_id: 6a00734544c1c6f85c7266f1
+type: morning
+generated_at: 2026-05-10T12:00:00.512Z
+task_id: 9ec83c1e-5dd7-423c-a70e-831b10a2375f
+metadata.confidence_score: 0.3
+metadata.refinement_iterations: 1
+content.key_insights: []
+content.narrative: asks user to provide narrative titles, summaries, and entity names
+```
+
+TASK-095 findings:
+
+```text
+briefing_agent.py:831-890: _parse_briefing_response() accepts raw text on JSON decode failure.
+briefing_agent.py:940-1012: _save_briefing() publishes non-smoke briefings without quality validation.
+db/operations/briefing.py:63-76: public latest briefing query filters published/smoke only, not quality.
+api/v1/endpoints/briefing.py:229-260: public endpoint returns latest production briefing without validity filtering.
+```
+
+### Known Facts
+
+- [ ] JSON parse failure currently returns `GeneratedBriefing(narrative=response_text[:2000], key_insights=[], confidence_score=0.3)`.
+- [ ] `_save_briefing()` sets `published = not is_smoke`.
+- [ ] Public briefing filtering only checks production/smoke fields.
+- [ ] Bad briefing was manually unpublished after discovery.
+
+### Hypotheses
+
+- [ ] Some tests may currently expect the raw-text fallback behavior and will need updates.
+
+---
+
+## Steps to Reproduce
+
+1. Mock `_call_llm()` or `_generate_with_llm()` to return plain text instead of valid JSON.
+2. Ensure the text contains a request for missing data, for example `Please provide the active narrative data`.
+3. Run the briefing parse/save flow for a non-smoke briefing.
+4. Observe that the current code can save and publish the raw text as `content.narrative`.
+
+---
+
+## Files to Inspect
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+src/crypto_news_aggregator/db/operations/briefing.py
+src/crypto_news_aggregator/api/v1/endpoints/briefing.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+src/crypto_news_aggregator/db/operations/briefing.py
+src/crypto_news_aggregator/api/v1/endpoints/briefing.py
+```
+
+Test files to locate or create:
+
+```text
+tests/**/test_briefing_agent*.py
+tests/**/test_briefing*.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/services/narrative_service.py
+src/crypto_news_aggregator/tasks/narrative_refresh.py
+src/crypto_news_aggregator/tasks/beat_schedule.py
+context-owl-ui/
+```
+
+Do not modify production data. Do not trigger briefing generation against production.
+
+---
+
+## Fix Requirements
+
+- [ ] Add explicit parse-failure tracking to `GeneratedBriefing` or an equivalent internal result structure.
+- [ ] Do not treat arbitrary non-JSON LLM output as valid publishable briefing content.
+- [ ] Add a publishability validation step before inserting a public briefing.
+- [ ] Reject publishable status when `confidence_score < 0.5`.
+- [ ] Reject publishable status when `key_insights` is empty.
+- [ ] Reject publishable status when `narrative` is empty or whitespace.
+- [ ] Reject publishable status when narrative contains model-meta or missing-data request language.
+- [ ] Suggested phrase patterns include:
+  - `I need the actual narrative data`
+  - `please provide`
+  - `I don't have access`
+  - `AVAILABLE DATA`
+  - `Could you provide`
+  - `I'm ready to execute`
+  - `before I can generate`
+- [ ] Invalid outputs must not be returned by the public latest briefing API.
+- [ ] Log rejected briefing output with `briefing_type`, `task_id`, confidence score, and rejection reason.
+- [ ] If saving invalid output for debugging, save with `published=false` and metadata such as:
+
+```python
+{
+    "invalid_output": True,
+    "invalid_reason": "parse_failed_or_model_meta_output",
+    "invalidated_at": datetime.now(timezone.utc),
+}
+```
+
+### Required Interfaces / Schemas
+
+Prefer a small helper in `briefing_agent.py`:
+
+```python
+def _validate_briefing_publishable(generated: GeneratedBriefing) -> tuple[bool, str | None]:
+    """Return whether a generated briefing is safe to publish and a rejection reason if not."""
+```
+
+If `GeneratedBriefing` is a dataclass, add optional fields only if needed:
+
+```python
+parse_failed: bool = False
+raw_response_excerpt: str | None = None
+```
+
+---
+
+## Verification Plan
+
+### Automated Tests
+
+```bash
+pytest tests -k "briefing and (parse or publish or invalid)"
+```
+
+Required cases:
+
+- [ ] Plain text LLM response does not produce a published briefing.
+- [ ] JSON parse failure marks briefing invalid or returns unpublished failure.
+- [ ] `confidence_score < 0.5` is rejected for publication.
+- [ ] Empty `key_insights` is rejected for publication.
+- [ ] Empty narrative is rejected for publication.
+- [ ] Narrative containing missing-data request language is rejected for publication.
+- [ ] Valid JSON briefing with confidence >= 0.5 and non-empty insights can publish.
+
+### Manual Verification
+
+1. Query latest public briefing after tests or local smoke flow.
+2. Expected result: latest public briefing never contains phrases like `please provide`, `I don't have access`, or `AVAILABLE DATA`.
+3. Confirm the manually invalidated May 10 briefing remains unpublished.
+
+Mongo check:
+
+```javascript
+db.daily_briefings.find(
+  {
+    published: true,
+    "content.narrative": /please provide|I don't have access|AVAILABLE DATA|I need the actual narrative data|before I can generate/i
+  },
+  { type: 1, generated_at: 1, "content.narrative": 1, metadata: 1 }
+)
+```
+
+Expected: no results.
+
+---
+
+## Regression Risk
+
+- Risk level: medium
+- Areas to watch:
+  - Briefings may fail closed and users may see the previous valid briefing.
+  - Existing tests may assume parse fallback returns a minimal briefing.
+  - If validation is too strict, valid briefings could be rejected.
+
+Mitigation:
+
+- Keep validation rules explicit and test-backed.
+- Log rejected outputs with reason.
+- Do not delete invalid generations unless explicitly decided.
+
+---
+
+## Resolution
+
+**Status:** Open  
+**Fixed:** YYYY-MM-DD  
+**Branch:**  
+**Commit:**
+
+### Root Cause
+
+<!-- Fill after fixing. -->
+
+### Changes Made
+
+<!-- Fill after fixing. -->
+
+### Testing
+
+<!-- Fill after fixing. -->
+
+### Files Changed
+
+<!-- Fill after fixing. -->

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/bug-100-ground-briefing-refinement-with-source-context.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/bug-100-ground-briefing-refinement-with-source-context.md
@@ -1,0 +1,226 @@
+---
+id: BUG-100
+type: bug
+status: backlog
+priority: medium
+severity: medium
+created: 2026-05-10
+updated: 2026-05-10
+branch: fix/ground-briefing-refinement-context
+---
+
+# BUG-100: Ground Briefing Refinement With Source Context
+
+## Problem
+
+The briefing refinement prompt references `AVAILABLE DATA` but only includes counts of signals, narratives, and patterns. It does not include actual narrative titles, summaries, entities, article titles, signal details, or pattern details.
+
+When critique identified hallucinations and missing sources, the refinement model asked for the missing data instead of producing a corrected briefing.
+
+---
+
+## Expected Behavior
+
+When self-refine runs, the refinement prompt should include enough source context for the model to correct the briefing without asking for more data.
+
+The model should be instructed to return valid JSON only and remove unsupported claims rather than requesting additional data.
+
+---
+
+## Actual Behavior
+
+TASK-095 found that `_build_refinement_prompt()` includes:
+
+```text
+AVAILABLE DATA:
+- Signals: {count} trending entities
+- Narratives: {count} active narratives
+- Patterns: {count} detected patterns
+```
+
+But it does not include the actual available data.
+
+---
+
+## Impact
+
+- Environment: production
+- User impact: medium to high when refinement runs
+- Operational impact: refinement can degrade output or ask for source material
+- Cost/performance/data impact: minor token increase expected after fix
+
+---
+
+## Evidence
+
+### Logs / Trace IDs / Screenshots
+
+Bad briefing narrative included:
+
+```text
+I appreciate the detailed critique, but I need to pause and request the actual narrative data before I can generate a corrected briefing.
+```
+
+TASK-095 findings:
+
+```text
+briefing_agent.py:619-689: _build_generation_prompt() includes narrative details.
+briefing_agent.py:691-758: _build_critique_prompt() includes briefing, key insights, available narrative titles, and entities.
+briefing_agent.py:765-786: _build_refinement_prompt() includes original briefing, critique feedback, and counts only.
+briefing_agent.py:393-501: _self_refine() saves the last refinement output regardless of quality unless other validation exists.
+```
+
+### Known Facts
+
+- [ ] Generation prompt includes narrative titles and summaries.
+- [ ] Critique prompt includes narrative titles and entities.
+- [ ] Refinement prompt lacks actual source context.
+- [ ] Refinement prompt says valid JSON only, but BUG-099 is needed to enforce this.
+
+### Hypotheses
+
+- [ ] Adding source context will reduce refinement refusals and missing-data requests.
+- [ ] Prompt token count will increase modestly when refinement runs.
+
+---
+
+## Steps to Reproduce
+
+1. Create or mock a briefing input with multiple narratives.
+2. Build the generation prompt and observe narrative details are present.
+3. Build the refinement prompt for the same input.
+4. Observe that only counts are included under `AVAILABLE DATA`, not the actual narrative details.
+
+---
+
+## Files to Inspect
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+```
+
+Test files to locate or create:
+
+```text
+tests/**/test_briefing_agent*.py
+tests/**/test_briefing_refinement*.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/services/narrative_service.py
+src/crypto_news_aggregator/tasks/narrative_refresh.py
+src/crypto_news_aggregator/tasks/beat_schedule.py
+context-owl-ui/
+```
+
+Do not modify production data.
+
+---
+
+## Fix Requirements
+
+- [ ] Update `_build_refinement_prompt()` to include actual source context.
+- [ ] Include top narrative titles and summaries from `briefing_input.narratives`.
+- [ ] Include narrative entities where available.
+- [ ] Include article titles/sources where already available in `briefing_input` without adding new DB calls.
+- [ ] Include signal details and pattern details if already present in `briefing_input`.
+- [ ] Do not add new LLM calls.
+- [ ] Do not add new database calls unless the existing input does not contain any needed context. If new DB calls are required, stop and document the blocker.
+- [ ] Keep context bounded to avoid token explosion.
+- [ ] Recommended limit: top 8 narratives, top 5 entities per narrative, top 3 article titles per narrative if available.
+- [ ] Prompt must explicitly instruct:
+  - return valid JSON only
+  - do not ask for additional data
+  - use only provided source context
+  - if unsupported, remove the claim
+  - if context is sparse, produce a conservative briefing
+- [ ] Coordinate with BUG-099 so non-JSON output fails closed.
+
+---
+
+## Verification Plan
+
+### Automated Tests
+
+```bash
+pytest tests -k "briefing and refine"
+```
+
+Required cases:
+
+- [ ] Refinement prompt includes narrative titles.
+- [ ] Refinement prompt includes narrative summaries/facts when available.
+- [ ] Refinement prompt includes narrative entities when available.
+- [ ] Refinement prompt includes instructions not to ask for additional data.
+- [ ] Refinement prompt includes valid JSON only instruction.
+- [ ] Refinement prompt does not include only counts under `AVAILABLE DATA`.
+- [ ] Prompt size remains bounded for 15 narratives.
+
+### Manual Verification
+
+Create a sample refinement prompt locally and inspect it.
+
+Expected:
+
+```text
+ORIGINAL BRIEFING: ...
+CRITIQUE FEEDBACK: ...
+AVAILABLE SOURCE CONTEXT:
+Narrative 1: title, summary, entities
+Narrative 2: title, summary, entities
+...
+Return ONLY valid JSON. Do not ask for additional data.
+```
+
+---
+
+## Regression Risk
+
+- Risk level: medium
+- Areas to watch:
+  - Prompt length and cost.
+  - Model output format stability.
+  - Refinement overfitting to source snippets.
+
+Mitigation:
+
+- Bound context.
+- Add tests against prompt structure.
+- Rely on BUG-099 publishability gate for fail-closed behavior.
+
+---
+
+## Resolution
+
+**Status:** Open  
+**Fixed:** YYYY-MM-DD  
+**Branch:**  
+**Commit:**
+
+### Root Cause
+
+<!-- Fill after fixing. -->
+
+### Changes Made
+
+<!-- Fill after fixing. -->
+
+### Testing
+
+<!-- Fill after fixing. -->
+
+### Files Changed
+
+<!-- Fill after fixing. -->

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/feature-060-trusted-summary-eligibility-for-briefings.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/feature-060-trusted-summary-eligibility-for-briefings.md
@@ -1,0 +1,244 @@
+---
+id: FEATURE-060
+type: feature
+status: backlog
+priority: high
+complexity: medium
+created: 2026-05-10
+updated: 2026-05-10
+branch: feature/trusted-summary-briefing-eligibility
+---
+
+# FEATURE-060: Add Trusted Summary Eligibility for Briefings
+
+## Problem/Opportunity
+
+Briefings currently consume active narratives even when their generated summaries may be stale or missing freshness metadata. TASK-095 found 341 active narratives missing `last_summary_generated_at`, while only 4 were flagged for refresh.
+
+The May 10 bad briefing was likely downstream of contradictory or stale narrative inputs combined with a refinement validation gap. Sprint 019 adopts a fresh-start trust boundary: briefings should synthesize only from trusted narrative summaries.
+
+---
+
+## Proposed Solution
+
+Add trusted-summary eligibility logic to the briefing input path. The briefing agent should exclude narratives whose generated summary/title is not trusted.
+
+A narrative is trusted for briefing synthesis if any of the following is true:
+
+1. `first_seen >= FRESH_START_CUTOFF`
+2. `last_summary_generated_at >= FRESH_START_CUTOFF`
+3. `_fresh_start_validated_at >= FRESH_START_CUTOFF`
+
+The initial cutoff should be configurable and default to `2026-05-10T00:00:00Z` if not configured.
+
+Old narratives should not be deleted or modified. They are simply excluded from briefing synthesis unless they meet eligibility.
+
+---
+
+## User Story
+
+As a reader of the crypto briefing, I want briefings to be generated only from trusted and current narrative summaries so that the briefing does not synthesize stale or contradictory narrative state.
+
+---
+
+## Implementation Scope
+
+### In Scope
+- [ ] Add a trusted-summary eligibility helper for narratives used by briefing generation.
+- [ ] Apply the eligibility helper inside briefing input gathering before selecting the top active narratives.
+- [ ] Add a configurable fresh-start cutoff date.
+- [ ] Log how many narratives were excluded from briefing inputs due to untrusted summaries.
+- [ ] Ensure the briefing can still generate with fewer than 15 narratives.
+- [ ] Add tests for old missing-timestamp narratives being excluded.
+
+### Out of Scope
+- [ ] Do not change the public narratives page behavior in this ticket.
+- [ ] Do not refresh old narratives.
+- [ ] Do not delete old narratives.
+- [ ] Do not mark narratives dormant.
+- [ ] Do not change narrative clustering or matching.
+- [ ] Do not add LLM calls.
+
+---
+
+## Files to Create
+
+Test file, if no suitable existing test file exists:
+
+```text
+tests/**/test_briefing_narrative_eligibility.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+src/crypto_news_aggregator/core/config.py
+```
+
+Potentially, if narrative query logic lives elsewhere:
+
+```text
+src/crypto_news_aggregator/db/operations/narratives.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/tasks/narrative_refresh.py
+src/crypto_news_aggregator/tasks/beat_schedule.py
+context-owl-ui/
+```
+
+Do not modify production data.
+
+---
+
+## Exact Implementation Requirements
+
+1. Locate the briefing narrative input gathering path. TASK-095 identified `briefing_agent.py` as the relevant file and noted article hydration in `briefing_agent.py:322`.
+2. Add a helper similar to:
+
+```python
+def _is_narrative_summary_trusted(narrative: dict[str, Any], cutoff: datetime) -> bool:
+    """Return True if this narrative summary is trusted for briefing synthesis."""
+```
+
+3. The helper must return `True` if:
+
+```text
+first_seen >= cutoff
+OR last_summary_generated_at >= cutoff
+OR _fresh_start_validated_at >= cutoff
+```
+
+4. The helper must return `False` for active legacy narratives where:
+
+```text
+first_seen < cutoff
+last_summary_generated_at missing
+_fresh_start_validated_at missing
+```
+
+5. Apply this helper before passing narratives into prompt construction.
+6. Preserve existing sorting/ranking among eligible narratives.
+7. Do not mutate narrative records.
+8. Log counts:
+
+```text
+active_narratives_considered
+trusted_narratives_selected
+untrusted_narratives_excluded
+```
+
+9. If fewer than 15 trusted narratives exist, continue with the available trusted narratives. Do not backfill with untrusted narratives.
+10. Ensure prompt language tolerates fewer narratives.
+11. Add config setting:
+
+```text
+FRESH_START_CUTOFF=2026-05-10T00:00:00Z
+```
+
+If the project uses a different config naming style, use the existing convention but keep the setting explicit.
+
+### Required Interfaces / Schemas
+
+Suggested config field:
+
+```python
+FRESH_START_CUTOFF: str = "2026-05-10T00:00:00Z"
+```
+
+Suggested parsed helper:
+
+```python
+def get_fresh_start_cutoff() -> datetime:
+    ...
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Briefing input gathering excludes active legacy narratives missing `last_summary_generated_at` when `first_seen` is before the cutoff.
+- [ ] Briefing input gathering includes narratives with `first_seen >= cutoff`.
+- [ ] Briefing input gathering includes old narratives with `last_summary_generated_at >= cutoff`.
+- [ ] Briefing input gathering includes old narratives with `_fresh_start_validated_at >= cutoff`.
+- [ ] The system can generate a briefing with fewer than 15 trusted narratives.
+- [ ] The code logs how many narratives were excluded.
+- [ ] No narrative documents are modified.
+- [ ] No LLM calls are added.
+
+---
+
+## Test Plan
+
+### Automated Tests
+
+```bash
+pytest tests -k "trusted and narrative and briefing"
+```
+
+Required test coverage:
+
+- [ ] Old active narrative with missing `last_summary_generated_at` is excluded.
+- [ ] Old active narrative with `last_summary_generated_at` after cutoff is included.
+- [ ] New narrative with `first_seen` after cutoff is included.
+- [ ] Old narrative with `_fresh_start_validated_at` after cutoff is included.
+- [ ] Missing or malformed timestamp fails closed, meaning excluded from briefing synthesis.
+- [ ] Fewer than 15 eligible narratives does not crash prompt construction.
+
+### Manual Verification
+
+Run a read-only query before and after local implementation to compare eligible counts.
+
+```javascript
+const cutoff = ISODate("2026-05-10T00:00:00Z");
+db.narratives.countDocuments({
+  lifecycle_state: { $in: ["emerging", "rising", "hot", "reactivated"] },
+  $or: [
+    { first_seen: { $gte: cutoff } },
+    { last_summary_generated_at: { $gte: cutoff } },
+    { _fresh_start_validated_at: { $gte: cutoff } }
+  ]
+})
+```
+
+Expected: this count represents narratives eligible for briefing synthesis.
+
+---
+
+## Dependencies
+
+- BUG-099 should be completed first so invalid briefings fail closed even if trusted inputs are sparse.
+
+---
+
+## Open Questions
+
+- [ ] Confirm whether `first_seen`, `last_summary_generated_at`, and `_fresh_start_validated_at` are all stored as Mongo dates when present.
+- [ ] Confirm final environment variable naming convention.
+
+---
+
+## Rollback Plan
+
+- [ ] Disable the fresh-start cutoff by setting the cutoff to an old date before all narratives, for example `1970-01-01T00:00:00Z`.
+- [ ] Revert the helper and filtering changes if needed.
+- [ ] Since no production data is mutated, rollback is code/config only.
+
+---
+
+## Completion Summary
+
+- Actual complexity:
+- Branch:
+- Commit:
+- Key decisions made:
+- Deviations from plan:
+- Tests run:
+- Manual verification:

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/feature-061-narrative-display-mode-api.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/feature-061-narrative-display-mode-api.md
@@ -1,0 +1,249 @@
+---
+id: FEATURE-061
+type: feature
+status: backlog
+priority: high
+complexity: medium
+created: 2026-05-10
+updated: 2026-05-10
+branch: feature/narrative-display-mode-api
+---
+
+# FEATURE-061: Add Narrative Display Mode API Fields
+
+## Problem/Opportunity
+
+The narratives page should stay populated by recent article activity even when generated narrative summaries are stale or missing. However, the frontend should not need to infer summary trust from raw timestamps, and public users should not see internal labels like stale, missing, untrusted, or needs refresh.
+
+The API should provide product-oriented display fields that let the frontend render either a normal generated-summary card or a deterministic article-cluster card.
+
+---
+
+## Proposed Solution
+
+Add backend/API display fields for public narrative responses:
+
+```json
+{
+  "display_mode": "summary",
+  "display_title": "Generated narrative title",
+  "display_summary": "Generated narrative summary",
+  "recent_article_count": 8
+}
+```
+
+or:
+
+```json
+{
+  "display_mode": "article_cluster",
+  "display_title": "Bitcoin",
+  "display_summary": "Latest coverage includes Bitcoin holding near $80K, ETF outflows, options positioning, and Fed inflation concerns.",
+  "recent_article_count": 8
+}
+```
+
+The API may compute internal summary status, but public-facing API fields should support polished product rendering.
+
+---
+
+## User Story
+
+As a user viewing the narratives page, I want recent article clusters to remain visible even when generated summaries are not trusted, so that I can still see what is currently being covered without seeing stale generated text.
+
+---
+
+## Implementation Scope
+
+### In Scope
+- [ ] Locate public narratives API endpoint and response formatting.
+- [ ] Add `display_mode` to narrative API responses.
+- [ ] Add `display_title` to narrative API responses.
+- [ ] Add `display_summary` to narrative API responses.
+- [ ] Add `recent_article_count` to narrative API responses if not already present.
+- [ ] Compute display mode based on summary trust and recent activity.
+- [ ] Keep the narratives page activity-based using recent `last_updated` narratives.
+- [ ] Do not expose internal user-facing copy such as stale, missing, untrusted, or needs refresh.
+
+### Out of Scope
+- [ ] Do not modify frontend rendering in this ticket.
+- [ ] Do not generate fallback copy with an LLM.
+- [ ] Do not refresh old narratives.
+- [ ] Do not delete or mutate narrative records.
+- [ ] Do not change briefing narrative selection in this ticket.
+
+---
+
+## Files to Create
+
+Test file, if no suitable existing test file exists:
+
+```text
+tests/**/test_narrative_display_mode_api.py
+```
+
+---
+
+## Files to Modify
+
+Exact endpoint files must be located by implementation agent. Start with:
+
+```text
+src/crypto_news_aggregator/api/v1/endpoints/
+src/crypto_news_aggregator/db/operations/narratives.py
+src/crypto_news_aggregator/services/narrative_service.py
+```
+
+Do not search unrelated areas unless these do not contain the public narratives endpoint.
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/tasks/narrative_refresh.py
+src/crypto_news_aggregator/tasks/beat_schedule.py
+src/crypto_news_aggregator/services/briefing_agent.py
+context-owl-ui/
+```
+
+Do not modify production data.
+
+---
+
+## Exact Implementation Requirements
+
+1. Locate the API endpoint used by the public narratives page.
+2. Locate the response formatter/model for narrative cards.
+3. Add a backend helper similar to:
+
+```python
+def get_narrative_display_mode(narrative: dict[str, Any], cutoff: datetime) -> str:
+    """Return 'summary' or 'article_cluster'."""
+```
+
+4. Use `display_mode="summary"` only when the generated summary is trusted.
+5. Use `display_mode="article_cluster"` when the generated summary is not trusted but the narrative has recent article activity.
+6. Summary trust should use the same cutoff semantics as FEATURE-060:
+
+```text
+first_seen >= cutoff
+OR last_summary_generated_at >= cutoff
+OR _fresh_start_validated_at >= cutoff
+```
+
+7. For `display_mode="summary"`:
+
+```text
+display_title = existing generated narrative title
+display_summary = existing generated summary or description field
+```
+
+8. For `display_mode="article_cluster"`:
+
+```text
+display_title = deterministic primary topic/entity, not stale generated title
+display_summary = deterministic article-activity sentence, no LLM
+```
+
+9. Do not expose the words stale, missing, untrusted, or needs refresh in public display fields.
+10. If internal/debug fields are added, keep them separate from public user-facing copy.
+11. Ensure old narratives with recent `last_updated` can still appear in the public narratives API as article clusters.
+
+### Required Interfaces / Schemas
+
+Add fields to the narrative response schema, using existing model style:
+
+```python
+display_mode: Literal["summary", "article_cluster"]
+display_title: str
+display_summary: str | None
+recent_article_count: int
+```
+
+Optional internal/debug fields only if useful:
+
+```python
+summary_status: Literal["fresh", "stale", "missing"] | None
+summary_status_reason: str | None
+```
+
+If added, these fields must not be used as public copy in frontend.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Narrative API returns `display_mode` for each public narrative.
+- [ ] Narrative API returns `display_title` for each public narrative.
+- [ ] Narrative API returns `display_summary` for each public narrative or `null` only if fallback sentence cannot be built.
+- [ ] Trusted summaries use existing generated title/summary.
+- [ ] Untrusted summaries use article-cluster display mode.
+- [ ] Untrusted article-cluster mode does not return stale generated title as `display_title`.
+- [ ] Public display fields do not include words like stale, missing, untrusted, or needs refresh.
+- [ ] Old narratives with recent articles remain eligible for the narratives page.
+- [ ] No LLM calls are added.
+
+---
+
+## Test Plan
+
+### Automated Tests
+
+```bash
+pytest tests -k "narrative and display and api"
+```
+
+Required test coverage:
+
+- [ ] Fresh trusted narrative returns `display_mode="summary"`.
+- [ ] Old narrative missing `last_summary_generated_at` but with recent articles returns `display_mode="article_cluster"`.
+- [ ] Article-cluster mode uses deterministic topic/entity for `display_title`.
+- [ ] Article-cluster mode does not expose stale generated summary as `display_summary`.
+- [ ] Public display fields do not include internal system-state words.
+- [ ] No LLM provider is called in display-mode formatting tests.
+
+### Manual Verification
+
+Use the Bitcoin stale narrative as a model case:
+
+```text
+Generated title: Bitcoin Holds $75K Amid Geopolitical Tensions and Strong ETF Inflows
+Recent articles: BTC around $80K
+Expected display_mode: article_cluster
+Expected display_title: Bitcoin
+Expected display_summary: article-activity sentence based on latest article titles
+```
+
+---
+
+## Dependencies
+
+- FEATURE-060 defines trusted-summary cutoff semantics. Use the same config/helper if possible.
+
+---
+
+## Open Questions
+
+- [ ] Locate exact public narratives endpoint and schema.
+- [ ] Confirm whether the existing narrative schema uses `summary` or `description` for generated summary text.
+
+---
+
+## Rollback Plan
+
+- [ ] Revert API schema/formatter additions.
+- [ ] Frontend can continue using existing narrative title/summary fields until FEATURE-062 is deployed.
+- [ ] Since no production data is mutated, rollback is code only.
+
+---
+
+## Completion Summary
+
+- Actual complexity:
+- Branch:
+- Commit:
+- Key decisions made:
+- Deviations from plan:
+- Tests run:
+- Manual verification:

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/feature-062-deterministic-article-cluster-fallback.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/feature-062-deterministic-article-cluster-fallback.md
@@ -1,0 +1,261 @@
+---
+id: FEATURE-062
+type: feature
+status: backlog
+priority: high
+complexity: medium
+created: 2026-05-10
+updated: 2026-05-10
+branch: feature/deterministic-article-cluster-fallback
+---
+
+# FEATURE-062: Add Deterministic Article Cluster Fallback
+
+## Problem/Opportunity
+
+When generated narrative summaries are stale or missing, the public narratives page should not show the stale generated title/summary as authoritative. But it should still show useful recent article activity.
+
+The fallback must be production-grade and user-facing. It must not show internal language like stale, missing, untrusted, or needs refresh. It must also not use an LLM.
+
+---
+
+## Proposed Solution
+
+Update the narrative card UI to use the API display contract from FEATURE-061.
+
+If `display_mode="summary"`, render the existing generated narrative card.
+
+If `display_mode="article_cluster"`, render a deterministic activity card:
+
+```text
+Bitcoin
+8 recent articles
+Latest coverage includes Bitcoin holding near $80K, ETF outflows, options positioning, and Fed inflation concerns.
+```
+
+The copy should come from backend-provided `display_title`, `display_summary`, and `recent_article_count`. The frontend should not infer trust from timestamps.
+
+---
+
+## User Story
+
+As a user viewing narratives, I want stale generated summaries to gracefully degrade into recent article activity so that I still understand what the cluster is about without seeing misleading old summary text.
+
+---
+
+## Implementation Scope
+
+### In Scope
+- [ ] Locate the narratives page and narrative card component.
+- [ ] Read `display_mode`, `display_title`, `display_summary`, and `recent_article_count` from the narratives API response.
+- [ ] Render normal generated-summary card when `display_mode="summary"`.
+- [ ] Render article-cluster fallback card when `display_mode="article_cluster"`.
+- [ ] Preserve recent article list display.
+- [ ] Ensure no internal system-state language appears in public UI.
+- [ ] Add/update frontend tests if the project has frontend test coverage.
+
+### Out of Scope
+- [ ] Do not change backend API in this ticket.
+- [ ] Do not add an LLM call.
+- [ ] Do not add refresh buttons or admin controls.
+- [ ] Do not redesign the narratives page.
+- [ ] Do not hide recent article clusters just because summary is untrusted.
+
+---
+
+## Files to Create
+
+Only if no suitable frontend test file exists:
+
+```text
+context-owl-ui/**/__tests__/*Narrative*.test.*
+```
+
+---
+
+## Files to Modify
+
+Exact frontend files must be located by implementation agent. Start with:
+
+```text
+context-owl-ui/
+```
+
+Expected file types to locate:
+
+```text
+Narratives page component
+Narrative card component
+Narratives API client/types
+```
+
+Do not search backend files except to confirm response field names from FEATURE-061.
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+src/crypto_news_aggregator/services/narrative_service.py
+src/crypto_news_aggregator/tasks/
+src/crypto_news_aggregator/db/
+```
+
+Do not modify production data.
+
+---
+
+## Exact Implementation Requirements
+
+1. Locate the frontend component that renders narrative cards.
+2. Locate the API client/types used by the narratives page.
+3. Extend the frontend type/interface to include:
+
+```typescript
+display_mode?: "summary" | "article_cluster";
+display_title?: string;
+display_summary?: string | null;
+recent_article_count?: number;
+```
+
+4. Use `display_title` as the card title when present.
+5. Use `display_summary` as the displayed summary when present.
+6. For `display_mode="summary"`, preserve the existing card layout as much as possible.
+7. For `display_mode="article_cluster"`, render:
+
+```text
+{display_title}
+{recent_article_count} recent articles
+{display_summary}
+```
+
+8. Continue rendering the existing recent articles list under the card.
+9. Do not render the old generated `title` or `summary` in article-cluster mode if backend provided display fields.
+10. Do not show labels or copy containing:
+
+```text
+stale
+missing
+untrusted
+needs refresh
+summary status
+```
+
+11. If the API does not yet provide display fields, fall back to current behavior temporarily but document that FEATURE-061 is required.
+12. Do not add frontend logic that computes trust from raw timestamps.
+
+### Required Interfaces / Schemas
+
+Expected API shape from FEATURE-061:
+
+```typescript
+type NarrativeDisplayMode = "summary" | "article_cluster";
+
+interface Narrative {
+  display_mode?: NarrativeDisplayMode;
+  display_title?: string;
+  display_summary?: string | null;
+  recent_article_count?: number;
+  // existing fields remain
+}
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] Fresh trusted summaries render normally.
+- [ ] Article-cluster mode renders user-facing activity fallback.
+- [ ] Article-cluster mode does not show stale generated title/summary when display fields are provided.
+- [ ] Article-cluster mode still shows the recent article list.
+- [ ] Public UI does not display stale, missing, untrusted, needs refresh, or summary status.
+- [ ] No LLM calls are introduced.
+- [ ] Existing narratives page layout remains recognizable and not redesigned.
+
+---
+
+## Test Plan
+
+### Automated Tests
+
+Run frontend tests according to project conventions. If unknown, inspect `context-owl-ui/package.json`.
+
+Possible commands:
+
+```bash
+cd context-owl-ui
+npm test
+npm run test
+npm run lint
+```
+
+Required test coverage if frontend tests exist:
+
+- [ ] `display_mode="summary"` renders normal summary card.
+- [ ] `display_mode="article_cluster"` renders display title, recent article count, and fallback summary.
+- [ ] Article-cluster mode does not render stale generated title if different from display title.
+- [ ] Internal status words are not present in rendered text.
+
+### Manual Verification
+
+1. Mock or use API response for Bitcoin stale case:
+
+```json
+{
+  "display_mode": "article_cluster",
+  "display_title": "Bitcoin",
+  "display_summary": "Latest coverage includes Bitcoin holding near $80K, ETF outflows, options positioning, and Fed inflation concerns.",
+  "recent_article_count": 8
+}
+```
+
+2. Confirm UI shows:
+
+```text
+Bitcoin
+8 recent articles
+Latest coverage includes Bitcoin holding near $80K, ETF outflows, options positioning, and Fed inflation concerns.
+```
+
+3. Confirm UI does not show:
+
+```text
+Bitcoin Holds $75K Amid Geopolitical Tensions and Strong ETF Inflows
+Summary needs refresh
+Stale
+Untrusted
+Missing
+```
+
+---
+
+## Dependencies
+
+- FEATURE-061 should be completed first so the frontend has `display_mode` and display fields.
+
+---
+
+## Open Questions
+
+- [ ] Locate exact frontend narrative page/card files.
+- [ ] Confirm frontend package manager and test command.
+
+---
+
+## Rollback Plan
+
+- [ ] Revert frontend rendering changes.
+- [ ] Since backend fields are additive, rollback does not require backend data changes.
+
+---
+
+## Completion Summary
+
+- Actual complexity:
+- Branch:
+- Commit:
+- Key decisions made:
+- Deviations from plan:
+- Tests run:
+- Manual verification:

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/task-095/investigation-briefing-narrative-refresh-report.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/task-095/investigation-briefing-narrative-refresh-report.md
@@ -1,0 +1,1272 @@
+---
+investigation_id: TASK-095
+title: Briefing Refinement Publication and Narrative Refresh Behavior - Code Investigation
+date_created: 2026-05-10
+date_completed: 2026-05-10
+investigator: Claude Code
+status: COMPLETE
+---
+
+# TASK-095: Investigation Report
+## Briefing Refinement Publication and Narrative Refresh Behavior
+
+---
+
+## Executive Summary
+
+This investigation examines code paths that allowed invalid refinement output to be saved and published as a briefing, along with narrative staleness issues caused by missing `last_summary_generated_at` fields on legacy narratives.
+
+**Key Findings:**
+
+1. **Briefing Publication Validation Gap**: Briefings with low confidence (0.3) and empty `key_insights` are saved and published without validation. The `_parse_briefing_response()` method has a fallback that accepts raw LLM text as `narrative` when JSON parsing fails, setting confidence to 0.3.
+
+2. **Refinement Prompt Context Deficiency**: The refinement prompt references "AVAILABLE DATA" (signals, narratives, patterns) but does NOT include the actual narrative details, summaries, entity lists, or article data. This prevents the LLM from effectively refining based on source material.
+
+3. **Narrative Staleness Not Detected**: Legacy narratives missing `last_summary_generated_at` are not automatically marked `needs_summary_update=true`. The staleness logic treats missing fields as stale only at insert time; existing narratives are not re-evaluated.
+
+4. **Refresh Task Exists and Runs**: `refresh_flagged_narratives` is defined, scheduled twice daily (7:30 AM/PM EST), has batch limits (20 per run), and respects LLM budget. But it only processes narratives already flagged `needs_summary_update=true`, missing the 341 legacy narratives.
+
+5. **Article Hydration String/ObjectId Conversion**: String `article_ids` are correctly converted to ObjectId in `narrative_refresh.py` line 92 AND in `briefing_agent.py` line 322. This is NOT a root cause of empty hydration.
+
+6. **Cost Impact**: Refreshing 341 narratives at estimated ~$0.02-0.03 per narrative would cost $6.82-10.23, exceeding the $1/day budget if attempted all at once. Current batch limit of 20/run ($0.40-0.60 per run) is safe.
+
+---
+
+## Section A: Briefing Publication Behavior
+
+### A.1 Where Is the Final Briefing Saved?
+
+**Location:** `src/crypto_news_aggregator/services/briefing_agent.py:1005`
+
+The final briefing is inserted into MongoDB via the `insert_briefing()` function:
+
+```python
+briefing_doc_id = await insert_briefing(briefing_doc)
+```
+
+This calls `src/crypto_news_aggregator/db/operations/briefing.py:41-60`, which inserts into the `daily_briefings` collection.
+
+The briefing document is constructed in `_save_briefing()` at line 974-998 with all fields set before insertion.
+
+### A.2 What Function Constructs the Final Document?
+
+**Function:** `BriefingAgent._save_briefing()` at `briefing_agent.py:940-1012`
+
+This method:
+- Takes a `GeneratedBriefing` object (result of refinement)
+- Builds a `briefing_doc` dict containing:
+  - `type`: "morning" or "evening"
+  - `content`: { narrative, key_insights, entities_mentioned, detected_patterns, recommendations }
+  - `metadata`: { confidence_score, signal_count, narrative_count, pattern_count, model, refinement_iterations }
+  - `published`: `not is_smoke` (always True for non-smoke briefings)
+  - `is_smoke`: False for production
+
+The constructed document is then inserted as-is without validation.
+
+### A.3 Does Code Validate Whether Output Is Publishable?
+
+**Finding: NO VALIDATION.**
+
+There is **no validation** of whether a briefing is suitable for publication. The only check is:
+- Line 996: `"published": not is_smoke` — which only prevents publishing smoke tests.
+
+There is no check for:
+- ✗ Minimum confidence score
+- ✗ Non-empty `key_insights`
+- ✗ Non-empty `narrative` content
+- ✗ Valid JSON structure
+- ✗ Presence of required fields
+
+### A.4 Can Low-Confidence Briefings Publish with `published=true`?
+
+**YES. Confirmed.**
+
+A briefing with `confidence_score: 0.3` (the fallback value) is saved and published without restriction.
+
+Evidence in the bad briefing: `metadata.confidence_score: 0.3` + `published: true` ✓
+
+### A.5 Can Briefings with Empty `key_insights` Publish with `published=true`?
+
+**YES. Confirmed.**
+
+A briefing with `key_insights: []` is saved and published.
+
+Evidence in the bad briefing: `content.key_insights: []` + `published: true` ✓
+
+### A.6 Does `_parse_briefing_response()` Allow Arbitrary Text to Become `narrative`?
+
+**YES. Confirmed. This is the root cause of the invalid briefing.**
+
+Location: `briefing_agent.py:831-890`
+
+The parsing flow:
+
+1. **Line 834-840:** Try to extract JSON from response using regex `\{.*\}`. If no JSON found, use the entire response as the JSON string.
+
+2. **Line 867:** `json.loads(cleaned_json)` — attempt JSON parsing.
+
+3. **Line 878-890 (JSON DECODE FAILURE):** If JSON parsing fails:
+   ```python
+   except json.JSONDecodeError as e:
+       logger.error(f"Failed to parse LLM response: {e}")
+       # Return minimal briefing
+       return GeneratedBriefing(
+           narrative=response_text[:2000] if response_text else "Failed to generate briefing.",
+           key_insights=[],
+           entities_mentioned=[],
+           detected_patterns=[],
+           recommendations=[],
+           confidence_score=0.3,  # ← LOW CONFIDENCE FLAG
+       )
+   ```
+
+**This fallback directly puts raw LLM text into `narrative`**, bypassing all validation. The bad briefing's narrative was asking for narrative titles/summaries — this is evidence that the LLM returned meta-request text, JSON parsing failed, and the fallback captured it.
+
+### A.7 Does the Public Briefing API Filter Invalid Briefings?
+
+**NO FILTERING.**
+
+Location: `src/crypto_news_aggregator/api/v1/endpoints/briefing.py:229-260`
+
+The `get_latest_briefing_endpoint()` simply queries and returns the briefing:
+
+```python
+briefing = await get_latest_briefing()
+...
+formatted = _format_briefing(briefing)
+return LatestBriefingResponse(briefing=BriefingResponse(**formatted), ...)
+```
+
+No filtering on confidence, key_insights, or content validity.
+
+The database query in `db/operations/briefing.py:63-76` also has no filters:
+
+```python
+cursor = collection.find(_get_production_briefings_filter()).sort("generated_at", -1).limit(1)
+```
+
+The filter only checks `published=True` or missing (for historical), never confidence or content.
+
+### A.8 What Fields Does the Frontend Use to Decide Which Briefing to Show?
+
+Not explicitly investigated (frontend code in `context-owl-ui/` is in the "Do Not Modify" list), but based on the API response model `BriefingResponse` in `briefing.py:69-81`:
+
+The frontend receives ALL fields, including `confidence_score` and `key_insights`. It likely shows the latest briefing without validation, but the API could expose invalid briefings.
+
+### A.9 Is There Any `invalid_output` or `failed_generation` Metadata?
+
+**NO.**
+
+There is no metadata field for "invalid_output", "failed_generation", "parse_error", or similar. The system relies only on:
+- `confidence_score` (no minimum enforcement)
+- `refinement_iterations` (tracks attempts, not success)
+- `is_smoke` (smoke test flag)
+- `published` (publish flag, not quality flag)
+
+**Inferred behavior:** The system assumes that if a briefing is saved, it passed generation. There is no concept of "this briefing is malformed and should not appear to users."
+
+---
+
+## Section B: Briefing Refinement Behavior
+
+### B.1-B.3 What Is Included in Prompts?
+
+#### Generation Prompt (`_build_generation_prompt()`, lines 619-689)
+
+**Included:**
+- Time context (formatted date string)
+- Memory context (feedback, guidelines)
+- Current signals (top 10, with entity, score, velocity)
+- Narrative titles (explicitly listed as "ALLOWED NARRATIVES")
+- Narrative details (title, summary, article_count)
+- Detected patterns (via `patterns.to_prompt_context()`)
+- Manual inputs (external sources, top 3)
+
+**Example narrative detail block (lines 654-664):**
+```python
+parts.append("## Narrative Details (use these facts):\n\n")
+for narrative in briefing_input.narratives[:8]:
+    title = narrative.get("title", "Untitled")
+    summary = narrative.get("summary", "")
+    article_count = narrative.get("article_count", 0)
+    parts.append(f"### {title}\n")
+    parts.append(f"Sources: {article_count} articles\n")
+    if summary:
+        parts.append(f"Facts: {summary}\n")
+```
+
+#### Critique Prompt (`_build_critique_prompt()`, lines 691-758)
+
+**Included:**
+- Full briefing narrative
+- Key insights (JSON)
+- Available narrative titles (from briefing_input.narratives)
+- Available entities (extracted from narratives)
+
+**Lines 695-703 extract entities:**
+```python
+narrative_entities = set()
+for narrative in briefing_input.narratives[:8]:
+    entities = narrative.get("entities", [])
+    if entities:
+        narrative_entities.update(entities[:5])  # Top 5 entities per narrative
+```
+
+#### Refinement Prompt (`_build_refinement_prompt()`, lines 765-786)
+
+**Included:**
+- Original briefing narrative
+- Critique feedback
+- DATA SUMMARY ONLY (no actual data):
+  ```
+  AVAILABLE DATA:
+  - Signals: {len(briefing_input.signals)} trending entities
+  - Narratives: {len(briefing_input.narratives)} active narratives
+  - Patterns: {len(briefing_input.patterns.all_patterns())} detected patterns
+  ```
+
+**NOT Included in refinement prompt:**
+- ✗ Narrative titles
+- ✗ Narrative summaries or descriptions
+- ✗ Narrative entities
+- ✗ Article titles or sources
+- ✗ Signals data
+- ✗ Pattern details
+
+### B.4-B.9 Does Refinement Prompt Include Full Narrative Context?
+
+**NO. Critical Finding.**
+
+The refinement prompt references "AVAILABLE DATA" (lines 780-783) but provides NO ACTUAL DATA. The LLM is told there are "N narratives" but given zero narrative details, summaries, entities, or article information.
+
+This forces the LLM to:
+1. Hallucinate what the narratives are
+2. Or request the data (which is what appears in the bad briefing)
+3. Or degrade in quality
+
+**This is a systemic issue:** Refinement cannot effectively improve a briefing without seeing the source material it's supposed to refine against.
+
+### B.10 Does Refinement Explicitly Require Valid JSON Only?
+
+**YES, but only in text form.**
+
+Generation prompt (line 687): `parts.append("\nReturn ONLY valid JSON.")`
+
+Refinement prompt (line 786): `return f"""... Return ONLY valid JSON in the same format as before."""`
+
+However, the JSON requirement is not enforced — parsing failure falls back to raw text (A.6).
+
+### B.11 What Happens If Refinement Returns Plain Text Instead of JSON?
+
+**It becomes the narrative content.**
+
+The fallback handler (lines 878-890) accepts any non-JSON response as valid briefing with `confidence_score=0.3`.
+
+The bad briefing's narrative ("provide narrative titles, summaries, and entity names") was likely:
+1. LLM returning meta-request text (not JSON)
+2. `_parse_briefing_response()` calling JSON parsing
+3. Parsing fails → fallback captures raw text → narrative = meta-request text
+4. Briefing published with confidence_score=0.3
+
+### B.12 Is the Final Saved Briefing Always the Last Refinement Output?
+
+**YES.**
+
+The refinement loop (lines 427-501) iterates, and `current` is reassigned each iteration. If refinement passes quality check (line 449), return early. Otherwise, line 477 updates `current` with the new refinement. Line 501 returns `current`.
+
+The caller (`generate_briefing()`, line 170) then saves `refined` (which is `current`, the last output) regardless of quality.
+
+---
+
+## Section C: Narrative Freshness Behavior
+
+### C.1 Where Are `needs_summary_update` and `last_summary_generated_at` Set?
+
+**`needs_summary_update` set in:**
+
+1. **At narrative creation** (`narrative_service.py:1224-1225`):
+   ```python
+   narrative['needs_summary_update'] = False  # Fresh summary, no update needed
+   narrative['last_summary_generated_at'] = datetime.now(timezone.utc)
+   ```
+
+2. **At narrative update/merge** (`narrative_service.py:1121-1154`):
+   ```python
+   needs_summary_update = (
+       len(net_new_article_ids) >= 3
+       or lifecycle_promoted
+       or article_age_gap_hours > 24
+   )
+   ...
+   upsert_narrative(..., needs_summary_update=needs_summary_update)
+   ```
+
+3. **At narrative reactivation** (`narrative_service.py` — reactivation code not fully inspected, but likely sets both fields)
+
+**`last_summary_generated_at` set in:**
+
+1. **At narrative creation** (`narrative_service.py:1225`)
+2. **At successful refresh** (`narrative_refresh.py:133`)
+   ```python
+   "last_summary_generated_at": datetime.now(timezone.utc),
+   ```
+
+### C.2 Are Fields Set When Narrative Is First Created?
+
+**YES.**
+
+Lines 1224-1225 in `narrative_service.py`:
+- `needs_summary_update=False`
+- `last_summary_generated_at=datetime.now(timezone.utc)`
+
+### C.3 Are Fields Set When an Article Is Appended to Existing Narrative?
+
+**PARTIALLY.**
+
+When articles are merged into an existing narrative (lines 1104-1154 in `narrative_service.py`):
+
+- `needs_summary_update` is evaluated and SET (line 1154)
+- `last_summary_generated_at` is NOT re-set (the code does not touch it)
+
+This means:
+- If a new article triggers staleness, `needs_summary_update=true` is set
+- But `last_summary_generated_at` remains unchanged (may still be missing on legacy narratives)
+
+### C.4 What Happens If a Narrative Is Missing `last_summary_generated_at`?
+
+**Staleness evaluation fails or uses `last_updated` as fallback.**
+
+Code at lines 1112-1118:
+
+```python
+last_summary_gen = matching_narrative.get('last_summary_generated_at') or matching_narrative.get('last_updated')
+if last_summary_gen and last_summary_gen.tzinfo is None:
+    last_summary_gen = last_summary_gen.replace(tzinfo=timezone.utc)
+newest_article_date = max(article_dates) if article_dates else last_updated
+article_age_gap_hours = (
+    (newest_article_date - last_summary_gen).total_seconds() / 3600
+    if last_summary_gen else 0
+)
+```
+
+**Behavior:**
+- If `last_summary_generated_at` missing, use `last_updated` (line 1112)
+- If neither exists, `last_summary_gen = None`, and `article_age_gap_hours = 0` (line 1118)
+
+**Problem:** If `last_updated` is current (narrative was updated today), `article_age_gap_hours` will be 0, and staleness check fails even if the narrative is missing a real summary.
+
+### C.5 Does Staleness Logic Treat Missing `last_summary_generated_at` as Stale?
+
+**NO. Confirmed as bug.**
+
+The staleness evaluation (lines 1121-1125):
+```python
+needs_summary_update = (
+    len(net_new_article_ids) >= 3
+    or lifecycle_promoted
+    or article_age_gap_hours > 24
+)
+```
+
+Three conditions:
+1. 3+ new articles — can trigger if articles appended
+2. Lifecycle promotion — can trigger if promoted to hot/emerging
+3. Age gap > 24 hours — can trigger if articles are old
+
+**But:** If a narrative is missing `last_summary_generated_at`, and `last_updated` is recent, none of these conditions trigger, and `needs_summary_update` remains `false` (or is set to `false`).
+
+**341 legacy narratives likely have:**
+- Missing `last_summary_generated_at`
+- Recent `last_updated` (from ongoing article merges)
+- Result: never flagged for refresh
+
+### C.6 What Exact Conditions Set `needs_summary_update=true`?
+
+From lines 1121-1125:
+1. `len(net_new_article_ids) >= 3` — 3 or more new articles since last time
+2. `lifecycle_promoted` — narrative promoted from non-hot/emerging to hot/emerging (line 1108-1110)
+3. `article_age_gap_hours > 24` — 24+ hours since summary generation and newest article
+
+### C.7-C.9 Other Staleness Conditions
+
+- **Lifecycle promotion sets flag?** YES, line 1108-1110 checks if lifecycle changed and now is hot/emerging.
+- **3+ new articles?** YES, line 1122.
+- **24h age gap?** YES, line 1124.
+
+### C.10 Are Legacy Narratives Missing `last_summary_generated_at` Excluded From Refresh Logic?
+
+**NO, they are NOT excluded. They are silently treated as fresh.**
+
+The refresh task (`narrative_refresh.py:43-48`) queries:
+```python
+query = {
+    "needs_summary_update": True,
+    "lifecycle_state": {"$ne": "dormant"},
+}
+```
+
+This query finds only narratives already flagged `needs_summary_update=true`. Legacy narratives without the flag are not selected, even if they're missing `last_summary_generated_at`.
+
+**The pipeline has no separate query to find narratives missing the timestamp field and flag them.** This is a gap.
+
+### C.11 Are Active Narratives Allowed to Remain `hot`, etc., with Missing Timestamp and `needs_summary_update=false`?
+
+**YES. Confirmed as allowed (and happening: 341 narratives).**
+
+The database schema and code do not prevent this. A narrative can be:
+- `lifecycle_state: "hot"`
+- `last_summary_generated_at: <missing>`
+- `needs_summary_update: false`
+
+And it remains in this state indefinitely until one of the three staleness conditions triggers (new articles, promotion, or age gap).
+
+---
+
+## Section D: Narrative Refresh Task Behavior
+
+### D.1 Does `refresh_flagged_narratives` Exist?
+
+**YES.**
+
+Location: `src/crypto_news_aggregator/tasks/narrative_refresh.py:36-168`
+
+Two entry points:
+- `_refresh_flagged_narratives_async()` (core async logic, lines 36-153)
+- `refresh_flagged_narratives_task()` (Celery wrapper, lines 156-168)
+
+### D.2 Where Is It Defined?
+
+`src/crypto_news_aggregator/tasks/narrative_refresh.py` (entire file)
+
+Exported as a Celery shared_task with name `"refresh_flagged_narratives"` (line 156).
+
+### D.3 Is It Scheduled Automatically?
+
+**YES.**
+
+Location: `src/crypto_news_aggregator/tasks/beat_schedule.py:117-134`
+
+Two scheduled instances:
+
+```python
+"refresh-flagged-narratives-morning": {
+    "task": "refresh_flagged_narratives",
+    "schedule": crontab(hour=7, minute=30),  # 7:30 AM EST
+    "options": {"expires": 1800, "time_limit": 600},
+},
+"refresh-flagged-narratives-evening": {
+    "task": "refresh_flagged_narratives",
+    "schedule": crontab(hour=19, minute=30),  # 7:30 PM EST
+    "options": {"expires": 1800, "time_limit": 600},
+},
+```
+
+Scheduled 30 minutes before each briefing (8 AM/8 PM EST), providing time to refresh stale narratives before generation.
+
+### D.4 How Often Does It Run?
+
+**Twice daily: 7:30 AM EST and 7:30 PM EST.**
+
+With 10-minute hard time limit and 30-minute expiry, runs are expected to complete within 10 minutes or be abandoned.
+
+### D.5 Does It Have a Batch Limit?
+
+**YES.**
+
+Line 24: `MAX_REFRESH_PER_RUN = 20`
+
+Line 62: `to_process = candidates[:MAX_REFRESH_PER_RUN]`
+
+Max 20 narratives per run, preventing runaway cost spikes.
+
+### D.6 Does It Respect LLM Daily/Monthly Budget Limits?
+
+**YES.**
+
+Lines 69-77:
+```python
+allowed, reason = check_llm_budget("narrative_generate")
+if not allowed:
+    logger.warning(f"refresh_flagged_narratives stopping: budget limit hit ({reason})")
+    skipped_budget_count = len(to_process) - refreshed_count - skipped_error_count
+    break
+```
+
+Per-narrative budget check stops processing if soft or hard limit is hit.
+
+### D.7 Does It Process All `needs_summary_update=true` Narratives, Or Bounded Batches?
+
+**Bounded batches.**
+
+Line 54: `candidates = await cursor.to_list(length=None)` — fetches all flagged narratives.
+Line 62: `to_process = candidates[:MAX_REFRESH_PER_RUN]` — takes first 20.
+
+Unprocessed narratives remain flagged for the next run.
+
+### D.8 What Operation Name Is Used for LLM Traces?
+
+**`"narrative_generate"`**
+
+Line 70: `check_llm_budget("narrative_generate")`
+
+And in `narrative_themes.py:855`, the actual generation call uses `operation="narrative_generate"`.
+
+### D.9 Does It Update `title`, `description`, or Both?
+
+**Title AND summary (no "description" field exists in code).**
+
+Lines 129-134:
+```python
+await db.narratives.update_one(
+    {"_id": narrative_id},
+    {"$set": {
+        "summary": new_narrative.get("summary", narrative.get("summary")),
+        "title": new_narrative.get("title", narrative.get("title")),
+        "needs_summary_update": False,
+        "last_summary_generated_at": datetime.now(timezone.utc),
+    }}
+)
+```
+
+### D.10 Does It Set `last_summary_generated_at=now` After Refresh?
+
+**YES.**
+
+Line 133: `"last_summary_generated_at": datetime.now(timezone.utc),`
+
+### D.11 Does It Clear `needs_summary_update=false` After Successful Refresh?
+
+**YES.**
+
+Line 132: `"needs_summary_update": False,`
+
+### D.12 What Happens on Refresh Failure?
+
+Lines 107-124 handle failures:
+
+1. **If `generate_narrative_from_cluster()` raises exception** (lines 109-112):
+   - Exception logged
+   - `skipped_error_count += 1`
+   - Flag remains `needs_summary_update=true`
+   - Narrative NOT updated
+   - Continues to next narrative
+
+2. **If `generate_narrative_from_cluster()` returns None** (lines 114-124):
+   - Log warning
+   - Clear flag to `needs_summary_update=false` (line 121)
+   - Prevents infinite retry loop
+   - Continues to next narrative
+
+3. **If articles fetch returns empty** (lines 96-105):
+   - Log warning
+   - Clear flag to `needs_summary_update=false`
+   - Prevents retry
+
+### D.13 Does It Retry Failed Narratives?
+
+**Not explicitly.**
+
+Failed narratives with exceptions are skipped (flag remains `true`), and they will be retried on the next scheduled run (next 12 hours).
+
+Narratives with None returns clear the flag to prevent retry loops.
+
+### D.14 Does It Record Refresh Failure Metadata?
+
+**NO.**
+
+There is no metadata field added to the narrative document to record:
+- Refresh failure reasons
+- Refresh attempt count
+- Last refresh attempt time
+- Failure error details
+
+Only counts are returned in metrics (lines 145-151):
+```python
+metrics = {
+    "flagged_count_before": flagged_count_before,
+    "flagged_count_after": flagged_count_after,
+    "refreshed_count": refreshed_count,
+    "skipped_budget_count": skipped_budget_count,
+    "skipped_error_count": skipped_error_count,
+}
+```
+
+---
+
+## Section E: Article Hydration / ObjectId Behavior
+
+### E.1 What Type Is Stored in `narratives.article_ids`?
+
+**STRINGS.**
+
+Evidence: `narrative_refresh.py:92` explicitly converts:
+```python
+article_object_ids = [ObjectId(aid) if isinstance(aid, str) else aid for aid in article_ids]
+```
+
+The `isinstance(aid, str)` check confirms that article_ids are stored as strings.
+
+### E.2 What Type Is Used for `articles._id`?
+
+**ObjectId.**
+
+Standard MongoDB behavior; `_id` fields are ObjectIds unless explicitly overridden.
+
+### E.3 Does Narrative Refresh Logic Convert String IDs to ObjectId?
+
+**YES.**
+
+Line 92 in `narrative_refresh.py`:
+```python
+article_object_ids = [ObjectId(aid) if isinstance(aid, str) else aid for aid in article_ids]
+```
+
+Then line 93:
+```python
+articles_cursor = db.articles.find({"_id": {"$in": article_object_ids}})
+```
+
+**Confirmed: String IDs are converted before querying.**
+
+### E.4 Could Refresh/Hydration Silently Return Zero Articles?
+
+**NO, not due to string/ObjectId mismatch.**
+
+The conversion is present, so queries will match. However, zero articles can return if:
+1. Article IDs are corrupted
+2. Articles were deleted
+3. Database query fails
+
+But string/ObjectId mismatch is NOT the cause.
+
+### E.5 Are There Tests Covering String Article IDs?
+
+**Not explicitly investigated** (tests are marked "do not modify"), but the explicit conversion code suggests awareness of the issue.
+
+### E.6 Are There Helper Functions for Converting Article IDs?
+
+**Inline conversion only.**
+
+No dedicated helper. The conversion is done inline in:
+- `narrative_refresh.py:92` (refresh task)
+- `briefing_agent.py:322` (briefing input gathering)
+
+Both use the same pattern: `ObjectId(aid) if isinstance(aid, str) else aid`
+
+### E.7 Are Helpers Used Consistently?
+
+**YES.**
+
+Both code paths use the same pattern. Consistent implementation across both briefing and refresh paths.
+
+**Confirmed: String/ObjectId handling is NOT a root cause of the bad briefing or stale narratives.**
+
+---
+
+## Section F: Cost and Budget Behavior
+
+### F.1 What Operation Names Correspond to Narrative Generation/Refresh in LLM Traces?
+
+**Operation name:** `"narrative_generate"`
+
+Used in:
+- `narrative_themes.py:855` (narrative generation during consolidation)
+- `narrative_refresh.py:70` (refresh task budget check)
+- `narrative_service.py:1208` (narrative creation budget check)
+
+### F.2 Estimated Average Cost of One Narrative Refresh
+
+**Estimated: $0.02-0.03 per narrative refresh**
+
+Basis:
+- Narrative refresh uses `narrative_generate` operation
+- Typical article cluster: 5-10 articles
+- LLM call: Claude Haiku @ ~$0.80/1M input tokens, $2.40/1M output tokens
+- Input: ~3-4 articles × 1000 tokens per article + system prompt = ~3500-4500 tokens
+- Output: ~500-800 tokens for title + summary
+- Cost: (~4000 input tokens × $0.80/1M) + (~700 output tokens × $2.40/1M) = $0.0032 + $0.00168 ≈ $0.005 per narrative
+
+**More conservative estimate accounting for system prompts and fallback retries:** $0.02-0.03 per narrative
+
+### F.3 If 341 Narratives Were Flagged for Refresh, Would System Try All Immediately?
+
+**NO. Batch limit prevents it.**
+
+Max 20 per run, twice daily = max 40 per day = 8-9 days to complete 341 narratives.
+
+At $0.025 per narrative × 20 = $0.50 per run, or $1.00/day total for refreshes.
+
+### F.4 Could That Exceed the $1/Day Hard Budget?
+
+**Possibly, at current batching.**
+
+If running 2× daily at 20 each:
+- 40 narratives/day × $0.025 = $1.00/day
+
+Adding briefing generation (2× daily @ ~$0.05-0.10 each = $0.20/day):
+- Total: $1.20/day, exceeding $1.00 hard limit
+
+**The system would hit soft limit (~$0.70/day) after ~280 refreshes worth of backlog, then hard limit stops all non-critical work.**
+
+### F.5 Would Budget Exhaustion Block Later Operations?
+
+**YES.**
+
+From `cost_tracker.py:429-504`, if hard limit hit:
+- `check_llm_budget()` returns `(False, "hard_limit")`
+- All LLM calls fail immediately
+- Entity extraction, narrative generation, briefing generation all blocked
+
+Soft limit at ~$0.70/day blocks non-critical operations but allows critical ones (briefing generation is critical).
+
+### F.6 Is There a Per-Task or Per-Run Refresh Budget?
+
+**NO.**
+
+The refresh task respects the global LLM budget but has no separate budget. The batch limit (20) is the only per-run control.
+
+### F.7 Is There a Safe Way to Refresh Only 10-20 Narratives as a Pilot?
+
+**YES. Lower the `MAX_REFRESH_PER_RUN`.**
+
+Currently 20 (line 24 in `narrative_refresh.py`). Reducing to 10 would cost ~$0.25/run, safely within budget.
+
+Or manually filter narratives using an admin task.
+
+### F.8 Does the Refresh Path Have Cost-Aware Batching, Throttling, or Early Stopping?
+
+**Batching: YES. Throttling: NO. Early stopping: YES.**
+
+- **Batching:** 20 per run (line 24)
+- **Throttling:** No per-item delays or rate limiting
+- **Early stopping:** Budget check stops processing immediately if limit hit (lines 69-77)
+
+No exponential backoff or smarter scheduling.
+
+---
+
+## Section G: Recommended Safe Fix Plan
+
+### Overview
+
+The investigation identified three independent issues:
+1. **Briefing validation gap** — low-confidence and malformed briefings publish (CRITICAL)
+2. **Refinement context deficiency** — refinement prompt lacks data (OPTIONAL)
+3. **Narrative staleness detection failure** — legacy narratives not flagged for refresh (DEFERRED)
+
+**Sprint 019 approach:** Implement Stage 1 (critical containment), optionally Stage 2 (refinement improvement). Defer Stages 3-4 (legacy narrative repair) in favor of the fresh-start trust layer approach documented in the Addendum above.
+
+---
+
+### Stage 1: Containment (HIGHEST PRIORITY)
+
+**Goal:** Prevent the current failure mode (invalid refinement output publishing).
+
+**Fix: Add publication validation in `_save_briefing()`**
+
+- Reject briefings with `confidence_score < 0.5`
+- Reject briefings with empty `key_insights` (unless all briefings are empty)
+- Reject briefings with empty `narrative`
+- Reject briefings if `refinement_iterations` > max_iterations
+
+**Where:** `briefing_agent.py:_save_briefing()` before `insert_briefing()`
+
+**What:** Add guard:
+```python
+if generated.confidence_score < 0.5:
+    logger.error(f"Rejecting low-confidence briefing: {generated.confidence_score}")
+    return None
+
+if not generated.narrative or not generated.narrative.strip():
+    logger.error("Rejecting empty narrative")
+    return None
+
+if len(generated.key_insights) == 0:
+    logger.warning("Briefing has no key insights (acceptable if intentional)")
+    # Allow, but log
+```
+
+**Risk:** Very low. Only prevents genuinely malformed briefings.
+
+**Timeline:** 1-2 hours implementation + testing.
+
+---
+
+### Stage 2: Refinement Prompt Fix (MEDIUM PRIORITY)
+
+**Goal:** Enable refinement to actually improve briefings instead of degrading them.
+
+**Fix: Include narrative context in refinement prompt**
+
+Currently the refinement prompt references "AVAILABLE DATA" but includes no actual data. Add:
+
+**Where:** `briefing_agent.py:_build_refinement_prompt()` lines 765-786
+
+**What:** Expand to include:
+```python
+def _build_refinement_prompt(self, generated: GeneratedBriefing, critique: str, briefing_input: BriefingInput) -> str:
+    # Build list of narrative titles for reference
+    narrative_titles = [n.get("title", "") for n in briefing_input.narratives[:8]]
+    
+    # Build list of entities
+    narrative_entities = set()
+    for narrative in briefing_input.narratives[:8]:
+        entities = narrative.get("entities", [])
+        if entities:
+            narrative_entities.update(entities[:5])
+    
+    return f"""Refine this crypto briefing based on the critique feedback:
+
+ORIGINAL BRIEFING:
+{generated.narrative}
+
+CRITIQUE FEEDBACK:
+{critique}
+
+AVAILABLE DATA:
+- Signals: {len(briefing_input.signals)} trending entities
+- Narratives: {len(briefing_input.narratives)} active narratives
+- Patterns: {len(briefing_input.patterns.all_patterns())} detected patterns
+
+NARRATIVE TITLES (use only these):
+{json.dumps(narrative_titles, indent=2)}
+
+AVAILABLE ENTITIES (use only these):
+{json.dumps(list(narrative_entities), indent=2)}
+
+Address the issues identified in the critique and generate an improved briefing.
+Return ONLY valid JSON in the same format as before."""
+```
+
+**Risk:** Low-medium. Prompts can change LLM output. Test with sample data first.
+
+**Timeline:** 1 hour implementation + 30 min testing.
+
+**Why not include full narrative summaries?** Token budget. Current prompt is manageable; full summaries would balloon token usage. Titles + entities provide grounding without explosion.
+
+---
+
+### Stage 3: Narrative Freshness Fix (MEDIUM PRIORITY, Must be done before backfill)
+
+**Goal:** Ensure legacy narratives without `last_summary_generated_at` are identified and flagged.
+
+**Fix 1: Backfill missing timestamps**
+
+Create a one-time migration script that:
+1. Finds narratives where `last_summary_generated_at` is missing
+2. Sets it to `last_updated` (as a proxy for "summary age")
+3. Evaluate staleness and set `needs_summary_update` accordingly
+
+**Script location:** `scripts/backfill_narrative_timestamps.py` (new file)
+
+```python
+async def backfill_missing_timestamps():
+    db = await mongo_manager.get_async_database()
+    
+    # Find narratives missing last_summary_generated_at
+    query = {
+        "last_summary_generated_at": {"$exists": False},
+        "lifecycle_state": {"$ne": "dormant"},
+    }
+    
+    cursor = db.narratives.find(query)
+    narratives = await cursor.to_list(length=None)
+    
+    for narrative in narratives:
+        last_updated = narrative.get("last_updated")
+        
+        # Set timestamp to last_updated or now
+        timestamp = last_updated or datetime.now(timezone.utc)
+        
+        # Check if needs refresh (article_age_gap_hours > 24)
+        newest_article_date = ... # Query articles
+        age_gap_hours = (newest_article_date - timestamp).total_seconds() / 3600
+        needs_update = age_gap_hours > 24
+        
+        await db.narratives.update_one(
+            {"_id": narrative["_id"]},
+            {"$set": {
+                "last_summary_generated_at": timestamp,
+                "needs_summary_update": needs_update,
+            }}
+        )
+    
+    logger.info(f"Backfilled {len(narratives)} narratives")
+```
+
+**Risk:** Medium. Backfill script requires careful testing on staging first.
+
+**Timeline:** 2 hours implementation, 2 hours staging validation, 30 min production run.
+
+**Fix 2: Update staleness detection**
+
+Modify `narrative_service.py:1112-1125` to explicitly detect missing `last_summary_generated_at`:
+
+```python
+# If missing timestamp, treat as potentially stale
+if not matching_narrative.get("last_summary_generated_at"):
+    needs_summary_update = True  # Force refresh for legacy narratives
+    logger.info(f"Flagging narrative '{title}' for refresh: missing last_summary_generated_at")
+else:
+    # Existing staleness logic
+    needs_summary_update = (...)
+```
+
+**Risk:** Low-medium. Affects only new narrative merges; existing narratives unaffected until backfill.
+
+**Timeline:** 30 min implementation + testing.
+
+---
+
+### Stage 4: Narrative Batch Backfill (LOWEST PRIORITY, must be after Stage 3)
+
+**Goal:** Refresh the 341 legacy narratives safely without blowing budget.
+
+**Fix: Batch backfill with cost controls**
+
+After Stage 3 backfill+fix, ~100-200 narratives will be flagged `needs_summary_update=true` (estimate based on age gap > 24h condition).
+
+**Pilot approach (7 days):**
+- Run 2× daily (current schedule)
+- Limit to 10 narratives per run (lower than current 20)
+- Cost: 10 × 2 × $0.025 = $0.50/day (well within $1/day)
+- Time: 7 days to complete 140 narratives
+
+**Monitor:**
+- LLM trace costs for narrative_generate operations
+- Briefing quality before/after refreshes
+- No budget limit violations
+
+**If successful, increase to 20/run for 3-4 more days to finish remaining narratives.**
+
+**Risk:** Medium. Narrative regeneration can change content. Monitor briefings closely.
+
+**Timeline:** 7-10 days to complete full backfill.
+
+---
+
+### Stage 5: Long-Term Monitoring (ONGOING)
+
+**Goal:** Prevent recurrence.
+
+**Metrics to track:**
+- Briefing publication confidence_score distribution (alert if < 0.5 appears)
+- Briefing key_insights emptiness rate (alert if > 0%)
+- Narratives missing last_summary_generated_at (should be 0 after backfill)
+- Narratives flagged for refresh (should be small, < 20 at any time)
+- Refinement iteration count (should stabilize, not increase)
+
+**Dashboard:**
+- Add observability to briefing generation logs
+- Add metrics to LLM cost tracking
+- Weekly review of briefing quality metrics
+
+---
+
+## User-Facing Ramifications
+
+### Immediate (Stage 1 Containment)
+
+**Positive:**
+- No more invalid briefings published
+- Briefing quality floor established
+
+**Negative:**
+- If a briefing fails validation, no briefing published that day (rare, but possible)
+- May need admin override mechanism for edge cases
+
+### Short-term (Stage 2-3, Refinement + Staleness Fix)
+
+**Positive:**
+- Refinement improves more effectively
+- Legacy narrative summaries refresh, content becomes current
+- Briefing mentions updated facts instead of month-old narratives
+
+**Negative:**
+- Narrative titles/summaries may change on refresh (users see fresh content, but different wording)
+- Initial refresh wave may take 1-2 weeks (narrative updates won't be instant)
+
+### Medium-term (Stage 4, Backfill)
+
+**Positive:**
+- All briefings contain current narrative context
+- Entity mentions align with recent articles
+- Users see coherent, up-to-date briefings
+
+**Negative:**
+- None expected if Stages 1-3 successful
+
+---
+
+## Cost Ramifications
+
+### Stage 1: Containment
+**Cost:** $0 (code only, no LLM calls)
+
+### Stage 2: Refinement Prompt Fix
+**Cost:** +5-10% to briefing generation cost due to larger prompt
+- Current: 2 briefings/day × ~$0.05-0.10 each = ~$0.20/day
+- After fix: ~$0.22-0.25/day
+- **Incremental: +$0.02-0.05/day (~$0.60-1.50/month)**
+
+### Stage 3: Narrative Freshness Fix
+**Cost:** One-time backfill (~$5-7)
+- 341 narratives × $0.02-0.03 per refresh = $6.82-10.23
+- But only run as part of staged backfill
+
+### Stage 4: Batch Backfill
+**Cost:** Depends on pilot scope
+- 10/run, 2× daily, 10 days: 200 narratives × $0.025 = $5.00
+- **Or full 341 at once (not recommended): $8.53-10.23**
+
+### Stage 5: Monitoring
+**Cost:** $0 (observability only)
+
+### Total Monthly Cost Impact
+- **Current:** ~$20-25/month (briefing generation only)
+- **After all stages:** ~$22-28/month (briefing + occasional narrative refresh)
+- **Increase:** ~10% for improved narrative freshness
+
+---
+
+## Risks and Rollback Plan
+
+### Risk 1: Briefing Validation Rejects Too Many
+**Symptom:** No briefing published some days
+**Rollback:** Disable validation check (lines in _save_briefing), accept all briefings again
+**Recover:** 15 minutes
+
+### Risk 2: Refinement Prompt Causes Degradation
+**Symptom:** Briefing quality decreases after adding context
+**Rollback:** Revert _build_refinement_prompt() to simple version, remove entity/title lists
+**Recover:** 30 minutes + redeploy
+
+### Risk 3: Narrative Backfill Script Overwrites User Data
+**Symptom:** Narratives lose important metadata during backfill
+**Mitigation:** Test on staging database clone first; use read-only query to identify affected records; review sample before running
+**Rollback:** MongoDB backup restore (pre-backfill snapshot)
+**Recover:** 1-2 hours
+
+### Risk 4: Batch Refresh Causes Token Explosion
+**Symptom:** Budget exhausted, all LLM operations blocked
+**Mitigation:** Start with 10/run, monitor daily cost, increase only if safe
+**Rollback:** Stop refresh task, wait for budget reset (daily at midnight UTC)
+**Recover:** Immediate (next day), or manually reset cost cache if needed
+
+---
+
+## Summary: Staged Fix Order
+
+| Stage | Component | Priority | Sprint 019 | Effort | Risk | Timeline |
+|-------|-----------|----------|-----------|--------|------|----------|
+| 1 | Briefing validation | CRITICAL | ✅ Required | 2h | Low | Day 1 |
+| 2 | Refinement context | High | ◐ Optional | 1.5h | Med | Day 2 |
+| 3 | Narrative staleness backfill | High | ✗ Deferred | 3h | Med | Future |
+| 4 | Batch narrative refresh | Medium | ✗ Deferred | 7-10d | Med | Future |
+| 5 | Trust layer + deterministic fallback | High | ✅ Required | 5-7d | Low | Week 1-2 |
+| 6 | Monitoring | Low | ✓ Partial | 2h | Low | Ongoing |
+
+**Recommended execution for Sprint 019:**
+- **Week 1:** Implement Stage 1 (containment), Stage 5 (trust layer architecture)
+- Validate on staging, deploy to production
+- **Week 2:** Implement deterministic article-cluster fallback, API display_mode field
+- Test narratives page and briefing generation with trust filters
+- Establish Stage 6 monitoring for trusted/untrusted split
+- **Future sprints:** Consider Stages 3-4 (legacy repair) as optional optimization
+
+---
+
+## Addendum: Fresh-Start Narrative Trust Option
+
+After reviewing the investigation findings, the product team chose not to immediately repair or refresh all 341 legacy narratives missing `last_summary_generated_at`.
+
+The investigation found:
+
+- Active narratives missing `last_summary_generated_at`: 341
+- Narratives with `needs_summary_update=true`: 4
+- Refresh task exists and works for flagged narratives
+- Refresh task runs twice daily with `MAX_REFRESH_PER_RUN = 20`
+- Full legacy refresh would create avoidable LLM cost and budget pressure
+- The most urgent user-facing failure is invalid briefing publication, not historical narrative repair
+
+### Product Decision
+
+Sprint 019 will use a fresh-start trust model instead of immediate legacy repair:
+
+1. **Briefing generation** should only use trusted narrative summaries.
+2. **The narratives page** should continue showing recent article activity.
+3. **Stale or missing narrative summaries** should not be presented as authoritative user-facing copy.
+4. **The UI should gracefully fall back** to an article-cluster display for untrusted summaries.
+5. **The fallback display must be deterministic** and must not call an LLM.
+6. **Old narratives remain in MongoDB** for future repair, audit, or selective reactivation.
+7. **Sprint 019 will not** mass-refresh, delete, dormancy-mark, or migrate all legacy narratives.
+
+### Trusted Summary Rule
+
+A narrative summary is considered trusted for briefing synthesis if one of the following is true:
+
+```
+first_seen >= FRESH_START_CUTOFF
+OR last_summary_generated_at >= FRESH_START_CUTOFF
+OR _fresh_start_validated_at >= FRESH_START_CUTOFF
+```
+
+Narratives that do not meet this rule should be excluded from briefing synthesis.
+
+### Narratives Page Rule
+
+The narratives page should not use the same strict filter as briefing generation. It should remain activity-based:
+
+```
+show narratives with recent article activity, such as last_updated >= FRESH_START_CUTOFF
+```
+
+This avoids hiding current article clusters simply because they are attached to old legacy narratives.
+
+### Display Mode Rule
+
+The backend/API should compute a product-facing display mode for each narrative. Expected display modes:
+
+- **`summary`** — use generated title and summary
+- **`article_cluster`** — use deterministic fallback from recent article titles, entities, sources, and counts
+
+**For trusted summaries:**
+- `display_mode = "summary"`
+- Frontend may show the generated title and generated summary.
+
+**For untrusted summaries:**
+- `display_mode = "article_cluster"`
+- Frontend should render a user-facing article activity card, e.g.:
+  ```
+  Bitcoin
+  8 recent articles
+  Latest coverage includes Bitcoin holding near $80K, ETF outflows, options positioning, 
+  and Fed inflation concerns.
+  ```
+
+This line must be generated deterministically from recent article titles, entities, source names, and article count. It must not call an LLM.
+
+### User-Facing Copy Constraint
+
+Do not expose internal system state to public users.
+
+The frontend should **not show**:
+- "Summary needs refresh"
+- "Stale"
+- "Missing"
+- "Untrusted"
+- "Needs update"
+
+Those terms may exist internally, but the public UI should use polished article-cluster fallback copy.
+
+### Cost Decision
+
+Sprint 019 should avoid the estimated legacy refresh cost:
+
+- Full refresh of 341 narratives: ~$6.82-$10.23
+- Budget risk: May trigger soft/hard limits if attempted all at once
+- Deterministic fallback cost: $0
+
+The only expected LLM cost increase in Sprint 019 should come from the briefing refinement prompt grounding fix (if implemented), because the prompt may include more source context.
+
+### Revised Recommended Path
+
+The original investigation recommended staged repair of legacy narratives. That remains a valid future option, but it is no longer the recommended near-term path.
+
+**Revised Sprint 019 recommendation:**
+
+**Option A: Controlled legacy repair (original plan)**
+- Stage 3: Backfill missing timestamps, fix staleness detection
+- Stage 4: Batch refresh 341 narratives over 7-10 days
+- Cost: ~$6.82-10.23
+- Timeline: 10-15 days
+- Risk: Budget pressure, narrative content changes
+
+**Option B: Fresh-start narrative trust layer (recommended for Sprint 019)**
+- Add trusted-summary eligibility check for briefing inputs
+- Add narrative display mode fields to public API
+- Add deterministic article-cluster fallback for untrusted summaries
+- Prevent invalid briefings from publishing (Stage 1)
+- Ground briefing refinement prompts with source context (Stage 2, optional)
+- Cost: $0 (plus optional Stage 2 refinement cost)
+- Timeline: 2-3 weeks
+- Risk: Low; forward-correctness focused
+
+### Explicit Non-Goals for Sprint 019
+
+- ✗ Do not refresh all 341 legacy narratives
+- ✗ Do not delete old narratives
+- ✗ Do not mark old narratives dormant
+- ✗ Do not overwrite `last_summary_generated_at` for legacy narratives as a shortcut
+- ✗ Do not expose stale/missing/untrusted labels to public users
+- ✗ Do not use LLM calls to generate article-cluster fallback copy
+- ✗ Do not change narrative clustering or matching behavior (separate ticket if needed)
+
+### Future Repair Option
+
+Ignoring old narratives for briefing synthesis does not prevent repairing them later.
+
+Because old narratives remain in MongoDB, future work can selectively or gradually repair them by:
+
+- Refreshing high-value narratives manually
+- Adding `_fresh_start_validated_at` after review
+- Flagging old narratives with `needs_summary_update=true`
+- Reducing refresh batch size
+- Running controlled backfill over days or weeks
+- Creating a separate legacy narrative repair sprint
+
+This keeps Sprint 019 focused on forward correctness and user-facing safety while preserving optionality for historical repair.
+
+---
+
+## Conclusion
+
+The bad briefing was caused by a **fallback parsing handler that accepts non-JSON LLM text as valid briefing content** (confidence_score=0.3). This is a code-level validation gap, not a data or configuration issue.
+
+The **341 stale narratives** are not being refreshed because their missing `last_summary_generated_at` timestamps cause staleness checks to evaluate as "not stale" (when paired with recent `last_updated` values). The refresh system works correctly for flagged narratives; the problem is flag detection.
+
+Both issues are **fixable with code changes only** — no data migration required except for the narrative timestamp backfill (which is low-risk and one-time).
+
+**Immediate action (critical):** Implement containment fix (Stage 1) to prevent future invalid briefings from publishing.
+
+**Recommended near-term path for Sprint 019:** Implement a fresh-start narrative trust layer that excludes untrusted summaries from briefing synthesis and renders recent article clusters deterministically on the narratives page. This avoids the estimated $6.82-10.23 cost of refreshing all 341 legacy narratives while ensuring user-facing correctness.
+
+**Future option:** Legacy narrative repair remains valid but deferred. Old narratives persist in MongoDB and can be selectively refreshed, backfilled, or validated in a future sprint without affecting Sprint 019's forward-correctness focus.
+
+---
+
+## Appendix: Files and Functions Reference
+
+### Key Code Locations
+
+**Briefing Generation & Validation:**
+- `src/crypto_news_aggregator/services/briefing_agent.py:940-1012` — `_save_briefing()` (needs validation)
+- `src/crypto_news_aggregator/services/briefing_agent.py:831-890` — `_parse_briefing_response()` (fallback issue)
+- `src/crypto_news_aggregator/db/operations/briefing.py:41-60` — `insert_briefing()`
+
+**Briefing Prompts:**
+- `src/crypto_news_aggregator/services/briefing_agent.py:619-689` — `_build_generation_prompt()`
+- `src/crypto_news_aggregator/services/briefing_agent.py:691-758` — `_build_critique_prompt()`
+- `src/crypto_news_aggregator/services/briefing_agent.py:765-786` — `_build_refinement_prompt()` (missing context)
+
+**Refinement Loop:**
+- `src/crypto_news_aggregator/services/briefing_agent.py:393-501` — `_self_refine()`
+
+**Narrative Staleness:**
+- `src/crypto_news_aggregator/services/narrative_service.py:1112-1154` — staleness evaluation and flag setting
+- `src/crypto_news_aggregator/db/operations/narratives.py:64-300` — `upsert_narrative()`
+
+**Narrative Refresh:**
+- `src/crypto_news_aggregator/tasks/narrative_refresh.py:36-168` — refresh task (working correctly)
+- `src/crypto_news_aggregator/tasks/beat_schedule.py:117-134` — scheduling (working correctly)
+
+**Cost Tracking:**
+- `src/crypto_news_aggregator/services/cost_tracker.py:429-504` — `check_llm_budget()`
+
+**Public API:**
+- `src/crypto_news_aggregator/api/v1/endpoints/briefing.py:229-260` — `get_latest_briefing_endpoint()` (no validation)
+- `src/crypto_news_aggregator/api/v1/endpoints/briefing.py:134-186` — `_format_briefing()`
+
+---
+
+**End of Investigation Report**

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/task-095/task-095-briefing-narrative-refresh-investigation.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/task-095/task-095-briefing-narrative-refresh-investigation.md
@@ -1,0 +1,449 @@
+---
+ticket_id: TASK-095
+title: Investigate Briefing Refinement Publication and Narrative Refresh Behavior
+priority: high
+severity: high
+status: COMPLETE
+date_created: 2026-05-10
+date_completed: 2026-05-10
+branch: task/investigate-briefing-narrative-refresh
+effort_estimate: medium
+actual_effort: 2.5 hours
+---
+
+# TASK-095: Investigate Briefing Refinement Publication and Narrative Refresh Behavior
+
+## Problem Statement
+
+A production morning briefing published invalid model meta-output instead of a valid crypto briefing. The published narrative asked the user to provide active narrative titles, summaries, and entity names.
+
+This appears to be a downstream symptom of two possible system issues:
+
+1. Briefing refinement can return non-briefing text and still be saved/published.
+2. Active narratives may be stale because legacy narratives missing `last_summary_generated_at` are not being marked for summary refresh.
+
+Before implementing any fixes, investigate the current code paths and answer how the system actually behaves. Do not modify code, run migrations, or change production data.
+
+---
+
+## Context
+
+The bad briefing was already unpublished manually, so users now see the previous valid evening briefing.
+
+Bad briefing evidence:
+
+```text
+_id: 6a00734544c1c6f85c7266f1
+type: morning
+generated_at: 2026-05-10T12:00:00.512Z
+task_id: 9ec83c1e-5dd7-423c-a70e-831b10a2375f
+metadata.confidence_score: 0.3
+metadata.refinement_iterations: 1
+content.key_insights: []
+content.narrative: asks for narrative titles, summaries, and entity names
+```
+
+LLM trace evidence showed the briefing pipeline completed without technical errors:
+
+```text
+briefing_generate
+briefing_critique
+briefing_refine
+briefing_critique
+briefing_refine
+```
+
+All observed `llm_traces.error` values were null.
+
+Narrative freshness evidence:
+
+```text
+active narratives missing last_summary_generated_at: 341
+narratives with needs_summary_update=true: 4
+```
+
+Example stale active narrative:
+
+```text
+title: Bitcoin Holds $75K Amid Geopolitical Tensions and Strong ETF Inflows
+first_seen: 2025-10-18
+last_updated: 2026-05-10
+lifecycle_state: hot
+needs_summary_update: false
+last_summary_generated_at: missing
+```
+
+The actual linked articles are current BTC-around-$80K articles, including:
+
+```text
+Bitcoin holds $80K into weekly close as traders say BTC price dip not yet over
+Bitcoin Price Prospect: BTC Holds $80K While Momentum Starts Heating Up
+Bitcoin price may dip toward $70K as Fed estimates hotter inflation print
+Bitcoin briefly slips below $80,000, but options traders are betting the dip won’t last
+Bitcoin stalls as BTC ETF outflows hit $268M
+Bitcoin Bulls Defend $79,200 as $28.3M in Long Liquidations Resets Risk
+```
+
+Known likely data-type issue:
+
+```text
+narratives.article_ids appear to be stored as strings
+articles._id are ObjectIds
+```
+
+This may matter if narrative refresh/source hydration queries articles without converting string IDs to ObjectId.
+
+---
+
+## Task
+
+Perform a read-only investigation and produce a structured report answering the questions below.
+
+Do not implement fixes. Do not modify code. Do not run migrations. Do not change production data.
+
+1. Inspect briefing generation, refinement, parsing, saving, and public retrieval behavior.
+2. Inspect narrative summary freshness and refresh task behavior.
+3. Inspect article hydration behavior for string `article_ids` versus ObjectId `_id`.
+4. Inspect LLM cost/budget behavior for narrative refresh.
+5. Recommend a staged fix plan, but do not implement it.
+
+---
+
+## Files to Create
+
+```text
+docs/investigations/TASK-095-briefing-narrative-refresh-investigation.md
+```
+
+---
+
+## Files to Modify
+
+```text
+None
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+src/crypto_news_aggregator/services/narrative_service.py
+src/crypto_news_aggregator/tasks/
+src/crypto_news_aggregator/db/operations/
+src/crypto_news_aggregator/llm/
+context-owl-ui/
+```
+
+Do not modify any application code, tests, migrations, database records, or environment configuration in this task.
+
+---
+
+## Implementation Requirements
+
+This is an investigation-only task.
+
+- [ ] Do not edit production code.
+- [ ] Do not edit tests.
+- [ ] Do not run migrations.
+- [ ] Do not update MongoDB records.
+- [ ] Do not trigger production briefing generation.
+- [ ] Do not trigger narrative refresh jobs.
+- [ ] Do not run any command that could consume LLM budget unless explicitly approved.
+- [ ] Produce a written investigation report only.
+- [ ] Include exact file paths and function/class names for every finding.
+- [ ] Distinguish confirmed behavior from inferred behavior.
+- [ ] Distinguish code findings from database observations.
+- [ ] Include any unknowns or ambiguous code paths.
+
+### Files to Inspect First
+
+Start with these files. Follow imports/references as needed.
+
+```text
+src/crypto_news_aggregator/services/briefing_agent.py
+src/crypto_news_aggregator/services/narrative_service.py
+src/crypto_news_aggregator/tasks/
+src/crypto_news_aggregator/tasks/beat_schedule.py
+src/crypto_news_aggregator/db/operations/briefing.py
+src/crypto_news_aggregator/db/operations/narratives.py
+src/crypto_news_aggregator/llm/gateway.py
+```
+
+Also inspect any frontend/API code used by:
+
+```text
+briefings page
+narratives page
+public briefing API endpoint
+public narratives API endpoint
+admin briefing trigger endpoint
+```
+
+### Investigation Questions
+
+#### A. Briefing Publication Behavior
+
+Answer:
+
+1. Where exactly is the final briefing saved?
+2. What function constructs the final `daily_briefings` document?
+3. Does the code validate whether generated/refined output is actually publishable?
+4. Can a low-confidence briefing still be saved with `published=true`?
+5. Can a briefing with empty `key_insights` still be saved with `published=true`?
+6. Does `_parse_briefing_response` or equivalent fallback behavior allow arbitrary raw text to become `content.narrative`?
+7. Does the public briefing API filter out invalid, failed, low-confidence, or empty-insight briefings?
+8. What fields does the public briefing page use to decide which briefing to show?
+9. Is there any existing concept of `invalid_output`, `failed_generation`, or similar metadata?
+
+#### B. Briefing Refinement Behavior
+
+Answer:
+
+1. What exactly is included in the initial `briefing_generate` prompt?
+2. What exactly is included in the `briefing_critique` prompt?
+3. What exactly is included in the `briefing_refine` prompt?
+4. Does the refinement prompt include the full active narrative source context?
+5. Does the refinement prompt include active narrative titles?
+6. Does the refinement prompt include narrative summaries/descriptions?
+7. Does the refinement prompt include narrative entities?
+8. Does the refinement prompt include article titles/sources attached to each narrative?
+9. Is there any chance the refinement prompt references an `AVAILABLE DATA` section that is not actually included?
+10. Does the refinement prompt explicitly require valid JSON only?
+11. What happens if refinement returns plain text instead of JSON?
+12. Is the final saved briefing always the last refinement output, even if it is lower quality than the original generation?
+
+#### C. Narrative Freshness Behavior
+
+Answer:
+
+1. Where are `needs_summary_update` and `last_summary_generated_at` set?
+2. Are these fields set when a narrative is first created?
+3. Are these fields set when an article is appended to an existing narrative?
+4. What happens if an existing narrative is missing `last_summary_generated_at`?
+5. Does staleness logic treat missing `last_summary_generated_at` as stale?
+6. What exact conditions set `needs_summary_update=true`?
+7. Does lifecycle promotion set `needs_summary_update=true`?
+8. Does 3+ new articles since last summary set `needs_summary_update=true`?
+9. Does `last_updated > last_summary_generated_at + 24h` set `needs_summary_update=true`?
+10. Are legacy narratives missing `last_summary_generated_at` excluded from refresh logic?
+11. Are active narratives allowed to remain `hot`, `emerging`, `rising`, or `reactivated` with missing `last_summary_generated_at` and `needs_summary_update=false`?
+
+#### D. Narrative Refresh Task Behavior
+
+Answer:
+
+1. Does `refresh_flagged_narratives` exist?
+2. Where is it defined?
+3. Is it scheduled automatically?
+4. If scheduled, how often does it run?
+5. Does it have a batch limit?
+6. Does it respect LLM daily/monthly budget limits?
+7. Does it process all `needs_summary_update=true` narratives in one run or bounded batches?
+8. What operation name does it use for LLM traces?
+9. Does it update `title`, `description`, or both?
+10. Does it set `last_summary_generated_at=now` after refresh?
+11. Does it clear `needs_summary_update=false` after successful refresh?
+12. What happens on refresh failure?
+13. Does it retry failed narratives?
+14. Does it record refresh failure metadata?
+
+#### E. Article Hydration / ObjectId Behavior
+
+Answer:
+
+1. What type is stored in `narratives.article_ids`: strings, ObjectIds, or mixed?
+2. What type is used for `articles._id`?
+3. Does narrative refresh logic convert string `article_ids` to ObjectId before querying `articles`?
+4. Could refresh/source hydration silently return zero articles because of string/ObjectId mismatch?
+5. Are there tests covering string article IDs?
+6. Are there any helper functions for converting narrative article IDs into article ObjectIds?
+7. Are those helpers used consistently in briefing and narrative refresh paths?
+
+#### F. Cost and Budget Behavior
+
+Answer:
+
+1. What operation names correspond to narrative generation and narrative refresh in `llm_traces`?
+2. What is the estimated average cost of one narrative refresh based on existing code and traces?
+3. If 341 narratives were flagged for refresh, would the system try to refresh all immediately?
+4. Could that exceed the $1/day hard budget?
+5. Would budget exhaustion block later entity extraction, narrative generation, or briefing generation?
+6. Is there a per-task or per-run refresh budget separate from the global LLM budget?
+7. Is there a safe way in the current system to refresh only 10-20 narratives as a pilot?
+8. Does the refresh path have cost-aware batching, throttling, or early stopping?
+
+#### G. Recommended Safe Fix Plan
+
+Based on findings, propose a minimal staged plan.
+
+Include:
+
+1. containment fix to prevent invalid briefings from publishing
+2. refinement prompt/context fix
+3. narrative freshness fix for missing `last_summary_generated_at`
+4. small pilot refresh plan
+5. batch backfill plan with cost controls
+6. user-facing ramifications
+7. cost ramifications
+8. risks and rollback plan
+
+Do not implement the plan.
+
+### Configuration
+
+No configuration changes required.
+
+```text
+N/A
+```
+
+### Commands to Run
+
+Prefer static inspection commands only.
+
+Allowed:
+
+```bash
+grep -R "refresh_flagged_narratives" -n src/
+grep -R "needs_summary_update" -n src/
+grep -R "last_summary_generated_at" -n src/
+grep -R "briefing_refine" -n src/
+grep -R "briefing_critique" -n src/
+grep -R "published" -n src/ context-owl-ui/
+grep -R "daily_briefings" -n src/
+```
+
+Allowed if needed:
+
+```bash
+pytest --collect-only
+```
+
+Do not run:
+
+```bash
+pytest
+celery
+python -m crypto_news_aggregator.tasks...
+python -m crypto_news_aggregator.services...
+```
+
+unless explicitly approved, because some commands may trigger LLM calls, background jobs, or database writes.
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] No code files modified.
+- [ ] No tests modified.
+- [ ] No migrations created.
+- [ ] Investigation report created at `docs/investigations/TASK-095-briefing-narrative-refresh-investigation.md`.
+- [ ] Report includes file paths and function names for every finding.
+- [ ] Report answers all questions in sections A-G or explicitly marks unanswered items as unknown.
+
+### Manual Verification
+
+- [ ] Review `git diff` and confirm only the investigation report was added.
+- [ ] Confirm no production data was changed.
+- [ ] Confirm no LLM-consuming commands were run.
+- [ ] Confirm report distinguishes confirmed behavior from inferred behavior.
+- [ ] Confirm report includes a recommended staged fix plan but no implementation.
+
+---
+
+## Acceptance Criteria
+
+- [ ] The investigation identifies the exact code path that allowed invalid refinement output to become a published briefing.
+- [ ] The investigation identifies whether low-confidence / empty-insight briefings can currently publish.
+- [ ] The investigation identifies whether refinement prompts include sufficient narrative source context.
+- [ ] The investigation identifies where `needs_summary_update` and `last_summary_generated_at` are set and whether missing timestamps are treated as stale.
+- [ ] The investigation identifies whether `refresh_flagged_narratives` exists, whether it is scheduled, and whether it has batch/cost controls.
+- [ ] The investigation identifies whether string `article_ids` are converted to ObjectId during article hydration.
+- [ ] The investigation estimates cost ramifications of refreshing 10, 50, 100, and 341 narratives.
+- [ ] The investigation proposes a safe staged fix order.
+- [ ] No application code or production data is changed.
+
+---
+
+## Impact
+
+This investigation reduces risk before implementing fixes.
+
+Expected benefits:
+
+- Prevents premature changes to production data.
+- Clarifies whether the immediate user-facing bug is isolated to briefing publication validation or also requires prompt/context fixes.
+- Clarifies whether narrative refresh can be safely backfilled without blowing through the daily LLM budget.
+- Produces an implementation-ready plan for the next bug/fix tickets.
+
+User-facing impact of the investigation itself:
+
+- None. This task should not change runtime behavior.
+
+Cost impact of the investigation itself:
+
+- None expected. This task should not trigger LLM calls or refresh jobs.
+
+Operational risk:
+
+- Low, assuming no code, database, or runtime jobs are modified.
+
+---
+
+## Related Tickets
+
+- Follow-up likely: `BUG-XXX: Prevent Invalid Briefing Refinement Output From Publishing`
+- Follow-up likely: `BUG-XXX: Fix Narrative Summary Freshness for Legacy Active Narratives`
+- Follow-up likely: `TASK-XXX: Batch Backfill Stale Active Narrative Summaries With Cost Controls`
+
+---
+
+## Completion Summary
+
+**Status: COMPLETE** ✅
+
+- **Branch:** `task/investigate-briefing-narrative-refresh`
+- **Report Location:** `docs/investigations/TASK-095-briefing-narrative-refresh-investigation.md`
+- **Changes Made:** Investigation report only (1,125 lines). No code modifications, no database changes, no LLM calls.
+- **Tests Run:** N/A (read-only investigation)
+- **Manual Verification:**
+  - ✅ Confirmed no src/ files modified: `git diff src/` returns empty
+  - ✅ Confirmed no test files modified
+  - ✅ Confirmed investigation report created with all 7 sections (A-G)
+  - ✅ Confirmed exact file paths and function names included throughout
+  - ✅ Confirmed report distinguishes confirmed vs. inferred behavior
+  - ✅ Confirmed staged fix plan included (5 stages with risks/rollback)
+  - ✅ No production data changed
+  - ✅ No LLM-consuming commands executed
+
+**Deviations from Plan:** None. Completed exactly as specified.
+
+---
+
+## Key Investigation Findings (Summary)
+
+### Root Cause Identified
+**Briefing Publication Validation Gap:** The `_parse_briefing_response()` fallback handler (lines 878-890 in `briefing_agent.py`) accepts raw LLM text as valid briefing content when JSON parsing fails, setting `confidence_score=0.3`. No validation prevents publication of low-confidence or empty-insight briefings.
+
+### Secondary Issues Identified
+1. **Refinement Prompt Context Deficiency:** Refinement prompt references "AVAILABLE DATA" but includes no actual narrative details, summaries, entities, or articles — preventing effective refinement.
+2. **Narrative Staleness Detection Failure:** 341 legacy narratives missing `last_summary_generated_at` are not flagged for refresh because staleness logic uses `last_updated` as fallback, making recent-but-stale narratives appear fresh.
+
+### Confirmed (Not Root Cause)
+- ✅ String/ObjectId conversion: Correctly handled in both `narrative_refresh.py:92` and `briefing_agent.py:322`
+- ✅ Refresh task exists, scheduled, has batch limits (20/run), respects budget
+- ✅ Cost estimates: $6.82-10.23 for 341 narratives; $0.50/day at 20/run
+
+### Recommended Fix Stages
+1. **Stage 1 (Containment):** Add briefing validation (reject low-confidence/empty)
+2. **Stage 2 (Refinement):** Add narrative context to refinement prompt
+3. **Stage 3 (Staleness):** Backfill missing timestamps + fix staleness detection
+4. **Stage 4 (Backfill):** Batch refresh 341 narratives over 7-10 days
+5. **Stage 5 (Monitoring):** Dashboard tracking
+
+**Total Implementation Estimate:** ~15-20 hours (including staging validation)
+**Cost Impact:** +$0.02-0.05/day for refinement prompts; ~$5-7 one-time for backfill

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/task-096-sprint-019-verification-queries.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/task-096-sprint-019-verification-queries.md
@@ -1,0 +1,174 @@
+---
+ticket_id: TASK-096
+title: Add Sprint 019 Verification Queries
+priority: medium
+severity: medium
+status: OPEN
+date_created: 2026-05-10
+branch: task/sprint-019-verification-queries
+effort_estimate: small
+---
+
+# TASK-096: Add Sprint 019 Verification Queries
+
+## Problem Statement
+
+Sprint 019 changes user-facing briefing validation, briefing narrative eligibility, narrative display modes, and deterministic fallback display behavior. The sprint needs repeatable verification queries and checks so implementation agents can confirm that fixes work without modifying production data or triggering expensive jobs.
+
+---
+
+## Context
+
+TASK-095 confirmed:
+
+- Invalid briefing output can publish today.
+- 341 active narratives are missing `last_summary_generated_at`.
+- The narrative refresh task exists, is batched, and respects budget.
+- String `article_ids` are converted to ObjectId correctly in the refresh and briefing paths.
+- Sprint 019 chooses fresh-start narrative trust rather than mass legacy repair.
+
+This task creates a small runbook for verifying the Sprint 019 behavior safely.
+
+---
+
+## Task
+
+Create a verification document with read-only Mongo queries and local verification commands.
+
+1. Add queries to detect invalid published briefings.
+2. Add queries to count trusted-summary eligible briefing narratives.
+3. Add queries to count active recent narratives that should render as article clusters.
+4. Add checks to confirm no mass refresh was triggered.
+5. Add checks to confirm no public display fields expose internal language.
+6. Add cost checks for `llm_traces` around briefing and narrative operations.
+
+---
+
+## Files to Create
+
+```text
+docs/sprints/sprint-019-fresh-start-narrative-trust/verification/sprint-019-verification-queries.md
+```
+
+If the repo does not use a `verification/` subfolder inside sprint folders, create it for this sprint.
+
+---
+
+## Files to Modify
+
+```text
+None
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/
+context-owl-ui/
+```
+
+Do not modify application code, tests, production data, or configuration in this task.
+
+---
+
+## Implementation Requirements
+
+- [ ] Create the verification markdown file.
+- [ ] Include only read-only Mongo queries unless a section is explicitly marked as manual remediation and requires approval.
+- [ ] Include warnings not to run refresh tasks or briefing generation against production unless approved.
+- [ ] Include expected results for each query.
+- [ ] Include a section for post-deploy checks.
+- [ ] Include a section for rollback checks.
+- [ ] Include cost checks using `llm_traces.timestamp`, `llm_traces.operation`, and `llm_traces.cost`.
+
+### Required Query Sections
+
+1. Invalid published briefing detection
+2. Trusted briefing narrative eligibility count
+3. Recent activity narrative count
+4. Article-cluster display candidate count
+5. Legacy stale inventory count
+6. Narrative refresh backlog count
+7. LLM cost in last 24 hours by operation
+8. Public-copy forbidden word scan, if display fields are stored or queryable
+
+### Configuration
+
+Use this cutoff in examples:
+
+```text
+FRESH_START_CUTOFF=2026-05-10T00:00:00Z
+```
+
+### Commands to Run
+
+Documentation-only task. No automated tests required.
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] Markdown file exists at the expected path.
+- [ ] `git diff` shows only the verification markdown file.
+
+### Manual Verification
+
+- [ ] Review the document and confirm every query is read-only.
+- [ ] Confirm expected results are documented.
+- [ ] Confirm no production mutation command is included outside a clearly marked, approval-required section.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Verification document includes invalid published briefing query.
+- [ ] Verification document includes trusted-summary eligibility query.
+- [ ] Verification document includes recent activity narrative query.
+- [ ] Verification document includes narrative refresh backlog query.
+- [ ] Verification document includes LLM cost by operation query.
+- [ ] Verification document includes explicit warnings against unapproved production writes and refresh jobs.
+- [ ] No application code is changed.
+
+---
+
+## Impact
+
+Expected impact:
+
+- Makes Sprint 019 safer to validate.
+- Reduces repeated ad hoc Mongo query writing.
+- Provides a handoff checklist for implementation agents and manual review.
+
+User-facing impact:
+
+- None directly.
+
+Cost impact:
+
+- None. Queries are read-only and do not invoke LLM calls.
+
+---
+
+## Related Tickets
+
+- TASK-095: Briefing and Narrative Refresh Investigation
+- BUG-099: Prevent Invalid Briefings From Publishing
+- FEATURE-060: Add Trusted Summary Eligibility for Briefings
+- FEATURE-061: Add Narrative Display Mode API Fields
+- FEATURE-062: Add Deterministic Article Cluster Fallback
+- BUG-100: Ground Briefing Refinement With Source Context
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/verification/README.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/verification/README.md
@@ -1,0 +1,5 @@
+# Sprint 019 Verification
+
+Verification queries should be added by TASK-096.
+
+Do not run production mutations, briefing generation, or narrative refresh jobs from this directory without explicit approval.


### PR DESCRIPTION
…tion report

Adds "Addendum: Fresh-Start Narrative Trust Option" section documenting the product decision to prioritize forward correctness over immediate legacy narrative repair in Sprint 019.

Key changes:
- Defines trusted summary eligibility: first_seen, last_summary_generated_at, or _fresh_start_validated_at >= FRESH_START_CUTOFF
- Specifies narratives page remains activity-based (not trust-based)
- Introduces display_mode API field: "summary" for trusted, "article_cluster" for untrusted narratives
- Requires deterministic fallback copy (no LLM calls) for untrusted summaries
- Preserves legacy narratives in MongoDB for future selective repair/backfill
- Lists explicit non-goals: no mass refresh, deletion, dormancy marking in S019
- Reframes Section G recommendation: Option A (legacy repair) vs Option B (trust layer - recommended)
- Updates conclusion: immediate action is containment (Stage 1), near-term path is trust layer (avoids $6.82-10.23 cost), future option is deferred legacy repair
- Clarifies timeline: 2-3 weeks for trust layer in S019, future sprints for repair

This separates the investigation findings (still valid) from the product decision (fresh-start approach chosen) while preserving optionality for historical repair.