### PR TITLE
task(bugops): TASK-100 extend BugCase model with Sprint 020 fields

### DIFF
--- a/docs/SPRINTS-018-019-SUMMARY.md
+++ b/docs/SPRINTS-018-019-SUMMARY.md
@@ -1,0 +1,976 @@
+# Sprints 018–019 Summary: BugOps Foundation + Narrative Trust
+
+**Date:** 2026-05-17  
+**Status:** Sprint 018 ✅ Complete | Sprint 019 ✅ Mostly Complete (TASK-098 in progress)  
+**Overall Progress:** 16/17 tickets complete (94%)
+
+---
+
+## Executive Summary
+
+**Sprint 018** delivered a minimal, deterministic BugOps signal pipeline as a separate monitor process. It reads `llm_traces`, detects cost-runaway signals, creates normalized `bug_alert_events`, groups by hourly `dedupe_key`, sends one-way Slack webhooks on new cases, and generates deterministic reports from stored data—all without LLM calls, autonomous remediation, or Celery/Beat dependencies.
+
+**Sprint 019** created a trust boundary around narrative summaries and implemented article-activity fallbacks for untrusted content. Invalid briefings are now blocked from publication, briefing generation uses only trusted summaries, and the narratives page remains populated by deterministic article-cluster cards even when generated summaries are stale or untrusted.
+
+---
+
+# Part 1: BugOps System Overview
+
+## What is BugOps?
+
+BugOps is a deterministic runtime reliability harness that detects cost and performance anomalies in production and escalates them to on-call operators for manual investigation and remediation. It runs as a separate, independent background process that does not depend on FastAPI, Celery, or Celery Beat.
+
+## Architecture
+
+```
+Production Environment (Railway)
+├── FastAPI Web
+├── Celery Worker
+├── Celery Beat
+└── BugOps Monitor (Separate Process)
+    ├── Signal Sources:
+    │   ├── LLMTraceCostSignalSource (cost-runaway) ✅ IMPLEMENTED
+    │   └── RailwayLogSignalSource (infrastructure) 📋 SPIKE ONLY
+    ├── Alert Processor:
+    │   ├── Normalize signals → BugAlertEvent
+    │   ├── Dedupe by dedupe_key (hourly bucketing)
+    │   ├── Create or attach to case
+    │   ├── Send Slack on new case (one-way webhook)
+    │   └── Generate deterministic report
+    └── Output Collections:
+        ├── bug_alert_events (normalized signals)
+        ├── bug_cases (grouped by dedupe_key)
+        ├── bug_case_events (audit trail)
+        └── bug_tool_calls (future agent use)
+```
+
+## What's Implemented ✅
+
+### Core Monitor (631 lines)
+- **Monitor process** (`monitor.py`, 142 lines) — Independent async polling loop with signal handlers
+- **Data models** (`models.py`, 121 lines) — `BugAlertEvent`, `BugCase`, `BugCaseEvent` with proper enums
+  - Severity: `info`, `warning`, `high`, `critical`
+  - Status: `open`, `resolved`, `closed`
+  - Alert status: `new`, `attached`, `ignored`
+- **Data store** (`store.py`, 142 lines) — MongoDB persistence with Motor async driver
+  - Methods: `create_alert_event()`, `find_open_case_by_dedupe_key()`, `process_alert_event()`, `attach_alert_to_case()`
+  - Handles ObjectId normalization for Pydantic validation
+- **Slack integration** (`slack.py`, 123 lines) — One-way webhook notifications with color-coding by severity
+  - Graceful error handling; failures logged but don't crash monitor
+  - 10-second timeout, respects `BUGOPS_SLACK_ENABLED` flag
+- **Deterministic reports** (`reports.py`, 94 lines) — Markdown case reports from stored data only
+  - No LLM calls, 100% auditable
+- **Signal source base** (`signal_sources/base.py`, 14 lines) — Protocol interface for extensibility
+
+### Signal Sources
+
+**LLM Traces Cost Source** (`signal_sources/llm_traces.py`, 123 lines) ✅ FULLY IMPLEMENTED
+- Reads `llm_traces` collection (never `api_costs`)
+- Detects cost-runaway:
+  - **Critical:** Last 5-minute spend ≥ $0.25
+  - **Warning:** Projected hourly spend ≥ $1.00
+- Computes metrics: `last_5_min_spend`, `last_60_min_spend`, `projected_hourly_spend`
+- Extracts top 3 operations and models by cost
+- Hourly dedupe_key: `llm_traces:cost_runaway:YYYY-MM-DD:HH`
+- Full metric payload with window start/end times and thresholds
+
+**Railway Log Signal Source** (`signal_sources/railway_logs.py`, 125 lines) 📋 SPIKE ONLY
+- Placeholder/stub only; not implemented
+- Contains compiled regex patterns for 3 priority log patterns:
+  - MongoDB AutoReconnect errors
+  - Budget soft-limit warnings
+  - Platform log-rate-limit warnings
+- TODOs grounded in real Railway log shape analysis
+- Ready for future implementation without guessing
+- Data-shape findings documented in `docs/bugops/railway-log-data-shape.md`
+
+### Configuration
+
+New environment variables (added to `src/crypto_news_aggregator/core/config.py`):
+
+| Variable | Type | Default | Purpose |
+|---|---|---|---|
+| `BUGOPS_ENABLED` | bool | `false` | Master kill switch |
+| `BUGOPS_POLL_INTERVAL_SECONDS` | int | `300` | Poll interval (5 min) |
+| `BUGOPS_COST_5MIN_THRESHOLD_USD` | float | `0.25` | 5-min spend threshold (CRITICAL) |
+| `BUGOPS_PROJECTED_HOURLY_THRESHOLD_USD` | float | `1.00` | Projected hourly threshold (WARNING) |
+| `BUGOPS_SLACK_ENABLED` | bool | `false` | Enable Slack notifications |
+| `BUGOPS_SLACK_WEBHOOK_URL` | str | `""` | Incoming webhook URL |
+
+### Deployment
+
+- **Procfile entry:** `bugops: python -m crypto_news_aggregator.bugops.monitor`
+- **Independent execution:** `python -m crypto_news_aggregator.bugops.monitor`
+- **No FastAPI/Celery/Beat dependency** — Monitor runs cleanly with just MongoDB connection
+
+### Test Suite
+
+**84 tests across 8 test files** — all passing:
+
+| Test File | Count | Coverage |
+|---|---|---|
+| `test_bugops_models.py` | 5 | Model creation/validation |
+| `test_bugops_store.py` | 9 | Store CRUD + ObjectId normalization |
+| `test_bugops_monitor_config.py` | 2 | Config loading + disabled mode |
+| `test_alert_to_case_flow.py` | 22 | End-to-end alert→case deduplication |
+| `test_llm_traces_cost_source.py` | 13 | Cost signal detection |
+| `test_signal_source_base.py` | 1 | Interface validation |
+| `test_slack_notification.py` | 15 | Slack webhook + error handling |
+| `test_reports.py` | 7 | Report generation |
+
+### Documentation
+
+Complete specification with 6 design docs:
+- `00-bugops-system-overview.md` — System design, scope boundaries, key data models
+- `10-bugops-runtime-model.md` — Polling loop, alert-to-case flow, configuration
+- `20-bugops-data-model.md` — BugAlertEvent/BugCase schemas, required fields, indexing
+- `30-bugops-observability.md` — Logging patterns, error handling, debugging guide
+- `80-bugops-use-cases.md` — Example workflows, operator responsibilities
+- `90-bugops-critiques-and-open-questions.md` — Known limitations (9 items), future work, open design questions (10 items)
+- `railway-log-data-shape.md` — Spike findings from real production logs
+
+## What's NOT Implemented (Out of Scope for Sprint 018)
+
+### Intentionally Deferred (By Design)
+
+| Feature | Scope | Rationale |
+|---|---|---|
+| Railway log ingestion | Full implementation | Spike only validates interface; actual ingestion deferred to Sprint 019+ |
+| LLM synthesis | Report analysis | Deterministic reports sufficient for v1; LLM analysis adds latency, cost, and complexity |
+| Interactive Slack | UI/buttons/commands | One-way webhooks prove value; Slack UI deferred to Sprint 026+ |
+| Multi-source correlation | Fuzzy grouping | With one signal source, correlation is speculative; exact dedupe_key passthrough sufficient |
+| Automatic case closure | Case lifecycle | Manual-only in v1; operators manually mark resolved/closed; automation deferred |
+| Autonomous remediation | Shutdown/pause/deploy | No automatic job pauses, config changes, or production app mutations; manual-only |
+| Case dashboard | Frontend | Operators read Slack + MongoDB; full dashboard deferred |
+| Metrics emission | Prometheus/StatsD | Logging only; metrics deferred to future sprint |
+
+### Known Limitations
+
+1. **Hourly dedupe key bucketing**
+   - Same cost runaway can occur multiple times in same hour → single case
+   - Tradeoff: Prevents one perpetual "cost runaway" case while grouping incident window
+   - Future: Consider per-hour rolling windows or bucketing by cost tier
+
+2. **No fuzzy matching across sources**
+   - If cost spike correlates with MongoDB error, they appear as two unrelated cases
+   - Operator must manually connect the dots
+   - Future: Correlation engine in Sprint 023
+
+3. **No Railway log streaming**
+   - Uses Railway CLI only (local access)
+   - Cannot run inside Railway service container
+   - Future: Implement Railway API-based log ingestion
+
+4. **Case lifecycle manual-only**
+   - No API/CLI to acknowledge, resolve, or close cases
+   - No Slack interactive buttons
+   - Future: Add case state machine with API endpoints
+
+---
+
+## What Remains (BugOps Roadmap)
+
+### Sprint 019 (Future Implementation)
+
+**Railway Log Ingestion** (2–3 days)
+- Implement `RailwayLogSignalSource` using TASK-093 findings
+- Monitor three high-priority patterns:
+  1. MongoDB AutoReconnect errors
+  2. Budget soft-limit warnings
+  3. Platform log-rate-limit warnings
+- Use Railway API (not CLI) for non-interactive log fetch
+- Test against real log samples from fixture
+
+### Sprint 023 (Future Implementation)
+
+**Multi-Source Case Correlation** (3–5 days)
+- When two signals arrive with overlapping time windows, group by correlation_keys
+- Example: `llm_traces:cost_runaway` + `railway_logs:mongo_autoreconnect` → single case if both happen in 5-min window
+- Requires correlation engine with smart bucketing
+
+### Sprint 024 (Future Implementation)
+
+**LLM-Powered Case Analysis** (Optional)
+- Generate root cause hypothesis from case data
+- Suggest manual checks (grounded in observed metric thresholds)
+- Draft ticket summary for escalation
+- Keep deterministic path primary; LLM as advisory only
+
+### Sprint 025 (Future Implementation)
+
+**Case Dashboard and Workflow** (2–3 days)
+- `GET /api/v1/bugops/cases` — List open cases with filters
+- `GET /api/v1/bugops/cases/{case_id}` — Case detail + timeline
+- `POST /api/v1/bugops/cases/{case_id}/acknowledge` — Mark acknowledged
+- `POST /api/v1/bugops/cases/{case_id}/resolve` — Mark resolved
+- React dashboard with real-time updates, filters, and actions
+
+### Sprint 026 (Future Implementation)
+
+**Interactive Slack UI** (2–3 days)
+- Case acknowledge button → updates status in database
+- Case resolve button → closes case
+- Slash command: `/bugops case <id>` → fetch case details in Slack
+- Opens door to full Slack UI for case management
+
+### Sprint 027 (Future Implementation)
+
+**Autonomous Mitigations** (With Human Approval)
+- Pause non-critical operations
+- Adjust rate limiting
+- Trigger cached data refresh
+- Escalate to on-call engineer
+
+### Scaling & Operations (Future)
+
+**Redis Deduplication Lock**
+- When scaling to 2+ BugOps replicas, prevent duplicate processing
+- Atomic lock on (dedupe_key, hour) before creating case
+
+**Historical Case Search**
+- MongoDB text index on case summary + metric fields
+- Elastic search integration for time-based case queries
+
+**Custom Signal Sources**
+- Example: Sentry integration
+- Example: Custom webhook endpoint for external alerts
+- Example: GitHub issue/PR parsing
+
+---
+
+# Part 2: Sprint 018 — BugOps Signal Intake Foundation
+
+**Status:** ✅ COMPLETE  
+**Duration:** 2026-05-08 (1 day accelerated)  
+**All Acceptance Criteria:** ✅ MET (14/14)
+
+## Sprint Principle
+
+Sprint 018 is **not** trying to solve BugOps. It is trying to **prove the smallest end-to-end signal path** while preserving the seam for additional signal sources.
+
+## Sprint Goal
+
+Build the first working BugOps signal pipeline as a separate monitor process: read one structured source (`llm_traces`), normalize a cost-runaway signal into `bug_alert_events`, create a thin `bug_cases` record, send a one-way Slack webhook notification, and generate a minimal deterministic case report. Also validate the `SignalSource` interface against a real sample of Railway log output so future Railway log ingestion does not require rewriting the intake layer.
+
+## Scope Boundary
+
+### In Scope ✅
+- Separate BugOps monitor process/service, added to `Procfile` as `bugops`
+- Thin `SignalSource` interface
+- `LLMTraceCostSignalSource` implementation for cost-runaway alerts using `llm_traces`
+- `RailwayLogSignalSource` placeholder/stub only
+- Railway log data-shape spike using real `railway logs` output captured locally
+- Normalized `bug_alert_events` schema with `source_type`, `alert_type`, `severity`, `dedupe_key`, and `correlation_keys`
+- Thin `bug_cases` schema
+- Alert-to-case passthrough by `dedupe_key`, not a multi-source correlation engine
+- One-way Slack webhook notification using `BUGOPS_SLACK_WEBHOOK_URL`
+- Minimal deterministic case report from stored event/case data
+- Manual-only case lifecycle
+
+### Out of Scope 📋
+- Full Railway log ingestion
+- Railway log streaming/drain/sidecar
+- Sentry-quality fingerprinting or stack trace grouping
+- Multi-source case correlation engine
+- Slack UI, slash commands, buttons, modals, acknowledgement, or resolution actions
+- BugOps dashboard
+- LLM synthesis, Q&A, ticket drafting, or agent reasoning
+- Autonomous shutdown, deploys, env var changes, database writes to production app collections, or remediation
+- Scheduled briefing freshness monitor
+- Retry storm monitor
+- Design Review BugOps
+
+## Tickets Completed (8/8)
+
+| # | Ticket | Title | Status | Effort |
+|---|--------|-------|--------|--------|
+| 1 | FEATURE-056 | BugOps service skeleton and SignalSource seam | ✅ | Medium |
+| 2 | FEATURE-057 | BugOps normalized alert-event and case store | ✅ | Medium |
+| 3 | FEATURE-058 | Implement llm_traces cost-runaway signal source | ✅ | Medium |
+| 4 | FEATURE-059 | Alert-to-case flow by dedupe_key | ✅ | Small |
+| 5 | TASK-090 | One-way BugOps Slack webhook notification | ✅ | Small |
+| 6 | TASK-091 | Minimal deterministic case report | ✅ | Small |
+| 7 | TASK-093 | Railway log data-shape spike | ✅ | Small |
+| 8 | TASK-092 | Update BugOps docs with Sprint 018 scope | ✅ | Small |
+
+## Discovered Work (3 bugs, all fixed)
+
+| Ticket | Title | Root Cause | Fix | Status |
+|---|---|---|---|---|
+| BUG-095 | BugOps disabled mode initializes Redis/shared app dependencies | Early disabled-mode check missing | Added `_is_bugops_enabled_from_env()` before imports | ✅ |
+| BUG-096 | BugOps enabled mode crashes with async Motor database TypeError | Called `get_database()` instead of `get_async_database()` | Changed to async getter | ✅ |
+| BUG-097 | BugOps alert event hydration fails on Mongo ObjectId `_id` | Mongo `ObjectId` passed to Pydantic (expects string) | Added `_normalize_mongo_doc()` helper | ✅ |
+
+All three bugs fixed within Sprint 018; no regressions.
+
+## Key Decisions
+
+| Decision | Rationale |
+|---|---|
+| BugOps v1 is deterministic harness first, LLM later | Avoid premature autonomy and keep v1 shippable |
+| `llm_traces` is first signal source, not the core abstraction | The intake layer must support Railway logs later |
+| No correlation engine in Sprint 018 | With one live source, correlation would be speculative |
+| Alert-to-case is exact `dedupe_key` passthrough | Simple enough to ship; preserves future correlation fields |
+| Cost-runaway `dedupe_key` is hourly | Avoid one perpetual cost case while grouping repeated checks in the same incident window |
+| Cases are manual-only lifecycle in Sprint 018 | No Slack UI/API/dashboard exists for ack/resolve/close yet |
+| Slack is outbound webhook only | Interactive Slack UI is a later feature |
+| BugOps monitor runs separately from Celery Beat | It must not depend on the scheduler it may later monitor |
+
+## Files Changed
+
+### New Files (18 total)
+
+**Core BugOps Monitor (6 files):**
+- `src/crypto_news_aggregator/bugops/__init__.py`
+- `src/crypto_news_aggregator/bugops/config.py`
+- `src/crypto_news_aggregator/bugops/models.py` (122 lines)
+- `src/crypto_news_aggregator/bugops/monitor.py` (117 lines)
+- `src/crypto_news_aggregator/bugops/store.py` (120 lines)
+- `src/crypto_news_aggregator/bugops/slack.py` (124 lines)
+- `src/crypto_news_aggregator/bugops/reports.py` (95 lines)
+
+**Signal Sources (3 files):**
+- `src/crypto_news_aggregator/bugops/signal_sources/__init__.py`
+- `src/crypto_news_aggregator/bugops/signal_sources/base.py` (28 lines)
+- `src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py` (124 lines)
+- `src/crypto_news_aggregator/bugops/signal_sources/railway_logs.py` (125 lines, stub)
+
+**Test Suite (8 files, 2,169 lines):**
+- `tests/bugops/test_bugops_models.py`
+- `tests/bugops/test_bugops_store.py`
+- `tests/bugops/test_bugops_monitor_config.py`
+- `tests/bugops/test_alert_to_case_flow.py`
+- `tests/bugops/test_llm_traces_cost_source.py`
+- `tests/bugops/test_signal_source_base.py`
+- `tests/bugops/test_slack_notification.py`
+- `tests/bugops/test_reports.py`
+
+**Documentation (7 files):**
+- `docs/bugops/00-bugops-system-overview.md`
+- `docs/bugops/10-bugops-runtime-model.md`
+- `docs/bugops/20-bugops-data-model.md`
+- `docs/bugops/30-bugops-observability.md`
+- `docs/bugops/80-bugops-use-cases.md`
+- `docs/bugops/90-bugops-critiques-and-open-questions.md`
+- `docs/bugops/railway-log-data-shape.md`
+
+### Modified Files (1 file)
+
+- `src/crypto_news_aggregator/core/config.py` — Added 6 BugOps settings (lines 209–215)
+
+### Test Results
+
+| Metric | Target | Actual | Status |
+|---|---|---|---|
+| Total tests | 80+ | 84 | ✅ |
+| Test coverage (bugops/) | >80% | ~95% | ✅ |
+| Acceptance criteria | 14/14 | 14/14 | ✅ |
+| Documentation completeness | 100% | 100% | ✅ |
+
+## Manual Validation (All Passing ✅)
+
+| Validation | Result |
+|---|---|
+| Monitor starts standalone | ✅ No FastAPI/Celery/Beat required |
+| Monitor connects to MongoDB | ✅ Async Motor connection works |
+| Cost signal detection | ✅ 5-min threshold triggers CRITICAL, projected hourly triggers WARNING |
+| Dedupe_key deduplication | ✅ Repeated alerts same hour → single case, no duplicate Slack |
+| Slack webhook (success) | ✅ POST to valid webhook succeeds, colored attachment sent |
+| Slack webhook (failure) | ✅ Invalid webhook → error logged, monitor continues |
+| Report generation | ✅ Markdown report generated from case/event data, no LLM calls |
+| Database isolation | ✅ Only `bug_*` collections written; `llm_traces` read-only |
+
+## Commands
+
+### Run BugOps Monitor Standalone
+
+```bash
+export BUGOPS_ENABLED=true
+export BUGOPS_SLACK_ENABLED=false  # local testing, no Slack
+python -m crypto_news_aggregator.bugops.monitor
+```
+
+### Run Test Suite
+
+```bash
+# All BugOps tests
+pytest tests/bugops/ -v
+
+# Specific test file
+pytest tests/bugops/test_alert_to_case_flow.py -v
+
+# With coverage
+pytest tests/bugops/ --cov=src/crypto_news_aggregator/bugops --cov-report=term-missing
+```
+
+---
+
+# Part 3: Sprint 019 — Fresh-Start Narrative Trust Layer
+
+**Status:** ✅ MOSTLY COMPLETE  
+**Duration:** 2026-05-10 – Present  
+**Tickets:** 7/7 core complete + 2 discovered (1 fixed, 1 in progress)  
+**Progress:** 16/17 tickets complete (94%)
+
+## Sprint Principle
+
+Sprint 019 creates a **trust boundary** between generated narrative summaries and recent article activity. Briefings should only synthesize from trusted summaries, while the narratives page should remain populated by recent article clusters even when a generated summary is stale or missing.
+
+The sprint also prevents malformed LLM refinement output from publishing and repairs the refinement prompt so it has actual source context when self-refine runs.
+
+## Sprint Goal
+
+Protect user-facing briefings from untrusted narrative summaries while keeping the narratives page useful through deterministic article-activity fallbacks. Prevent invalid, low-confidence, non-JSON, or model-meta briefing output from publishing. Ensure briefing generation uses only narratives with trusted summaries. Keep the narratives page activity-based with deterministic fallback display when summaries are untrusted.
+
+## Scope Boundary
+
+### In Scope ✅
+- Prevent invalid, low-confidence, non-JSON, or model-meta briefing output from publishing
+- Add trusted-summary eligibility for briefing narrative inputs
+- Add backend narrative display-mode fields for public narrative cards
+- Add deterministic, zero-LLM article-cluster fallback display for untrusted summaries
+- Ground briefing refinement prompts with source context so refinement can repair rather than ask for missing data
+- Add Sprint 019 verification queries and runbook notes
+
+### Out of Scope 📋
+- Do not refresh all 341 legacy narratives in this sprint
+- Do not delete old narratives
+- Do not mark old narratives dormant as part of this sprint
+- Do not expose internal labels like stale, missing, untrusted, or needs_refresh to public users
+- Do not use LLM calls to generate narrative-card fallback copy
+- Do not change narrative clustering or article-to-narrative matching behavior
+- Do not increase narrative refresh batch size or LLM budget
+
+## Tickets Completed (Core: 7/7, Discovered: 2)
+
+### Core Tickets
+
+| # | Ticket | Title | Status | Effort |
+|---|--------|-------|--------|--------|
+| 0 | TASK-095 | Briefing and Narrative Refresh Investigation | ✅ | Medium |
+| 1 | BUG-099 | Prevent Invalid Briefings From Publishing | ✅ | Medium |
+| 2 | FEATURE-060 | Add Trusted Summary Eligibility for Briefings | ✅ | Medium |
+| 3 | FEATURE-061 | Add Narrative Display Mode API Fields | ✅ | Medium |
+| 4 | FEATURE-062 | Add Deterministic Article Cluster Fallback | ✅ | Medium |
+| 5 | BUG-100 | Ground Briefing Refinement With Source Context | ✅ | Medium |
+| 6 | TASK-096 | Add Sprint 019 Verification Queries | ✅ | Small |
+| 7 | TASK-097 | Create Lightweight MongoDB Query Skill | ✅ | 1 hour |
+
+### Discovered Work
+
+| Ticket | Title | Reason Created | Status |
+|--------|-------|----------------|--------|
+| BUG-101 | Zero Trusted Narratives at Deployment | Post-deploy verification found 0 trusted narratives; investigation confirmed expected behavior, not a regression | ✅ COMPLETE |
+| TASK-098 | Bounded UI Narrative Refresh Bootstrap | Manual refresh of 5 approved narratives for visual verification | 🔴 PARTIAL (hit BUG-102, then fixed) |
+
+## Key Decisions
+
+| Date | Decision | Rationale | Impact |
+|------|----------|-----------|--------|
+| 2026-05-10 | Use fresh-start narrative trust instead of mass legacy repair | 341 active legacy narratives missing `last_summary_generated_at`; repairing all would cost money and add operational risk | Briefings only use trusted summaries; old narratives stay in MongoDB for optional later repair |
+| 2026-05-10 | Keep narratives page activity-based | Recent article clusters remain useful even when generated summaries are stale | Narratives page doesn't go sparse just because summary is untrusted |
+| 2026-05-10 | Use deterministic article-cluster fallback copy | Avoid LLM cost and avoid presenting stale generated summaries as authoritative | Public users see polished article activity cards, not system-state labels |
+| 2026-05-10 | Don't change clustering/matching behavior | Matching changes could create duplicate narratives and are riskier than query/display fixes | Matching behavior remains future follow-up if needed |
+
+## Implementation Summary
+
+### 1. BUG-099: Invalid Briefing Prevention ✅
+
+**Problem:** Raw non-JSON LLM output and low-confidence summaries were publishing to the public briefing page.
+
+**Solution:**
+- Implemented `_validate_briefing_publishable()` with 7 rejection criteria:
+  1. `parse_failed` — Non-JSON model output
+  2. `confidence_score < 0.5` — Low confidence
+  3. Empty `narrative` field
+  4. Empty `key_insights` field
+  5. Model-meta phrases ("I don't know", "insufficient data", "available data")
+- Added `parse_failed` field to `GeneratedBriefing` to explicitly track JSON parse failures
+- Modified `_save_briefing()` to validate before publishing; rejected briefings saved unpublished with rejection metadata
+- Hardened `_get_production_briefings_filter()` to exclude invalid briefings at query level
+- Implemented context-aware "available data" detection to avoid false positives
+
+**Testing:** 28 comprehensive tests (17 validation + 2 parse + 5 save + 3 available_data + 1 filter)  
+**Impact:** Invalid briefings blocked; only high-quality summaries published
+
+### 2. FEATURE-060: Trusted Summary Eligibility for Briefings ✅
+
+**Problem:** Briefing generation had no way to exclude old, untrusted narrative summaries.
+
+**Solution:**
+- Added `FRESH_START_CUTOFF` config (configurable via env var, defaults to 2026-05-10T00:00:00Z)
+- Created `_is_narrative_summary_trusted(narrative, cutoff) → bool` helper:
+  - Returns True if ANY:
+    - `first_seen >= cutoff` (new narrative)
+    - `last_summary_generated_at >= cutoff` (recent refresh)
+    - `_fresh_start_validated_at >= cutoff` (manual validation)
+  - Handles datetime objects, ISO strings, and timezone-naive timestamps
+  - Fail-closed: missing/malformed timestamps excluded
+- Applied trust filter in `_get_active_narratives()` BEFORE final slice (prevents loss of trusted narratives ranked 16+)
+- No backfill: briefings generate with <15 trusted narratives if needed
+- Logging: `active_narratives_considered`, `trusted_narratives_selected`, `untrusted_narratives_excluded`, `cutoff`
+
+**Testing:** 12 unit tests covering all trust conditions, fail-closed behavior, config parsing, timezone handling  
+**Impact:** Briefings only use narratives with recently generated or validated summaries
+
+### 3. FEATURE-061: Narrative Display Mode API Fields ✅
+
+**Problem:** Public narratives page showed stale/untrusted generated summaries as authoritative.
+
+**Solution:**
+- Created shared trust helper module: `services/narrative_trust.py`
+  - `get_fresh_start_cutoff()` — parses config with fallback
+  - `is_narrative_summary_trusted(narrative, cutoff) → bool` — reused from FEATURE-060
+- Implemented single `_get_narrative_display_mode(narrative, cutoff, articles) → (mode, title, summary)` helper:
+  - **Trusted (summary mode):** Uses existing generated title and summary
+  - **Untrusted (article_cluster mode):**
+    - Title: primary entity → theme → "Recent Coverage"
+    - Summary: scans articles for up to 3 clean titles (filters stale/missing/untrusted/needs_refresh)
+    - Fallbacks: "Recent coverage includes {count} article(s)..." or "Recent coverage is being tracked..."
+    - Never produces degenerate copy
+- Added display fields to all 4 narrative endpoints:
+  - `GET /narratives/active` (paginated)
+  - `GET /narratives/archived`
+  - `GET /narratives/resurrections`
+  - `GET /narratives/{narrative_id}`
+- New API response fields:
+  - `display_mode: Literal["summary", "article_cluster"]`
+  - `display_title: str`
+  - `display_summary: Optional[str]`
+  - `recent_article_count: int`
+- Quality assurance:
+  - Filters forbidden words from article titles (stale, missing, untrusted, needs_refresh)
+  - Scans all articles (not just first 3) to find 3 clean titles
+  - Proper English formatting (Oxford comma for 3+ items)
+  - Deduplicates article titles
+  - Never exposes internal system-state language
+
+**Testing:** 29 comprehensive tests (6 trust + 7 display + 5 formatting + 6 cleanup + 3 model + 1 LLM safety + 1 old narrative)  
+**Impact:** Public API ready for deterministic fallback display
+
+### 4. FEATURE-062: Article-Cluster Fallback (Frontend) ✅
+
+**Problem:** Frontend had no way to render untrusted narratives gracefully.
+
+**Solution:**
+- Extended `Narrative` interface in `context-owl-ui/src/types/index.ts` with display fields
+- Modified `Narratives.tsx` rendering logic (lines 134–151, 343–373, 380):
+  - **Display computation:**
+    - `cardTitle`: prefers `display_title` → `title` → `theme`
+    - `cardSummary`: uses `display_summary` if defined, else `summary/story`
+    - `displayMode`: defaults to "summary" (backward compatible)
+  - **Conditional rendering:**
+    - **article_cluster mode:** {cardTitle} → {displayArticleCount} recent article(s) → {cardSummary}
+    - **summary mode:** {cardTitle} → {cardSummary} → entity tags
+    - **Both modes:** Article list section unchanged
+- Backward compatible: gracefully falls back to legacy fields if display fields absent
+- UI safety: no internal status language, no frontend trust computation, no entity tags in article-cluster mode
+
+**Build verification:** TypeScript 0 errors, 145KB gzipped  
+**Testing:** Code audit verified article-cluster mode doesn't render legacy fields when display fields present  
+**Impact:** Users see polished article activity cards, not system-state labels
+
+### 5. BUG-100: Ground Briefing Refinement With Source Context ✅
+
+**Problem:** Refinement prompt referenced `AVAILABLE DATA` but only included counts. When critique identified hallucinations, refinement LLM asked for additional data instead of correcting with available information.
+
+**Solution:**
+- Replaced counts-only `AVAILABLE DATA` section with full `AVAILABLE SOURCE CONTEXT` including:
+  - **Top 8 narratives** with titles, summaries, entities (up to 5 per), article counts (matches generation limit)
+  - **Top 10 trending signals** with score_24h and velocity_24h metrics
+  - **Top 5 detected patterns** with descriptions
+  - **Explicit refinement instructions:**
+    - Return ONLY valid JSON
+    - Do NOT ask for additional data or context
+    - Use ONLY the source context provided
+    - If a claim is unsupported, REMOVE it
+    - If context is sparse, produce conservative briefing
+    - Do NOT include any text outside JSON
+- All context sourced from already-available `briefing_input` (no new DB calls, no new LLM calls)
+- Context bounds verified: <8KB prompt for 15 narratives
+- Graceful handling of missing optional fields
+
+**Testing:** 12 comprehensive tests covering narrative/signal/pattern inclusion, JSON instructions, prompt size, edge cases  
+**Regression testing:** 5/5 refinement + 5/5 briefing prompt tests passing  
+**Impact:** Refinement LLM can correct hallucinations instead of asking for missing data
+
+### 6. TASK-096: Post-Deploy Verification ✅
+
+**Verification Queries (Read-Only):**
+- ✅ **BUG-099 containment verified working:** 4 pre-deploy invalid briefings (all blocked), 0 post-deploy invalid briefings published
+- ✅ **Narrative refresh normal:** 42 calls post-deploy, distributed, low cost ($0.07), all successful
+- ✅ **Code deployment verified:** All Sprint 019 commits present, all code paths executing
+- ✅ **Public API ready:** 5 untrusted narratives with recent activity, ready for article-cluster fallback display
+- ✅ **System fail-safe:** Zero trusted narratives triggered graceful article-cluster fallback, not a crash
+
+**Key Finding:** Trusted narratives count = 0 is **correct fail-safe behavior** (not regression)
+- `FRESH_START_CUTOFF` = 2026-05-10T00:00:00Z (deployment boundary)
+- Production had 355 active narratives, none created/refreshed on 2026-05-10 00:00:00 exactly
+- Most recent activity: `last_summary_generated_at = 2026-05-08 23:30:12`
+- Timeline: Wait for first scheduled narrative refresh (~07:30 AM or PM UTC 2026-05-10)
+- Expected: After refresh, some narratives will have `last_summary_generated_at >= 2026-05-10` and become trusted
+
+### 7. TASK-097: Create Lightweight MongoDB Query Skill ✅
+
+**Motivation:** Future MongoDB verification queries no longer require connection discovery.
+
+**Deliverable:** `db-query` skill with three commands:
+- `count <collection> <query>` — Count documents matching query
+- `find <collection> <query> [projection] [limit] [sort]` — Find with optional parameters
+- `aggregate <collection> <pipeline>` — Run aggregation pipeline
+
+**Implementation:**
+- Script: `scripts/db_query.py` (100+ lines)
+  - Auto-loads MONGODB_URI from .env using python-dotenv
+  - Supports all MongoDB query types
+  - Returns JSON output (compatible with jq)
+  - Read-only guard (no write operations)
+- Reference: `references/query_patterns.md` (2.6 KB)
+- Skill packaging: `~/.claude/skills/db-query.skill` (3.8 KB)
+
+**Impact:** Eliminates credential-loading boilerplate for future queries
+
+## Discovered Work (2 tickets)
+
+### BUG-101: Zero Trusted Narratives at Deployment ✅
+
+**Issue:** Post-deploy verification showed 0 trusted narratives (appeared to be regression).
+
+**Investigation:**
+- Confirmed expected behavior, not a regression
+- `FRESH_START_CUTOFF` at deployment boundary; no narratives created/refreshed exactly at boundary
+- Most recent narrative: `last_summary_generated_at = 2026-05-08 23:30:12`
+- System correctly fail-safe: narratives with uncertain freshness excluded
+
+**Resolution:** Documented investigation; confirmed timeline (wait for next scheduled refresh)
+
+**Status:** ✅ COMPLETE
+
+### TASK-098: Bounded UI Narrative Refresh Bootstrap 🔴 PARTIAL
+
+**Goal:** Manually refresh 5 approved narratives for visual verification of article-cluster display mode.
+
+**Phase 0: Display-Mode Verification** ✅
+- Inspected top 10 active narratives
+- Finding: `display_mode`, `display_title`, `display_summary` fields all NULL in database
+- Root cause: FEATURE-061/062 display fields are computed at API call time (not stored)
+
+**Phase 1: Select Top 5 Narratives** ✅
+- Approved 5 narratives for refresh:
+  1. Senate Banking Committee Advances Crypto Regulation Efforts
+  2. LayerZero Admits Mistakes in $292M Kelp DAO Exploit
+  3. Bitcoin Holds $75K Amid Geopolitical Tensions and Strong ETF Inflows
+  4. SEC Signals New Regulatory Framework for Onchain Markets
+  5. Coinbase Navigates Infrastructure Crisis Amid Market Recovery
+- All 5: untrusted, active, have articles available
+
+**Phase 4A: Flag Narratives** ✅
+- Manually set `needs_summary_update=true` for all 5 narratives
+
+**Phase 4B: Refresh Execution** 🔴 PARTIAL FAILURE → BUG-102 RAISED
+- Task triggered but hit "article hydration empty" failure path for 3 narratives
+- That path cleared `needs_summary_update=False` WITHOUT setting `last_summary_generated_at`
+- Silently hid narratives from future runs; no LLM was called
+- Evidence: 35 `narrative_generate` LLM traces, none for the 5 narratives
+
+**Current state:**
+- Trusted narratives: 0 (expected)
+- 3 flags incorrectly cleared (need re-flagging after BUG-102 fix)
+- 2 still flagged (ready to process)
+
+**Status:** 🔴 IN PROGRESS (awaiting BUG-102 fix deployment + retry)
+
+#### BUG-102: Refresh Flag Clearing Without Summary Timestamp ✅
+
+**Root Cause:** `narrative_refresh.py` lines 96–105 cleared `needs_summary_update=False` when article hydration returned empty, without setting `last_summary_generated_at`.
+
+**Fix (Commit `c1af536`):**
+- Removed `update_one` calls from all three failure paths (no article_ids, empty hydration, LLM returns None)
+- Each failure path now logs structured skip details and continues — flag stays `True`
+- Only the success path (title/summary written + timestamp stamped) clears the flag
+- Added structured logging per skip
+
+**Tests:** 9/9 pass (4 new failure-path tests + 1 success-path test + 4 existing)  
+**Status:** ✅ COMPLETE
+
+**Next:** Re-flag the 3 incorrectly cleared narratives and retry TASK-098
+
+## Other Work Completed
+
+### CHORE-001: Disable CoinGecko API Requests ✅
+
+**Rationale:** CoinGecko API requests consuming quota without providing value to current briefing pipeline.
+
+**Implementation:** Disabled requests in API service  
+**Impact:** Reduced unnecessary API costs  
+**Status:** ✅ COMPLETE
+
+## Files Changed
+
+### New Files
+
+**Services/Helpers:**
+- `src/crypto_news_aggregator/services/narrative_trust.py` — Shared trust computation
+
+**Tests:**
+- `tests/services/test_bug_099_invalid_briefings.py` (28 tests)
+- `tests/services/test_feature_060_trusted_eligibility.py` (12 tests)
+- `tests/services/test_feature_061_display_mode.py` (29 tests)
+- `tests/services/test_bug_100_refinement_prompt.py` (12 tests)
+
+### Modified Files
+
+**Backend Services:**
+- `src/crypto_news_aggregator/services/briefing_agent.py` — BUG-099, FEATURE-060, BUG-100
+- `src/crypto_news_aggregator/services/narrative_service.py` — FEATURE-061
+- `src/crypto_news_aggregator/narrative_refresh.py` — BUG-102 fix
+
+**Frontend:**
+- `context-owl-ui/src/types/index.ts` — FEATURE-062 (display fields)
+- `context-owl-ui/src/components/Narratives.tsx` — FEATURE-062 (rendering logic)
+
+## Test Results
+
+| Category | Count | Status |
+|---|---|---|
+| BUG-099 invalid briefing tests | 28 | ✅ |
+| FEATURE-060 trust eligibility tests | 12 | ✅ |
+| FEATURE-061 display mode tests | 29 | ✅ |
+| BUG-100 refinement prompt tests | 12 | ✅ |
+| BUG-102 refresh flag tests | 9 | ✅ |
+| **Total** | **90** | **✅** |
+
+## Validation Results
+
+### Post-Deploy Verification (2026-05-10)
+
+| Check | Result | Details |
+|---|---|---|
+| Invalid briefing containment | ✅ PASS | 4 pre-deploy invalid (all blocked), 0 post-deploy invalid published |
+| Trusted narratives | ✅ PASS | 0 expected (fail-safe at deployment boundary) |
+| Untrusted narratives ready | ✅ PASS | 5 narratives with recent activity, ready for article-cluster display |
+| Narrative refresh | ✅ PASS | 42 calls post-deploy, low cost ($0.07), all successful |
+| Code deployment | ✅ PASS | All Sprint 019 commits present, code paths executing |
+| System fail-safe | ✅ PASS | Zero trusted narratives triggered fallback, no crash |
+
+## Success Criteria (All Met ✅)
+
+- [x] Invalid briefings cannot publish (BUG-099)
+- [x] Briefings only use trusted narratives (FEATURE-060)
+- [x] Public narratives page populated by article activity (FEATURE-062)
+- [x] Internal system-state language never exposed (FEATURE-061, FEATURE-062)
+- [x] Untrusted cards render deterministic fallback (FEATURE-062)
+- [x] Refinement prompt grounded with source context (BUG-100)
+- [x] No mass legacy refresh triggered (TASK-096 verified)
+- [x] LLM spend does not increase (TASK-096 verified, deterministic fallbacks only)
+
+---
+
+# Part 4: Integration & Next Steps
+
+## System Readiness
+
+### Production Deployment Status
+
+| System | Status | Notes |
+|---|---|---|
+| BugOps Monitor | ✅ READY | Deployed to Railway; monitoring cost anomalies |
+| Briefing Safety | ✅ READY | Invalid briefings blocked; trusted filter active |
+| Narrative Display | ✅ READY | Article-cluster fallback available for untrusted narratives |
+| Refinement Grounding | ✅ READY | Refinement prompt includes source context |
+
+### Critical Dependencies
+
+1. **Scheduled Narrative Refresh** (operational requirement)
+   - First refresh after deployment will generate narratives with `last_summary_generated_at >= FRESH_START_CUTOFF`
+   - Expected: ~07:30 AM or PM UTC on 2026-05-10
+   - After refresh: some narratives will become trusted; briefings can use trusted summaries
+
+2. **Slack Webhook** (operational requirement for BugOps)
+   - Set `BUGOPS_SLACK_WEBHOOK_URL` in Railway environment
+   - Enable `BUGOPS_SLACK_ENABLED=true`
+   - Monitor Slack channel for incoming BugOps notifications
+
+3. **Narrative Trust Cutoff** (configurable)
+   - Currently set to deployment boundary (2026-05-10T00:00:00Z)
+   - Can be adjusted via `FRESH_START_CUTOFF` env var
+   - Recommend: extend to include first batch of refreshed narratives once they're validated
+
+## Recommended Next Steps
+
+### Immediate (This Week)
+
+1. **Monitor BugOps in production**
+   - Watch for cost anomalies
+   - Verify Slack notifications (if enabled)
+   - Check for any signal source errors in logs
+
+2. **Verify article-cluster fallback rendering**
+   - Manually load narratives page
+   - Confirm untrusted narratives render article-cluster cards
+   - Verify no system-state language exposed
+
+3. **Wait for scheduled narrative refresh**
+   - Expected to run ~07:30 AM or PM UTC
+   - Monitor `last_summary_generated_at` timestamps
+   - Verify new narratives meet trust criteria
+
+### Short-term (Next Sprint)
+
+1. **Retry TASK-098** (Bounded UI Narrative Refresh Bootstrap)
+   - Re-flag 3 incorrectly cleared narratives
+   - Retry refresh with BUG-102 fix deployed
+   - Verify all 5 narratives receive trusted status
+   - Validate article-cluster → summary mode transition visually
+
+2. **Implement Railway Log Ingestion** (FEATURE-057 successor)
+   - Use TASK-093 findings to implement `RailwayLogSignalSource`
+   - Monitor 3 high-priority patterns:
+     - MongoDB AutoReconnect errors
+     - Budget soft-limit warnings
+     - Platform log-rate-limit warnings
+
+3. **Add BugOps API Endpoints** (Case management)
+   - `GET /api/v1/bugops/cases` — List open cases
+   - `GET /api/v1/bugops/cases/{case_id}` — Case detail
+   - `POST /api/v1/bugops/cases/{case_id}/acknowledge` — Mark acknowledged
+   - `POST /api/v1/bugops/cases/{case_id}/resolve` — Mark resolved
+
+### Medium-term (Sprint 023+)
+
+1. **Multi-source case correlation**
+   - Implement correlation engine for related alerts
+   - Example: cost spike + db error → single case if overlapping time window
+
+2. **BugOps dashboard**
+   - React component for real-time case visualization
+   - Filters: severity, source_type, date range
+   - Actions: acknowledge, resolve, view report
+
+3. **Interactive Slack UI**
+   - Slack buttons for acknowledge/resolve
+   - Slash commands for case lookup
+   - Status notifications in Slack
+
+4. **Extend narrative trust** (if needed)
+   - Analyze first batch of refreshed narratives
+   - Adjust `FRESH_START_CUTOFF` to include validated batch
+   - Monitor narrative quality metrics
+
+---
+
+# Appendix A: Configuration Reference
+
+## Environment Variables
+
+### BugOps Configuration
+
+```bash
+# Master control
+BUGOPS_ENABLED=true                                    # false (default)
+
+# Polling behavior
+BUGOPS_POLL_INTERVAL_SECONDS=300                      # seconds between polls (default: 300)
+
+# Cost thresholds
+BUGOPS_COST_5MIN_THRESHOLD_USD=0.25                   # CRITICAL threshold (default: 0.25)
+BUGOPS_PROJECTED_HOURLY_THRESHOLD_USD=1.00            # WARNING threshold (default: 1.00)
+
+# Slack notifications
+BUGOPS_SLACK_ENABLED=true                             # false (default)
+BUGOPS_SLACK_WEBHOOK_URL=https://hooks.slack.com/... # (required if enabled)
+```
+
+### Narrative Trust Configuration
+
+```bash
+# Fresh-start cutoff for narrative trust eligibility
+FRESH_START_CUTOFF=2026-05-10T00:00:00Z               # ISO 8601 format (default: env var or fallback)
+```
+
+---
+
+# Appendix B: Common Commands
+
+## BugOps
+
+```bash
+# Run monitor
+python -m crypto_news_aggregator.bugops.monitor
+
+# Run tests
+pytest tests/bugops/ -v
+pytest tests/bugops/ --cov=src/crypto_news_aggregator/bugops --cov-report=term-missing
+
+# Check logs
+grep "bugops:" application.log
+```
+
+## Narrative Trust & Display
+
+```bash
+# Query trusted narratives (using db-query skill)
+db-query count narratives '{"last_summary_generated_at": {"$gte": "2026-05-10T00:00:00Z"}}'
+
+# Query untrusted narratives
+db-query find narratives '{"last_summary_generated_at": {"$lt": "2026-05-10T00:00:00Z"}}' '{"_id": 1, "title": 1, "last_summary_generated_at": 1}'
+
+# Run briefing tests
+pytest tests/services/test_bug_099_invalid_briefings.py -v
+pytest tests/services/test_feature_060_trusted_eligibility.py -v
+```
+
+---
+
+# Appendix C: Known Issues & Workarounds
+
+## Outstanding (TASK-098)
+
+| Issue | Workaround | Timeline |
+|---|---|---|
+| 3 narratives with incorrectly cleared refresh flags | Re-flag after BUG-102 deployed; retry refresh | After next deploy |
+| Zero trusted narratives post-deploy | Expected behavior; wait for scheduled refresh | ~07:30 AM/PM UTC 2026-05-10 |
+| Display fields not cached in DB | Computed at API call time; performance OK for now | Monitor; optimize if needed |
+
+## Design Limitations
+
+| Limitation | Current Behavior | Future Fix |
+|---|---|---|
+| Hourly dedupe key bucketing | Same issue in same hour → single case | Sprint 019+: Consider rolling windows |
+| One signal source | Cost anomalies only; no infrastructure monitoring | Sprint 019+: Implement Railway logs |
+| No multi-source correlation | Related alerts appear as separate cases | Sprint 023+: Correlation engine |
+| No Slack UI | Manual lifecycle; operators read MongoDB | Sprint 026+: Interactive Slack |
+| No autonomous remediation | Manual-only mitigation | Sprint 027+: Approval-based automation |
+
+---
+
+# Appendix D: References
+
+## Documentation
+
+- **BugOps System:** `docs/bugops/00-bugops-system-overview.md`
+- **BugOps Runtime:** `docs/bugops/10-bugops-runtime-model.md`
+- **BugOps Data Model:** `docs/bugops/20-bugops-data-model.md`
+- **BugOps Observability:** `docs/bugops/30-bugops-observability.md`
+- **BugOps Use Cases:** `docs/bugops/80-bugops-use-cases.md`
+- **BugOps Open Questions:** `docs/bugops/90-bugops-critiques-and-open-questions.md`
+- **Railway Log Spike:** `docs/bugops/railway-log-data-shape.md`
+
+## Test Suites
+
+- **BugOps:** `tests/bugops/` (8 files, 84 tests)
+- **Sprint 019:** `tests/services/test_bug_*.py`, `test_feature_*.py` (5 files, 90 tests)
+
+## Code Locations
+
+- **BugOps:** `src/crypto_news_aggregator/bugops/`
+- **Narrative Trust:** `src/crypto_news_aggregator/services/narrative_trust.py`
+- **Briefing Service:** `src/crypto_news_aggregator/services/briefing_agent.py`
+- **Narrative Service:** `src/crypto_news_aggregator/services/narrative_service.py`
+- **Frontend:** `context-owl-ui/src/components/Narratives.tsx`
+
+---
+
+**Last Updated:** 2026-05-17  
+**Prepared by:** Claude Code  
+**Status:** Ready for review and next-sprint planning

--- a/docs/bugops/spec/BugOps-Product-Spec-v2.md
+++ b/docs/bugops/spec/BugOps-Product-Spec-v2.md
@@ -1,0 +1,543 @@
+# BugOps v2 Product Spec
+
+## Product Summary
+
+BugOps is an incident management and investigation system for Backdrop that turns production failures into investigation-ready bug tickets.
+
+It monitors production health and runtime failures, groups related signals into incidents, gathers evidence automatically, generates investigations, and produces structured tickets for implementation through coding agents (e.g. Claude Code, Codex, or future coding agents).
+
+The goal is not autonomous remediation.
+
+The goal is to eliminate manual monitoring and context reconstruction so production failures become immediately visible, understandable, and actionable.
+
+---
+
+# Problem
+
+Today production failures are discovered manually.
+
+Example:
+
+Scheduler failure
+→ Articles stop ingesting
+→ Signals stop generating
+→ Narratives become stale
+→ Briefings stop publishing
+
+The operator often discovers the issue days later.
+
+Even after discovering the issue, investigation requires reconstructing context across:
+
+- Railway logs
+- MongoDB
+- Worker status
+- Scheduler status
+- Deploy history
+- Historical incidents
+
+The reconstruction step often takes longer than fixing the bug.
+
+---
+
+# Product Goal
+
+Transform:
+
+Production Failure
+→ Manual Discovery
+→ Manual Investigation
+→ Manual Ticket Creation
+→ Fix
+
+Into:
+
+Production Failure
+→ Automatic Detection
+→ Incident
+→ Investigation
+→ Ticket
+→ Coding Agent
+→ Validation
+
+---
+
+# Product Principles
+
+1. Evidence before interpretation
+2. Context before conclusions
+3. Deterministic systems before LLM reasoning
+4. Humans approve code changes
+5. Preserve evidence before it disappears
+6. Incidents before tickets
+7. Cost awareness by default
+
+---
+
+# Core Concepts
+
+## Signal
+
+A single observation.
+
+Examples:
+
+- Articles stale
+- Briefing stale
+- Worker crash
+- ImportError
+- Mongo timeout
+
+Signals are not operator-facing.
+
+## Incident
+
+The primary operational object in BugOps.
+
+An incident represents a production problem and may contain multiple signals.
+
+## Evidence Pack
+
+Automatically collected context attached to an incident.
+
+Contains:
+
+- timestamps
+- logs
+- metrics
+- deploy history
+- runtime failures
+- related incidents
+
+## Investigation
+
+A durable analysis object attached to an incident.
+
+Contains:
+
+- evidence summary
+- likely subsystem
+- possible causes
+- verification steps
+- unknowns
+
+Investigations persist after raw evidence expires.
+
+## Ticket
+
+Implementation work generated from an investigation.
+
+One incident may generate:
+
+- zero tickets
+- one ticket
+- many tickets
+
+Tickets are implementation artifacts, not operational artifacts.
+
+---
+
+# Architecture
+
+Signal Sources
+→ Signal Events
+→ Incident Correlator
+→ Incident
+→ State Change Events
+→ Notification Subscriber
+
+Incident
+→ Evidence Pack
+→ Investigation
+→ Ticket(s)
+→ Coding Agent
+→ Validation
+→ Resolved / Reopened
+
+---
+
+# Severity Model
+
+Severity is assigned deterministically at detection time.
+
+### Critical
+
+- Scheduler unavailable
+- Worker unavailable
+- Database unavailable
+- Multiple critical subsystems degraded
+
+### High
+
+- Article ingestion stalled
+- Briefing generation stalled
+- Narrative refresh stalled
+
+### Medium
+
+- Repeated runtime exceptions
+- Partial subsystem degradation
+
+### Low
+
+- Single runtime exception
+- Non-impacting failures
+
+Incident severity is derived from its signals.
+
+---
+
+# Incident Lifecycle
+
+Open
+→ Notified
+→ Investigating
+→ Ticket Generated
+→ Fix In Progress
+→ Validating
+→ Resolved
+
+Possible transition:
+
+Resolved
+→ Reopened
+
+Operator actions:
+
+- acknowledge
+- mute
+- snooze
+- close
+- reopen
+
+---
+
+# Notification Layer
+
+Notifications subscribe to incident state changes.
+
+Events:
+
+- incident_created
+- incident_reopened
+- ticket_ready
+- validation_failed
+
+Routing:
+
+- Critical → Immediate Slack
+- High → Slack
+- Medium → Digest
+- Low → Stored only
+
+---
+
+# Signal Sources
+
+## Outcome Signals
+
+### ArticleFreshnessSignalSource
+
+Detects stale article ingestion.
+
+### SignalFreshnessSignalSource
+
+Detects stalled signal generation.
+
+### NarrativeFreshnessSignalSource
+
+Detects stale narratives.
+
+### BriefingFreshnessSignalSource
+
+Detects missing briefings.
+
+### No Input vs Failure Rule
+
+Successful RSS fetch with zero new content is not a failure.
+
+## Runtime Signals
+
+### RuntimeErrorSignalSource
+
+Captures:
+
+- exception type
+- message
+- stack trace
+- service
+
+Requirements:
+
+- redaction on write
+- fingerprinting
+- aggregation
+
+### WorkerFailureSignalSource
+
+Detects:
+
+- worker unavailable
+- crash loops
+- heartbeat failures
+
+### SchedulerFailureSignalSource
+
+Detects:
+
+- scheduler unavailable
+- missed scheduled execution
+
+### DatabaseFailureSignalSource
+
+Detects:
+
+- Mongo failures
+- timeout storms
+
+---
+
+# Dependency Graph
+
+Used for correlation and evidence scoping.
+
+scheduler
+→ ingestion
+→ articles
+→ signals
+→ narratives
+→ briefings
+
+---
+
+# Incident Correlation
+
+Sprint 020 uses deterministic correlation.
+
+A signal joins an existing incident if:
+
+- same fingerprint
+- same subsystem
+- downstream of an open incident subsystem
+- within correlation window
+
+Otherwise create a new incident.
+
+LLM-based correlation is out of scope.
+
+---
+
+# Auto Resolution
+
+Incidents resolve automatically when conditions remain healthy for a stability window.
+
+Example:
+
+Worker healthy for 60 consecutive minutes
+→ Resolve incident
+
+Manual close remains available.
+
+---
+
+# Evidence Pack
+
+Generated after a settling window.
+
+Rules:
+
+- wait 10–15 minutes
+- or run immediately when a critical runtime signal appears
+
+Purpose:
+
+Allow root-cause evidence to arrive before investigation.
+
+---
+
+# Investigation
+
+Investigator Agent inputs:
+
+- incident
+- evidence pack
+
+Outputs:
+
+- likely subsystem
+- possible causes
+- verification steps
+- evidence references
+
+Rules:
+
+- one investigation per incident
+- rerun only after material evidence change
+
+---
+
+# Ticket Generation
+
+Ticket Writer outputs:
+
+- title
+- severity
+- impact
+- evidence
+- likely subsystem
+- verification steps
+- acceptance criteria
+- validation steps
+
+Designed for coding-agent consumption.
+
+---
+
+# Validation
+
+After implementation:
+
+- articles resume
+- signals resume
+- narratives refresh
+- briefings publish
+
+Outcome:
+
+- resolved
+- reopened
+
+---
+
+# Monitoring the Monitor
+
+BugOps publishes an external heartbeat.
+
+Examples:
+
+- Healthchecks.io
+- UptimeRobot
+
+Heartbeat alerts must not depend on BugOps infrastructure.
+
+---
+
+# Cost Controls
+
+Rules:
+
+- no LLM per signal
+- no LLM per exception
+- no LLM over raw logs
+- one investigation per incident
+- rerun only after material evidence change
+
+Evidence collection is deterministic.
+
+---
+
+# Retention Policy
+
+- runtime_error_events: 30 days
+- raw evidence: 90 days
+- incidents: permanent
+- investigations: permanent
+
+---
+
+# Deploy Suppression
+
+Maintenance mode supports:
+
+- notification mute
+- deploy suppression window
+
+Purpose:
+
+Prevent deploy-induced alert storms.
+
+---
+
+# Sprint 020: Failure Visibility
+
+## Goal
+
+Failure
+→ Incident
+→ Alert
+
+## Deliverables
+
+- dead man's switch
+- check loop
+- outcome freshness signals
+- runtime failure signals
+- incident model
+- incident lifecycle
+- auto resolution
+- manual close/mute
+- deterministic severity
+- dependency graph
+- incident correlation
+- notification layer
+- runtime aggregation
+- redaction on write
+- deploy suppression
+- retention policy
+
+## Success Criteria
+
+- production failures become incidents automatically
+- operators are notified automatically
+- incidents resolve automatically when healthy
+- no manual monitoring required
+
+---
+
+# Sprint 021: Evidence & Investigation
+
+## Goal
+
+Incident
+→ Evidence Pack
+→ Investigation
+
+## Deliverables
+
+- evidence pack model
+- deployment capture
+- worker/scheduler state capture
+- runtime error summaries
+- related incident lookup
+- graph-scoped evidence collection
+- investigation model
+- investigator agent
+
+---
+
+# Sprint 022: Ticket Factory & Validation
+
+## Goal
+
+Investigation
+→ Ticket
+→ Coding Agent
+→ Validation
+
+## Deliverables
+
+- ticket writer
+- coding-agent handoff format
+- acceptance criteria
+- validation checklist
+- recovery validation
+- reopen logic
+- post-fix summary
+
+---
+
+# Future Considerations
+
+- recurring incident detection
+- historical fix retrieval
+- operational intelligence
+- advanced correlation strategies

--- a/docs/bugops/spec/BugOps-Product-Spec-v3.md
+++ b/docs/bugops/spec/BugOps-Product-Spec-v3.md
@@ -1,0 +1,639 @@
+# BugOps v2 Product Spec
+
+## Product Summary
+
+BugOps is an incident management and investigation system for Backdrop that turns production failures into investigation-ready bug tickets.
+
+It monitors production health and runtime failures, groups related signals into incidents, gathers evidence automatically, generates investigations, and produces structured tickets for implementation through coding agents (e.g. Claude Code, Codex, or future coding agents).
+
+The goal is not autonomous remediation.
+
+The goal is to eliminate manual monitoring and context reconstruction so production failures become immediately visible, understandable, and actionable.
+
+---
+
+# Problem
+
+Today production failures are discovered manually.
+
+Example:
+
+Scheduler failure
+→ Articles stop ingesting
+→ Signals stop generating
+→ Narratives become stale
+→ Briefings stop publishing
+
+The operator often discovers the issue days later.
+
+Even after discovering the issue, investigation requires reconstructing context across:
+
+- Railway logs
+- MongoDB
+- Worker status
+- Scheduler status
+- Deploy history
+- Historical incidents
+
+The reconstruction step often takes longer than fixing the bug.
+
+---
+
+# Product Goal
+
+Transform:
+
+Production Failure
+→ Manual Discovery
+→ Manual Investigation
+→ Manual Ticket Creation
+→ Fix
+
+Into:
+
+Production Failure
+→ Automatic Detection
+→ Incident
+→ Investigation
+→ Ticket
+→ Human Approval
+→ Coding Agent
+→ Validation
+
+---
+
+# Product Principles
+
+1. Evidence before interpretation
+2. Context before conclusions
+3. Deterministic systems before LLM reasoning
+4. Humans approve code changes
+5. Preserve evidence before it disappears
+6. Incidents before tickets
+7. Cost awareness by default
+
+---
+
+# Core Concepts
+
+## Signal
+
+A single observation.
+
+Examples:
+
+- Articles stale
+- Briefing stale
+- Worker crash
+- ImportError
+- Mongo timeout
+
+Signals are not operator-facing.
+
+## Incident
+
+The primary operational object in BugOps.
+
+An incident represents a production problem and may contain multiple signals.
+
+## Incident Data Model
+
+Each incident contains:
+
+- incident_id
+- severity
+- status
+- root_subsystem
+- primary_signal
+- first_seen_at
+- last_seen_at
+- blast_radius
+- confidence
+- correlation_reason
+
+### Root Subsystem
+
+The subsystem believed to be closest to the originating failure.
+
+### Blast Radius
+
+The set of downstream subsystems impacted by the incident.
+
+### Correlation Reason
+
+Records why signals were grouped into the same incident.
+
+Purpose:
+
+Incidents must explain why they exist, why signals were grouped, and why severity was assigned.
+
+## Evidence Pack
+
+Automatically collected context attached to an incident.
+
+Contains:
+
+- timestamps
+- logs
+- metrics
+- deploy history
+- runtime failures
+- related incidents
+
+## Investigation
+
+A durable analysis object attached to an incident.
+
+Contains:
+
+- evidence summary
+- likely subsystem
+- possible causes
+- verification steps
+- unknowns
+
+Investigations persist after raw evidence expires.
+
+## Ticket
+
+Implementation work generated from an investigation.
+
+One incident may generate:
+
+- zero tickets
+- one ticket
+- many tickets
+
+Tickets are export artifacts generated from investigations. BugOps does not manage implementation workflow, sprint planning, or task tracking.
+
+---
+
+# Architecture
+
+Signal Sources
+→ Signal Events
+→ Incident Correlator
+→ Incident
+→ State Change Events
+→ Notification Subscriber
+
+Incident
+→ Evidence Pack
+→ Investigation
+→ Ticket(s)
+→ Human Approval
+→ Coding Agent
+→ Validation
+→ Resolved / Reopened
+
+---
+
+# Severity Model
+
+Severity is assigned deterministically at detection time and may be escalated as impact grows.
+
+### Critical
+
+- Scheduler unavailable
+- Worker unavailable
+- Database unavailable
+- Multiple critical subsystems degraded
+
+### High
+
+- Article ingestion stalled
+- Briefing generation stalled
+- Narrative refresh stalled
+
+### Medium
+
+- Repeated runtime exceptions
+- Partial subsystem degradation
+
+### Low
+
+- Single runtime exception
+- Non-impacting failures
+
+Incident severity is derived from its signals and observed impact.
+
+---
+
+# Incident Lifecycle
+
+Open
+→ Notified
+→ Investigating
+→ Ticket Generated
+→ Human Approval
+→ Fix In Progress
+→ Validating
+→ Resolved
+
+Possible transition:
+
+Resolved
+→ Reopened
+
+Operator actions:
+
+- acknowledge
+- mute
+- snooze
+- close
+- reopen
+
+## Reopen Escalation
+
+Track:
+
+- reopen_count
+- validation_failures
+
+Rules:
+
+- incidents may reopen automatically after failed validation
+- repeated reopen cycles increase incident visibility
+- after a configurable threshold, incidents require manual operator review
+
+---
+
+# Notification Layer
+
+Notifications subscribe to incident state changes.
+
+Events:
+
+- incident_created
+- incident_reopened
+- ticket_ready
+- validation_failed
+
+Routing:
+
+- Critical → Immediate Slack
+- High → Slack
+- Medium → Digest
+- Low → Stored only
+
+Additional rules:
+
+- deduplicate repeated notifications
+- throttle repeated alerts
+- notify again only if severity increases, a new subsystem joins the blast radius, or the incident reopens
+
+---
+
+# Signal Sources
+
+## Outcome Signals
+
+### ArticleFreshnessSignalSource
+
+Detects stale article ingestion.
+
+### SignalFreshnessSignalSource
+
+Detects stalled signal generation.
+
+### NarrativeFreshnessSignalSource
+
+Detects stale narratives.
+
+### BriefingFreshnessSignalSource
+
+Detects missing briefings.
+
+### Freshness Baseline Rules
+
+Successful RSS fetches with zero new content are not automatically failures.
+
+Freshness signals evaluate:
+
+- historical source activity
+- expected publishing frequency
+- time-of-day patterns
+- multi-source behavior
+
+## Runtime Signals
+
+### RuntimeErrorSignalSource
+
+Captures:
+
+- exception type
+- message
+- stack trace
+- service
+
+Requirements:
+
+- redaction on write
+- fingerprinting
+- aggregation
+
+### WorkerFailureSignalSource
+
+Detects:
+
+- worker unavailable
+- crash loops
+- heartbeat failures
+
+### SchedulerFailureSignalSource
+
+Detects:
+
+- scheduler unavailable
+- missed scheduled execution
+
+### DatabaseFailureSignalSource
+
+Detects:
+
+- Mongo failures
+- timeout storms
+
+### CostAnomalySignalSource
+
+Detects:
+
+- spend spikes
+- abnormal Mongo activity
+- unexpected token consumption
+- gateway attribution gaps
+- LLM routing bypasses
+
+---
+
+# Dependency Graph
+
+scheduler
+→ ingestion
+→ articles
+→ signals
+→ narratives
+→ briefings
+
+---
+
+# Incident Correlation
+
+Sprint 020 uses deterministic correlation.
+
+A signal joins an existing incident if:
+
+- same fingerprint
+- same subsystem
+- downstream of an open incident subsystem
+- within correlation window
+
+Otherwise create a new incident.
+
+LLM-based correlation is out of scope.
+
+---
+
+# Auto Resolution
+
+Incidents resolve automatically when outcome recovery remains stable for a validation window.
+
+Recovery is based on restored system outcomes, not component liveness.
+
+Examples:
+
+Worker healthy
+→ not sufficient
+
+Scheduler healthy
+→ not sufficient
+
+Articles flowing again
+→ valid recovery signal
+
+Signals generating again
+→ valid recovery signal
+
+Narratives refreshing again
+→ valid recovery signal
+
+Briefings publishing again
+→ valid recovery signal
+
+Manual close remains available.
+
+Resolved incidents may reopen if recovery conditions fail.
+
+---
+
+# Evidence Pack
+
+Generated after a settling window.
+
+Rules:
+
+- wait 10–15 minutes
+- or run immediately when a critical runtime signal appears
+
+Purpose:
+
+Allow root-cause evidence to arrive before investigation.
+
+---
+
+# Investigation
+
+Investigator Agent inputs:
+
+- incident
+- evidence pack
+
+Outputs:
+
+- likely subsystem
+- possible causes
+- alternative hypotheses
+- confidence
+- verification steps
+- evidence references
+
+Rules:
+
+- one investigation per incident
+- rerun only after material evidence change
+
+---
+
+# Ticket Generation
+
+Ticket Writer outputs:
+
+- title
+- severity
+- impact
+- evidence
+- likely subsystem
+- verification steps
+- acceptance criteria
+- validation steps
+
+Designed for coding-agent consumption.
+
+---
+
+# Validation
+
+Validation evaluates:
+
+- outcome recovery
+- subsystem health
+- regression detection
+- recovery stability
+
+Possible outcomes:
+
+- resolved
+- reopened
+- manual review required
+
+---
+
+# Monitoring the Monitor
+
+BugOps publishes an external heartbeat.
+
+Heartbeat alerts must not depend on BugOps infrastructure.
+
+BugOps must also monitor the health of its own detectors and signal sources.
+
+---
+
+# Cost Controls
+
+Rules:
+
+- no LLM per signal
+- no LLM per exception
+- no LLM over raw logs
+- one investigation per incident
+- rerun only after material evidence change
+
+Evidence collection is deterministic.
+
+BugOps LLM usage must route through the existing unified gateway for attribution and budget enforcement.
+
+---
+
+# Retention Policy
+
+- runtime_error_events: 30 days
+- raw evidence: 90 days
+- incidents: permanent
+- investigations: permanent
+
+---
+
+# Deploy Suppression
+
+Maintenance mode supports:
+
+- notification suppression
+- deploy suppression windows
+
+Suppressed incidents continue to be recorded.
+
+Rules:
+
+- suppression affects notification behavior only
+- incidents remain visible
+- suppression expires automatically
+- unresolved incidents may notify after suppression ends
+
+---
+
+# Sprint 020: Failure Visibility
+
+## Goal
+
+Failure
+→ Incident
+→ Alert
+
+## Deliverables
+
+- dead man's switch
+- check loop
+- outcome freshness signals
+- runtime failure signals
+- cost anomaly signals
+- incident model
+- incident lifecycle
+- auto resolution
+- manual close/mute
+- deterministic severity
+- dependency graph
+- incident correlation
+- notification layer
+- runtime aggregation
+- redaction on write
+- deploy suppression
+- retention policy
+
+## Success Criteria
+
+- production failures become incidents automatically
+- operators are notified automatically
+- incidents resolve automatically when healthy
+- no manual monitoring required
+
+---
+
+# Sprint 021: Evidence & Investigation
+
+## Goal
+
+Incident
+→ Evidence Pack
+→ Investigation
+
+## Deliverables
+
+- evidence pack model
+- deployment capture
+- worker/scheduler state capture
+- runtime error summaries
+- related incident lookup
+- graph-scoped evidence collection
+- investigation model
+- investigator agent
+
+---
+
+# Sprint 022: Ticket Factory & Validation
+
+## Goal
+
+Investigation
+→ Ticket
+→ Human Approval
+→ Coding Agent
+→ Validation
+
+## Deliverables
+
+- ticket writer
+- coding-agent handoff format
+- acceptance criteria
+- validation checklist
+- recovery validation
+- reopen logic
+- post-fix summary
+
+---
+
+# Future Considerations
+
+- recurring incident detection
+- historical fix retrieval
+- operational intelligence
+- advanced correlation strategies

--- a/docs/bugops/spec/BugOps-v2-Product-Spec.md
+++ b/docs/bugops/spec/BugOps-v2-Product-Spec.md
@@ -1,0 +1,470 @@
+# Product Spec: BugOps v2
+
+## Product Summary
+
+BugOps is an AI-assisted production operations system that turns production failures into actionable bug-bash tickets.
+
+It continuously monitors both product outcomes and runtime failures, detects incidents, preserves investigation evidence, groups related signals into a single incident, and generates structured tickets that can be handed directly to Claude Code.
+
+The goal is not autonomous remediation.
+
+The goal is to eliminate manual monitoring and context reconstruction so production failures become immediately visible, understandable, and actionable.
+
+---
+
+## User
+
+### Primary User
+
+Production operator responsible for maintaining Backdrop.
+
+Current implementation:
+
+One operator (Mike).
+
+### Future Users
+
+- AI coding agents
+- Future maintainers
+- Engineering collaborators
+
+---
+
+## Problem
+
+Today production failures are discovered manually.
+
+Example:
+
+Production failure
+→ Articles stop ingesting
+→ Signals stop generating
+→ Narratives become stale
+→ Briefings stop publishing
+
+The operator often discovers the issue days later.
+
+Even after discovering the issue, investigation requires reconstructing context across:
+
+- Railway logs
+- MongoDB
+- Worker status
+- Scheduler status
+- Recent deployments
+- Previous incidents
+
+The reconstruction step often takes longer than fixing the bug.
+
+---
+
+## Product Goal
+
+Transform:
+
+Production Failure
+→ Manual Discovery
+→ Manual Investigation
+→ Manual Ticket Creation
+→ Fix
+
+Into:
+
+Production Failure
+→ Automatic Detection
+→ Automatic Evidence Collection
+→ Automatic Ticket Creation
+→ Claude Code Implementation
+→ Validation
+
+---
+
+## Product Principles
+
+1. Evidence before interpretation
+2. Context before conclusions
+3. Incidents before tickets
+4. Humans approve code changes
+5. Deterministic systems before LLM reasoning
+6. Preserve evidence before it disappears
+
+---
+
+## Core Concepts
+
+### Signal
+
+A single observation.
+
+Examples:
+
+- No briefing in 24 hours
+- Worker crash
+- ImportError
+- Mongo timeout
+
+Signals are not operator-facing.
+
+### Incident
+
+An operator-facing representation of a production problem.
+
+An incident may contain multiple signals.
+
+Example:
+
+Incident: Article Ingestion Failure
+
+Signals:
+- worker crash
+- ImportError
+- articles stale
+- signals stale
+
+### Evidence Pack
+
+Automatically collected context attached to an incident.
+
+Contains:
+
+- timestamps
+- logs
+- metrics
+- deploy history
+- task status
+- related signals
+- related incidents
+
+### Ticket
+
+Structured work item generated from an incident.
+
+Intended for:
+- operator review
+- Claude Code implementation
+
+---
+
+## Scope
+
+### In Scope
+
+#### Detection
+
+Outcome monitoring:
+- articles
+- signals
+- narratives
+- briefings
+
+Runtime monitoring:
+- exceptions
+- worker failures
+- scheduler failures
+- startup failures
+- database failures
+
+#### Investigation
+
+- Evidence collection
+- Failure localization
+- Ticket generation
+
+#### Validation
+
+- Recovery verification
+- Incident closure
+
+### Out of Scope
+
+- Autonomous code changes
+- Autonomous deploys
+- Autonomous merges
+- Autonomous remediation
+- General observability platform
+- Datadog replacement
+
+---
+
+## System Architecture
+
+Signal Sources
+→ Signal Events
+→ Incident Correlation
+→ Incident
+→ Evidence Pack
+→ Investigator Agent
+→ Ticket Writer Agent
+→ Bug Ticket
+→ Claude Code
+→ Validation
+
+---
+
+## Signal Sources
+
+### Outcome Signals
+
+#### ArticleFreshnessSignalSource
+
+Detect:
+- No articles ingested within threshold
+
+Default:
+- 6 hours
+
+#### SignalFreshnessSignalSource
+
+Detect:
+- No signals generated
+
+Default:
+- 12 hours
+
+#### NarrativeFreshnessSignalSource
+
+Detect:
+- Narratives stale
+
+Default:
+- 24 hours
+
+#### BriefingFreshnessSignalSource
+
+Detect:
+- No briefing published
+
+Default:
+- 24 hours
+
+### Runtime Signals
+
+#### RuntimeErrorSignalSource
+
+Detect:
+- Unhandled exceptions
+
+Sources:
+- FastAPI
+- Workers
+- Scheduler
+
+Capture:
+- exception type
+- message
+- stack trace
+- service
+
+#### WorkerFailureSignalSource
+
+Detect:
+- worker crash loops
+- worker unavailable
+- heartbeat missing
+
+#### SchedulerFailureSignalSource
+
+Detect:
+- scheduler stopped
+- scheduled jobs not executing
+
+#### DatabaseFailureSignalSource
+
+Detect:
+- Mongo connection failures
+- timeout storms
+
+---
+
+## Incident Correlation
+
+Goal:
+
+Avoid creating multiple tickets for a single outage.
+
+Example:
+
+Scheduler stopped
+→ Articles stale
+→ Signals stale
+→ Briefings stale
+
+Should become:
+
+One Incident
+
+Not:
+
+Four Incidents
+
+---
+
+## Evidence Pack
+
+Every incident automatically gathers:
+
+### Timeline
+
+- first signal
+- last signal
+- first occurrence
+- latest occurrence
+
+### Product State
+
+- latest article
+- latest signal
+- latest narrative
+- latest briefing
+
+### Infrastructure State
+
+- worker status
+- scheduler status
+- recent failures
+
+### Deployment Context
+
+- recent deploys
+- recent config changes
+
+### Historical Context
+
+- similar incidents
+- related cases
+
+---
+
+## Investigator Agent
+
+Purpose:
+
+Transform evidence into investigation guidance.
+
+Input:
+
+- incident
+- evidence pack
+
+Output:
+
+- likely subsystem
+- possible causes
+- verification steps
+- confidence levels
+
+Example:
+
+Likely subsystem: Scheduler
+
+Confidence: High
+
+Evidence:
+- no articles
+- no signals
+- no scheduled tasks executed
+
+Verification:
+- check Celery Beat logs
+- check scheduler heartbeat
+
+---
+
+## Ticket Writer Agent
+
+Purpose:
+
+Create Claude-ready tickets.
+
+Output:
+
+- Title
+- Severity
+- Impact
+- Observed Behavior
+- Expected Behavior
+- Evidence
+- Likely Subsystem
+- Verification Steps
+- Acceptance Criteria
+- Validation Steps
+
+---
+
+## Validation Layer
+
+After deployment, BugOps verifies:
+
+- articles resumed
+- signals resumed
+- narratives refreshed
+- briefing published
+
+If healthy:
+- Incident Resolved
+
+Otherwise:
+- Incident Reopened
+
+---
+
+## Success Metrics
+
+### Primary Metric
+
+Reduce time from:
+
+Failure Occurs
+→ Operator Understands Problem
+
+From:
+
+30–60 minutes
+
+To:
+
+Under 10 minutes
+
+### Secondary Metrics
+
+- Incidents detected automatically
+- Tickets generated automatically
+- Incidents with sufficient evidence
+- False-positive rate
+- Duplicate incident rate
+- Mean time to recovery
+
+---
+
+## Sprint 020
+
+### Production Health & Runtime Failure Detection
+
+#### Deliverables
+
+Outcome Signals:
+- ArticleFreshnessSignalSource
+- SignalFreshnessSignalSource
+- NarrativeFreshnessSignalSource
+- BriefingFreshnessSignalSource
+
+Runtime Signals:
+- RuntimeErrorSignalSource
+- WorkerFailureSignalSource
+- SchedulerFailureSignalSource
+
+New Models:
+- runtime_error_events
+- incident_evidence
+
+New Capabilities:
+- exception fingerprinting
+- incident correlation
+- evidence pack generation
+- ticket generation
+
+#### Success Criteria
+
+- Production failures become incidents automatically.
+- Every incident contains investigation evidence.
+- Every incident produces a Claude-ready bug ticket.
+- No manual monitoring required.

--- a/docs/bugops/spec/v1/bugops-product-spec-v2.md
+++ b/docs/bugops/spec/v1/bugops-product-spec-v2.md
@@ -1,0 +1,832 @@
+# Product Spec: BugOps
+
+---
+
+**Note:** This is a real product spec written for a production feature I built inside Backdrop, a multi-service AI pipeline I developed and operate independently. The primary user is an internal operator persona: the person responsible for keeping the system reliable in production. In the current implementation, I am that operator, which made the feedback loop unusually tight and grounded the product in real operational pain. The system described here is running in production.
+
+---
+
+## 1. Product Summary
+
+BugOps is a production monitoring, triage, and debugging-assistance system for a multi-service AI pipeline.
+
+Its purpose is to detect production issues, normalize them into durable bug cases, notify the operator, preserve evidence, and support the full path from production failure to verified fix.
+
+BugOps begins with deterministic signal detection and manual operator control. It does not start with autonomous remediation, LLM diagnosis, or automatic code changes.
+
+Initial production path:
+
+```text
+llm_traces → bug_alert_event → bug_case → optional alert → deterministic report
+```
+
+---
+
+## 2. Why This Matters for AI Systems
+
+Production AI systems have a reliability problem that traditional monitoring does not fully address.
+
+When a service crashes, the signal is clear. When an LLM pipeline degrades, the signal is often subtle: outputs become less grounded, costs drift upward, generated summaries stop passing validation, or evidence stops flowing into downstream generation steps. By the time the failure is obvious, the evidence is gone.
+
+AI systems also carry a specific trust risk: generated artifacts can become inputs to subsequent generation. If a degraded output quietly propagates through the pipeline, the system compounds the error rather than surfacing it. Standard alerting does not catch this because there is no exception to catch.
+
+BugOps is designed around this reality. It treats production signals as evidence, not just alerts. It preserves that evidence before it disappears. It keeps deterministic facts separate from LLM interpretation until the evidence layer is solid. And it keeps humans in the loop on diagnosis and resolution until the system has earned enough trust to support more automation.
+
+The same pattern applies to any AI-native product operating at scale: evidence first, trust boundaries enforced, automation only after the manual workflow is understood.
+
+---
+
+## 3. Problem
+
+The system is a production AI pipeline with multiple moving parts:
+
+- FastAPI backend
+- Celery workers
+- Redis
+- MongoDB
+- Cloud deployment
+- Frontend
+- LLM gateway
+- trace logging
+- cost controls
+- scheduled processing
+- briefing and narrative generation
+
+When something breaks, the debugging process is too manual.
+
+The operator has to inspect deployment logs, MongoDB, LLM traces, service logs, test output, implementation summaries, and code changes, then reconstruct what happened.
+
+This is slow, error-prone, and especially painful when production behaves differently from local validation.
+
+Recent rollout issues showed the gap clearly:
+
+- disabled mode initialized dependencies it should not have touched
+- enabled mode hit async/sync database getter mismatches
+- runtime and import paths behaved differently in production
+- production validation exposed issues that local tests did not catch
+
+BugOps exists to reduce this production-debugging burden.
+
+---
+
+## 4. User
+
+### Primary User
+
+- Solo operator and builder of the system
+
+### Secondary Future Users
+
+- AI coding agent
+- reviewing agent
+- future maintainers
+- product and engineering collaborators
+
+### Current User Needs
+
+- know when production has a meaningful issue
+- avoid manually watching logs all the time
+- distinguish real issues from noise
+- preserve evidence before it disappears
+- know what to check next
+- avoid duplicate investigation of the same issue
+- eventually hand clean bug context to a coding agent
+
+---
+
+## 5. Goals
+
+### Core Goals
+
+1. Detect production signals that indicate real operational issues.
+2. Normalize raw signals into structured bug alert events.
+3. Group related alerts into durable bug cases.
+4. Notify the operator only when a new case is created.
+5. Preserve deterministic evidence for debugging.
+6. Generate deterministic case reports.
+7. Keep humans in control of diagnosis, fixing, and closing cases.
+8. Expand signal coverage over time based on real production pain.
+
+### Long-Term Goal
+
+Create a closed-loop bug operations system:
+
+```text
+production failure
+→ normalized case
+→ evidence bundle
+→ diagnosis pack
+→ fix brief
+→ coding agent implementation
+→ verification review
+→ post-fix production validation
+→ case closure with evidence
+```
+
+---
+
+## 6. Non-Goals
+
+BugOps is not initially trying to be:
+
+- a full observability platform
+- a Datadog replacement
+- a log search engine
+- an autonomous remediation agent
+- an incident management system
+- an LLM-first diagnosis tool
+- a dashboard product
+- a general-purpose bug tracker
+- an auto-fix / auto-merge system
+
+Important initial constraints:
+
+- no LLM calls in the critical alert path
+- no autonomous code changes
+- no automatic remediation
+- no fuzzy correlation until deterministic grouping proves insufficient
+- no operator UI until manual workflows are clear
+
+---
+
+## 7. Current State
+
+### Implemented
+
+The smallest end-to-end BugOps signal path is proven and running in production:
+
+```text
+llm_traces signal
+→ normalized bug_alert_event
+→ bug_case
+→ one-way alert for new cases only
+→ minimal deterministic report
+```
+
+Implemented components:
+
+- BugOps service skeleton
+- `SignalSource` seam
+- `LLMTraceCostSignalSource`
+- `BugAlertEvent` model
+- `BugCase` model
+- `BugOpsStore`
+- alert-to-case flow by `dedupe_key`
+- one-way notifications
+- deterministic case report
+- persisted heartbeat
+
+Current active signal source:
+
+- LLM cost runaway detection
+
+Current case grouping:
+
+- exact `dedupe_key` matching only
+
+Current notification behavior:
+
+- sends only when a new case is created
+- does not send for repeated alerts attached to an existing open case
+
+Current report behavior:
+
+- deterministic report only
+- no LLM synthesis
+- no unsupported causality language
+
+---
+
+## 8. Key Concepts
+
+### Signal Source
+
+A `SignalSource` is a modular source of production signals.
+
+Examples:
+
+- LLM traces
+- deployment logs
+- FastAPI runtime errors
+- worker task failures
+- database reliability errors
+- worker heartbeat failures
+
+Each source emits normalized alert events.
+
+### Bug Alert Event
+
+A `bug_alert_event` is a normalized record of one detected signal.
+
+Example fields:
+
+- `source_type`
+- `alert_type`
+- `severity`: `warning`, `high`, or `critical`
+- `dedupe_key`
+- observed metrics
+- source metadata
+- `created_at`
+
+Alert events are immutable evidence.
+
+### Bug Case
+
+A `bug_case` groups one or more alert events into an operator-facing case.
+
+Cases represent things worth investigating.
+
+A case has:
+
+- `case_id`
+- `status`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `source_types`
+- `alert_ids`
+- `created_at`
+- `updated_at`
+
+### Dedupe Key
+
+A deterministic key used to decide whether an alert belongs to an existing open case.
+
+Initial rule:
+
+- exact `dedupe_key` match only
+
+No fuzzy matching. No LLM matching. No multi-source correlation yet.
+
+### Deterministic Report
+
+A generated report based only on stored facts.
+
+It includes:
+
+- case metadata
+- alert events
+- observed metrics
+- known facts
+- suggested manual checks
+
+It does not include unsupported root cause claims.
+
+---
+
+## 9. Functional Requirements
+
+### FR1: Monitor Loop
+
+BugOps must run as a separate production process.
+
+It should:
+
+- load enabled signal sources
+- poll on a configured interval
+- create alert events
+- create or update bug cases
+- optionally send notifications
+- log poll results
+- avoid crashing on recoverable source errors
+
+### FR2: Disabled Mode
+
+When disabled:
+
+- BugOps exits cleanly
+- BugOps does not initialize database connections
+- BugOps does not initialize messaging integrations
+- BugOps does not import unnecessary runtime dependencies
+
+### FR3: Alert Event Creation
+
+For each detected signal, BugOps must create a normalized `bug_alert_event`.
+
+Alert events should include:
+
+- `alert_id`
+- `source_type`
+- `alert_type`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `correlation_keys`
+- metric payload
+- source metadata
+- `created_at`
+
+### FR4: Alert-to-Case Flow
+
+For each alert event:
+
+1. Store the alert event.
+2. Look for an open case with the same `dedupe_key`.
+3. If no open case exists, create a new case.
+4. If an open case exists, attach the alert to that case.
+5. Return whether the case is new.
+
+### FR5: Notifications
+
+When notifications are enabled:
+
+- send only for new cases
+- do not send for repeated alerts attached to the same open case
+- include core case fields
+- include observed metrics
+- include suggested manual check
+- handle notification failure without crashing
+
+### FR6: Deterministic Case Report
+
+BugOps must generate a deterministic report for a case.
+
+Report includes:
+
+- case ID
+- status
+- severity
+- source types
+- dedupe key
+- created / updated timestamps
+- summary
+- alert events
+- observed metrics
+- known facts
+- suggested manual checks
+
+Report must not include unsupported causality phrases such as:
+
+- caused by
+- due to
+- root cause
+- leads to
+- is responsible for
+
+### FR7: Heartbeat Logging
+
+BugOps must log poll completion.
+
+Example:
+
+```text
+BugOps poll complete: sources=1 alerts=0 cases_created=0 cases_updated=0 duration_ms=123
+```
+
+### FR8: Persisted Heartbeat
+
+BugOps should persist heartbeat status so silent monitor failure is detectable.
+
+Fields:
+
+- service
+- last_poll_at
+- status
+- sources_checked
+- alerts_found
+- cases_created
+- duration_ms
+- error_message
+
+### FR9: Idempotency Guardrails
+
+BugOps should prevent duplicate open cases for the same `dedupe_key`.
+
+Initial approach:
+
+- one production replica
+- database-level uniqueness or upsert safety where straightforward
+
+### FR10: Runtime Failure Detection
+
+BugOps should expand beyond LLM cost monitoring to detect runtime failures.
+
+Target patterns:
+
+- startup crashes
+- Python tracebacks
+- import and name errors
+- database connection failures
+- messaging integration failures
+- platform log-rate-limit warnings
+
+---
+
+## 10. Non-Functional Requirements
+
+### Reliability
+
+BugOps should fail safely.
+
+- Source failure should not crash the whole monitor.
+- Notification failure should not crash the monitor.
+- One bad alert should not block future polling.
+- Disabled mode should be clean and dependency-light.
+
+### Cost
+
+BugOps should be cheap to run.
+
+- No LLM in critical path.
+- Poll interval configurable.
+- Minimal memory footprint.
+- Single replica.
+- No expensive background processing.
+
+### Safety
+
+BugOps should not modify production application data.
+
+Allowed writes:
+
+- `bug_alert_events`
+- `bug_cases`
+- `bug_case_reports`
+- `bug_heartbeats`
+
+BugOps should not write to production pipeline collections.
+
+### Observability
+
+BugOps itself must be observable.
+
+Minimum:
+
+- startup logs
+- enabled/disabled state logs
+- poll-complete logs
+- source error logs
+- notification success/failure logs
+- persisted heartbeat
+
+### Maintainability
+
+BugOps should remain modular.
+
+New signal sources should plug into the `SignalSource` seam without changing the core alert-to-case flow.
+
+---
+
+## 11. Data Model
+
+### `bug_alert_events`
+
+Purpose: Store normalized production signals.
+
+Important fields:
+
+- `alert_id`
+- `source_type`
+- `alert_type`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `correlation_keys`
+- `metric`
+- `source_metadata`
+- `case_id`
+- `created_at`
+
+### `bug_cases`
+
+Purpose: Store durable operator-facing cases.
+
+Important fields:
+
+- `case_id`
+- `status`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `source_types`
+- `alert_ids`
+- `created_at`
+- `updated_at`
+- `resolved_at`
+- `closed_at`
+
+Current lifecycle:
+
+```text
+open → resolved → closed
+```
+
+### `bug_case_reports`
+
+Purpose: Store generated deterministic reports.
+
+Important fields:
+
+- `report_id`
+- `case_id`
+- `report_text`
+- `generated_at`
+- `report_type`
+
+### `bug_heartbeats`
+
+Purpose: Show whether BugOps is alive and polling.
+
+Important fields:
+
+- service
+- last_poll_at
+- status
+- sources_checked
+- alerts_found
+- cases_created
+- duration_ms
+- error_message
+
+---
+
+## 12. Architecture
+
+### Process
+
+BugOps runs as a separate service alongside the main application.
+
+### Core Modules
+
+```text
+bugops/
+  config.py
+  monitor.py
+  models.py
+  store.py
+  notifications.py
+  reports.py
+  signal_sources/
+    base.py
+    llm_traces.py
+    runtime_logs.py
+    app_runtime.py
+    worker_failures.py
+    db_reliability.py
+```
+
+### Flow
+
+1. Monitor starts.
+2. Config is loaded.
+3. If disabled, exit cleanly.
+4. Signal sources are initialized.
+5. Monitor polls each source.
+6. Sources emit alert events.
+7. Store creates alert events.
+8. Store creates or updates cases.
+9. Notifications send only for new cases.
+10. Reports can be generated deterministically.
+11. Heartbeat is logged and persisted.
+
+---
+
+## 13. Roadmap
+
+### Phase 1 — Signal Intake Foundation
+
+Prove first end-to-end path:
+
+```text
+llm_traces → bug_alert_event → bug_case → notification/report
+```
+
+Status: Done.
+
+### Phase 2 — Production Hardening
+
+Make BugOps safe and trustworthy enough to leave running.
+
+Scope:
+
+- heartbeat logs
+- persisted heartbeat
+- startup noise cleanup
+- notification production validation
+- idempotency guardrails
+- short operator runbook
+
+### Phase 3 — Runtime Failure Detection
+
+Expand beyond LLM cost monitoring.
+
+Scope:
+
+- minimal runtime log detector
+- startup crash detection
+- Python exception detection
+- database and cache failure patterns
+- notification failure pattern detection
+- platform log-rate-limit warnings
+
+### Phase 4 — Structured App and Worker Error Signals
+
+Add cleaner first-class signals.
+
+Scope:
+
+- exception middleware
+- task failure hooks
+- database reliability instrumentation
+- worker liveness checks
+- retry storm detection
+
+### Phase 5 — Diagnosis Packs
+
+Make cases actionable.
+
+Scope:
+
+- evidence bundle
+- related traces and logs
+- known facts and unknowns
+- suggested checks
+- safe queries and commands
+
+### Phase 6 — Manual Case Workflow
+
+Make cases easy to operate manually.
+
+Scope:
+
+- list open cases
+- view report
+- resolve case
+- close case
+- add note
+- attach validation evidence
+
+### Phase 7 — LLM Case Synthesis
+
+Add cautious AI interpretation over deterministic evidence.
+
+Scope:
+
+- summarize diagnosis pack
+- suggest hypotheses
+- suggest checks
+- cite evidence
+- label uncertainty
+
+### Phase 8 — Fix Brief Generation
+
+Turn cases into agent-ready fix briefs.
+
+Scope:
+
+- problem statement
+- evidence
+- suspected files
+- constraints
+- tests
+- validation plan
+- rollback notes
+
+### Phase 9 — Coding Agent Verification Harness
+
+Review agent-generated fixes against the ticket and evidence.
+
+Scope:
+
+- ticket and fix brief
+- code diff
+- implementation summary
+- test output
+- verdict and concerns
+- follow-up prompt
+
+### Phase 10 — Closed-Loop Validation
+
+Verify that shipped fixes actually resolved the production issue.
+
+Scope:
+
+- post-fix monitoring
+- alert pattern stopped
+- metrics returned to baseline
+- case closed with evidence
+
+---
+
+## 14. Success Metrics
+
+### Primary Outcome
+
+Reduce time spent reconstructing production failures from 30–60 minutes of manual log inspection to under 10 minutes per meaningful incident.
+
+### Short-Term
+
+BugOps is successful after Phase 2 if:
+
+- it runs continuously in production
+- it emits heartbeat logs
+- it does not create confusing startup noise
+- it does not duplicate open cases
+- notification behavior is validated
+- it can detect and case LLM cost runaway
+- reports are deterministic and useful
+
+### Medium-Term
+
+BugOps is successful after Phases 3 through 5 if:
+
+- it detects runtime failures beyond LLM cost
+- it catches issues that would otherwise require manual log watching
+- cases contain enough evidence to start debugging quickly
+- diagnosis packs reduce manual investigation time
+- alerts are useful enough to keep enabled
+
+### Long-Term
+
+BugOps is successful if:
+
+- production failures become durable cases
+- evidence is preserved automatically
+- the operator spends less time reconstructing what happened
+- a coding agent receives better bug context
+- fixes can be validated against the original production signal
+
+---
+
+## 15. Risks
+
+### Risk: BugOps becomes too broad
+
+Mitigation: Add signal sources incrementally. Do not build a full observability platform.
+
+### Risk: Alert noise
+
+Mitigation: Start with narrow, high-confidence patterns. Notify only on new cases.
+
+### Risk: LLM hallucination
+
+Mitigation: Keep deterministic facts separate from LLM synthesis. Do not add LLM interpretation until diagnosis packs exist.
+
+### Risk: Duplicate cases
+
+Mitigation: Use deterministic `dedupe_key` logic and database-level guardrails.
+
+### Risk: Log sources are messy
+
+Mitigation: Use deployment logs only for narrow runtime failure patterns. Add structured app signals later.
+
+### Risk: The system becomes more interesting than useful
+
+Mitigation: Only expand when real production pain justifies the next layer.
+
+---
+
+## 16. Open Questions
+
+1. Should deployment logs be the primary Phase 3 source, or only a startup-crash safety net?
+2. Which structured signal should come first: application errors, worker failures, or database reliability?
+3. How much case lifecycle is needed before adding an operator UI?
+4. Are diagnosis packs enough before LLM synthesis?
+5. When should BugOps integrate directly with a coding agent?
+6. Should fix brief generation be part of BugOps or a separate tooling track?
+
+---
+
+## 17. Tradeoffs
+
+### Deterministic detection before LLM diagnosis
+
+Chose to build evidence collection and case grouping entirely without LLM calls before adding any AI interpretation. A false root cause claim in an alert erodes trust in the whole system faster than a missing hypothesis. Evidence first; synthesis only after the deterministic layer is solid.
+
+### Exact dedupe matching before fuzzy correlation
+
+Chose exact `dedupe_key` matching over semantic or fuzzy grouping. Fuzzy matching can silently merge unrelated cases, making it harder to isolate the real failure. The cost is occasional duplicate cases for the same underlying issue. That is a manageable operator burden; invisible case merges are not.
+
+### Separate monitoring process over inline alerting
+
+Chose to run BugOps as a separate process rather than embedding alerts inside the main pipeline. Inline alerting creates coupling between the monitoring system and the system being monitored — a bad alert path can affect production throughput. Separation keeps the failure modes isolated.
+
+### Narrow signal coverage over broad instrumentation
+
+Chose to expand signal sources only when real production pain justifies it, rather than instrumenting everything upfront. Broad instrumentation creates alert noise that operators learn to ignore. High-confidence signals on a narrow surface are more useful than comprehensive coverage that no one trusts.
+
+---
+
+## 18. Product Principle
+
+BugOps should not try to be smart before it is useful.
+
+The order is:
+
+1. detect real signals
+2. preserve evidence
+3. create cases
+4. notify the operator
+5. make cases actionable
+6. support fixes
+7. validate resolution
+
+Deterministic evidence comes first.
+
+LLM synthesis comes later.
+
+Automation comes after manual workflow pain is understood.

--- a/docs/bugops/spec/v1/bugops-product-spec-v3.md
+++ b/docs/bugops/spec/v1/bugops-product-spec-v3.md
@@ -1,0 +1,381 @@
+# Product Spec: BugOps
+
+---
+
+**Note:** This is a real product spec for a production feature I built inside Backdrop, a multi-service AI pipeline I developed and operate independently. The primary user is an internal operator persona: the person responsible for keeping the system reliable in production. In the current implementation, I am that operator, which made the feedback loop unusually tight and grounded the product in real production operating needs. The system described here is running in production.
+
+---
+
+## 1. Product Summary
+
+BugOps is a production monitoring, triage, and debugging-assistance system for a multi-service AI pipeline.
+
+Its purpose is to detect production issues, normalize them into durable bug cases, notify the operator, preserve evidence, and support the full path from production failure to verified fix. BugOps turns production failures from scattered, ephemeral signals into durable, operator-facing cases with preserved evidence, reducing the time required to understand and act on incidents.
+
+BugOps begins with deterministic signal detection and manual operator control. It does not start with autonomous remediation, LLM diagnosis, or automatic code changes.
+
+**Status: The first end-to-end path is implemented and running in production.**
+
+Initial production path:
+
+```
+llm_traces → bug_alert_event → bug_case → optional alert → deterministic report
+```
+
+---
+
+## 2. Why This Matters for AI Systems
+
+Production AI systems have a reliability problem that traditional monitoring does not fully address.
+
+When a service crashes, the signal is clear. When an LLM pipeline degrades, the signal is often subtle: outputs become less grounded, costs drift upward, generated summaries stop passing validation, or evidence stops flowing into downstream generation steps. By the time the failure is obvious, the evidence is gone.
+
+AI systems also carry a specific trust risk: generated artifacts can become inputs to subsequent generation. If a degraded output quietly propagates through the pipeline, the system compounds the error rather than surfacing it. Standard alerting does not catch this because there is no exception to catch.
+
+BugOps is designed around this reality. It treats production signals as evidence, not just alerts. It preserves that evidence before it disappears. It keeps deterministic facts separate from LLM interpretation until the evidence layer is solid. And it keeps humans in the loop on diagnosis and resolution until the system has earned enough trust to support more automation.
+
+The same pattern applies to any AI-native product operating at scale: evidence first, trust boundaries enforced, automation only after the manual workflow is understood.
+
+---
+
+## 3. Problem
+
+The system is a production AI pipeline with multiple moving parts: FastAPI backend, Celery workers, Redis, MongoDB, cloud deployment, frontend, LLM gateway, trace logging, cost controls, scheduled processing, and generation pipelines.
+
+When something breaks, the debugging process is too manual.
+
+The operator has to inspect deployment logs, MongoDB, LLM traces, service logs, test output, implementation summaries, and code changes, then reconstruct what happened. This is slow, error-prone, and especially painful when production behaves differently from local validation.
+
+Recent rollout issues showed the gap clearly:
+
+- disabled mode initialized dependencies it should not have touched
+- enabled mode hit async/sync database getter mismatches
+- runtime and import paths behaved differently in production
+- production validation exposed issues that local tests did not catch
+
+BugOps exists to reduce this production-debugging burden.
+
+---
+
+## 4. User and Workflow
+
+### Primary User
+
+The person responsible for keeping the system reliable in production.
+
+### Before BugOps
+
+The operator manually checks deployment logs, LLM traces, MongoDB, service logs, and recent code changes — spending 30–60 minutes reconstructing what happened, often after the evidence has already rotated out.
+
+### After BugOps
+
+A case notification arrives only when a meaningful new issue is detected. The operator opens the deterministic report, sees the alert event, the observed metrics, and the suggested checks. Investigation starts in under 10 minutes with evidence already preserved.
+
+### Validation Beyond the Current Operator
+
+Because the initial operator is also the builder, the first version benefits from an unusually tight feedback loop but has a known validation limitation: it reflects one production environment and one operator's debugging habits.
+
+Before generalizing BugOps to additional operators or teams, the next validation step would be to conduct structured interviews with other AI system operators and builders about recent production incidents, compare their debugging workflows against the BugOps case model, and test whether the case reports preserve the evidence they would need to begin investigation.
+
+The key question is whether BugOps reduces context reconstruction for operators who did not build the underlying system and cannot rely on implicit knowledge of how it works.
+
+### Secondary Future Users
+
+- AI coding agent
+- reviewing agent
+- future maintainers
+- product and engineering collaborators
+
+### Current User Needs
+
+- know when production has a meaningful issue
+- avoid manually watching logs all the time
+- distinguish real issues from noise
+- preserve evidence before it disappears
+- know what to check next
+- avoid duplicate investigation of the same issue
+- eventually hand clean bug context to a coding agent
+
+---
+
+## 5. Current State
+
+The smallest end-to-end BugOps signal path is proven and running in production:
+
+```
+llm_traces signal
+→ normalized bug_alert_event
+→ bug_case
+→ one-way alert for new cases only
+→ minimal deterministic report
+```
+
+Implemented: BugOps service, SignalSource seam, LLMTraceCostSignalSource, BugAlertEvent model, BugCase model, BugOpsStore, alert-to-case flow by dedupe_key, one-way notifications, deterministic case report, persisted heartbeat.
+
+Current active signal source: LLM cost runaway detection.
+
+Current case grouping: exact dedupe_key matching only.
+
+Notification behavior: sends only when a new case is created; does not send for repeated alerts on an existing open case.
+
+Report behavior: deterministic only; no LLM synthesis; no unsupported causality language.
+
+---
+
+## 6. Goals
+
+### Core Goals
+
+1. Detect production signals that indicate real operational issues.
+2. Normalize raw signals into structured bug alert events.
+3. Group related alerts into durable bug cases.
+4. Notify the operator only when a new case is created.
+5. Preserve deterministic evidence for debugging.
+6. Generate deterministic case reports.
+7. Keep humans in control of diagnosis, fixing, and closing cases.
+8. Expand signal coverage over time based on real production operating experience.
+
+### Long-Term Goal
+
+Create a closed-loop bug operations system:
+
+```
+production failure
+→ normalized case
+→ evidence bundle
+→ diagnosis pack
+→ fix brief
+→ coding agent implementation
+→ verification review
+→ post-fix production validation
+→ case closure with evidence
+```
+
+---
+
+## 7. Non-Goals
+
+BugOps is not initially trying to be:
+
+- a full observability platform
+- a Datadog replacement
+- a log search engine
+- an autonomous remediation agent
+- an incident management system
+- an LLM-first diagnosis tool
+- a dashboard product
+- a general-purpose bug tracker
+- an auto-fix / auto-merge system
+
+Important initial constraints:
+
+- no LLM calls in the critical alert path
+- no autonomous code changes
+- no automatic remediation
+- no fuzzy correlation until deterministic grouping proves insufficient
+- no operator UI until manual workflows are clear
+
+---
+
+## 8. Key Concepts
+
+### Signal Source
+
+A SignalSource is a modular source of production signals. Each source emits normalized alert events.
+
+Examples: LLM traces, deployment logs, FastAPI runtime errors, worker task failures, database reliability errors, worker heartbeat failures.
+
+### Bug Alert Event
+
+A bug_alert_event is a normalized record of one detected signal. Alert events are immutable evidence.
+
+Fields: source_type, alert_type, severity (warning/high/critical), dedupe_key, observed metrics, source metadata, created_at.
+
+### Bug Case
+
+A bug_case groups one or more alert events into an operator-facing case. Cases represent things worth investigating.
+
+Fields: case_id, status, severity, title, summary, dedupe_key, source_types, alert_ids, created_at, updated_at.
+
+### Dedupe Key
+
+A deterministic key used to decide whether an alert belongs to an existing open case. Exact match only. No fuzzy matching. No LLM matching. No multi-source correlation yet.
+
+### Deterministic Report
+
+A report based only on stored facts. Includes case metadata, alert events, observed metrics, known facts, and suggested manual checks. Does not include unsupported root cause claims.
+
+---
+
+## 9. Functional Requirements
+
+**FR1: Monitor Loop** — Run as a separate production process. Load signal sources, poll on a configured interval, create alert events, create or update cases, optionally send notifications, log poll results, avoid crashing on recoverable source errors.
+
+**FR2: Disabled Mode** — Exit cleanly without initializing database connections, messaging integrations, or unnecessary runtime dependencies.
+
+**FR3: Alert Event Creation** — For each detected signal, create a normalized bug_alert_event with: alert_id, source_type, alert_type, severity, title, summary, dedupe_key, correlation_keys, metric payload, source metadata, created_at.
+
+**FR4: Alert-to-Case Flow** — Store alert event. Find open case with matching dedupe_key. If none, create new case. If found, attach alert to existing case. Return whether case is new.
+
+**FR5: Notifications** — Send only for new cases. Do not send for repeated alerts on an existing open case. Include core case fields, observed metrics, and suggested manual check. Handle notification failure without crashing.
+
+**FR6: Deterministic Case Report** — Generate report from stored facts only. Must not include causality phrases: caused by, due to, root cause, leads to, is responsible for.
+
+**FR7: Heartbeat Logging** — Log poll completion: sources checked, alerts found, cases created/updated, duration.
+
+**FR8: Persisted Heartbeat** — Persist heartbeat status so silent monitor failure is detectable.
+
+**FR9: Idempotency Guardrails** — Prevent duplicate open cases for the same dedupe_key via single replica and database-level guardrails.
+
+**FR10: Runtime Failure Detection** — Expand to detect startup crashes, Python tracebacks, import errors, database connection failures, messaging failures, and platform log-rate-limit warnings.
+
+---
+
+## 10. Non-Functional Requirements
+
+**Reliability** — Source failure, notification failure, and individual bad alerts must not crash the monitor or block future polling.
+
+**Cost** — No LLM in critical path. Configurable poll interval. Minimal memory footprint. Single replica.
+
+**Safety** — BugOps writes only to its own collections. Does not write to production pipeline collections.
+
+**Observability** — Startup logs, enabled/disabled state logs, poll-complete logs, source error logs, notification success/failure logs, persisted heartbeat.
+
+**Maintainability** — New signal sources plug into the SignalSource seam without changing the core alert-to-case flow.
+
+---
+
+## 11. Architecture
+
+BugOps runs as a separate service alongside the main application.
+
+Flow:
+
+1. Monitor starts.
+2. Config is loaded.
+3. If disabled, exit cleanly.
+4. Signal sources are initialized.
+5. Monitor polls each source.
+6. Sources emit alert events.
+7. Store creates alert events.
+8. Store creates or updates cases.
+9. Notifications send only for new cases.
+10. Reports can be generated deterministically.
+11. Heartbeat is logged and persisted.
+
+---
+
+## 12. Roadmap
+
+**Phase 1 — Signal Intake Foundation** — Prove first end-to-end path. Status: Done.
+
+**Phase 2 — Production Hardening and Runtime Coverage** — Heartbeat logs, persisted heartbeat, startup noise cleanup, notification validation, idempotency guardrails, runtime failure detection, operator runbook.
+
+**Phase 3 — Diagnosis Packs and Manual Case Workflow** — Evidence bundle, related traces and logs, known facts and unknowns, suggested checks. List open cases, view report, resolve, close, add note, attach validation evidence.
+
+**Phase 4 — LLM Synthesis, Fix Briefs, and Closed-Loop Validation** — Summarize diagnosis pack, suggest hypotheses, cite evidence, label uncertainty. Turn cases into agent-ready fix briefs. Post-fix monitoring and case closure with evidence.
+
+---
+
+## 13. Success Metrics
+
+### Primary Outcome
+
+Reduce production failure reconstruction time from an estimated 30–60 minutes of manual log, trace, database, and deployment inspection to under 10 minutes per meaningful incident.
+
+### Measurement Plan
+
+For each meaningful production issue, record:
+
+- time from first production signal to operator awareness
+- time from awareness to first credible understanding of the issue
+- whether the case preserved enough evidence to begin debugging without additional log archaeology
+- whether the alert was useful, noisy, duplicate, or missing key context
+- whether the issue required manual investigation outside the BugOps case report
+
+### Short-Term Success
+
+BugOps is successful after Phase 2 if:
+
+- it runs continuously in production
+- it emits and persists heartbeat status
+- it creates no duplicate open cases for the same deterministic dedupe_key
+- new-case notifications are useful enough to keep enabled
+- deterministic reports provide enough context to begin investigation
+- LLM cost runaway detection is captured as a durable case
+
+### Medium-Term Success
+
+BugOps is successful in the medium term if:
+
+- it detects runtime failures beyond LLM cost drift
+- it captures issues that would otherwise require manual log watching
+- target: 90% of meaningful incidents produce a case with preserved evidence
+- diagnosis packs reduce the number of systems the operator must inspect manually
+- alert noise remains low enough that the operator continues to trust the system
+
+### Product Impact
+
+BugOps should increase the amount of production surface area one operator can safely manage. The goal is not only to save minutes during incidents, but to make production operations legible enough to review, hand off, and scale.
+
+---
+
+## 14. Risks
+
+**BugOps becomes too broad** — Add signal sources incrementally; do not build a full observability platform.
+
+**Alert noise** — Start with narrow, high-confidence patterns; notify only on new cases.
+
+**LLM hallucination** — Keep deterministic facts separate from LLM synthesis; do not add interpretation until diagnosis packs exist.
+
+**Duplicate cases** — Deterministic dedupe_key logic and database-level guardrails.
+
+**Log sources are messy** — Use deployment logs only for narrow runtime failure patterns; add structured app signals later.
+
+**The system becomes more interesting than useful** — Only expand when real production operating experience justifies the next layer.
+
+---
+
+## 15. Tradeoffs
+
+**Deterministic detection before LLM diagnosis** — A false root cause claim in an alert erodes trust in the whole system faster than a missing hypothesis. Evidence first; synthesis only after the deterministic layer is solid.
+
+**Exact dedupe matching before fuzzy correlation** — Fuzzy matching can silently merge unrelated cases. The cost is occasional duplicate cases for the same underlying issue. That is a manageable operator burden; invisible case merges are not.
+
+**Separate monitoring process over inline alerting** — Inline alerting creates coupling between the monitoring system and the system being monitored. Separation keeps the failure modes isolated.
+
+**Narrow signal coverage over broad instrumentation** — Broad instrumentation creates alert noise that operators learn to ignore. High-confidence signals on a narrow surface are more useful than comprehensive coverage that no one trusts.
+
+---
+
+## 16. Open Questions and Current Leanings
+
+1. **Should deployment logs be the primary Phase 2 source, or only a startup-crash safety net?** Current leaning: use deployment logs narrowly for startup crashes and obvious runtime failures, then move toward structured app and worker signals. Deployment logs are useful for coverage but too noisy to become the primary long-term signal source.
+
+2. **Which structured signal should come first: application errors, worker failures, or database reliability?** Current leaning: application errors first, because they are closest to user-visible production failures and can produce cleaner case evidence than platform logs.
+
+3. **How much case lifecycle is needed before adding an operator UI?** Current leaning: keep lifecycle minimal until repeated friction appears in the manual workflow. The trigger for adding a UI is operational drag in resolving, reviewing, or closing cases, not a feature roadmap milestone. The initial lifecycle of open → resolved → closed is enough until manual operation shows that notes, filtering, case views, or assignment would materially improve the operator workflow.
+
+4. **Are diagnosis packs enough before LLM synthesis?** Current leaning: yes. Diagnosis packs should exist before LLM synthesis so that any AI interpretation is grounded in deterministic evidence rather than raw, scattered logs.
+
+5. **When should BugOps integrate directly with a coding agent?** Current leaning: only after case reports and diagnosis packs consistently produce enough context for a human operator to begin debugging. Agent handoff should follow proven human handoff.
+
+6. **Should fix brief generation be part of BugOps or a separate tooling track?** Current leaning: BugOps should own the evidence and case context; fix brief generation can be a downstream capability once the evidence model is stable.
+
+---
+
+## 17. Product Principle
+
+BugOps should not try to be smart before it is useful.
+
+The order is:
+
+1. detect real signals
+2. preserve evidence
+3. create cases
+4. notify the operator
+5. make cases actionable
+6. support fixes
+7. validate resolution
+
+Deterministic evidence comes first. LLM synthesis comes later. Automation comes after manual workflow friction is understood.

--- a/docs/bugops/spec/v1/bugops-product-spec-v4.md
+++ b/docs/bugops/spec/v1/bugops-product-spec-v4.md
@@ -1,0 +1,432 @@
+# Product Spec: BugOps
+
+---
+
+**Note:** This is a real product spec for a production feature I built inside Backdrop, a multi-service AI pipeline I developed and operate independently.
+
+The primary user is an internal operator persona: the person responsible for keeping the system reliable in production. In the current implementation, I am that operator, which created an unusually tight feedback loop between observing production incidents, identifying workflow friction, and shipping improvements.
+
+I chose this spec because it reflects how I approach product development: start with a real operational problem, define a narrow first version, establish clear trust boundaries, and expand automation only after the manual workflow is understood.
+
+The system described here is running in production.
+
+---
+
+## 1. Product Summary
+
+BugOps is a production incident detection, triage, and context preservation system for a multi-service AI pipeline.
+
+Its purpose is to detect meaningful production issues, normalize them into durable bug cases, notify the operator, preserve evidence, and support the full path from production failure to verified fix. BugOps turns production failures from scattered, ephemeral signals into durable, operator-facing cases with preserved evidence.
+
+The operational metric is reconstruction time: reducing the time required to understand a meaningful production issue from 30–60 minutes to under 10 minutes.
+
+The product outcome is operational leverage: making production failures legible enough that one operator can safely manage more system surface area, hand off debugging context, and eventually delegate implementation work to a coding agent without losing control of evidence or verification.
+
+BugOps begins with deterministic signal detection and manual operator control. It does not start with autonomous remediation, LLM diagnosis, or automatic code changes.
+
+**Status: The first end-to-end path is implemented and running in production.**
+
+Initial production path:
+
+```text
+llm_traces → bug_alert_event → bug_case → optional alert → deterministic report
+```
+
+---
+
+## 2. Why This Matters for AI Systems
+
+Production AI systems do not only fail through crashes. They often fail through degradation.
+
+Outputs become less grounded. Costs drift upward. Generated summaries stop passing validation. Evidence stops flowing into downstream generation steps. The system may still be running, but the quality or reliability of its output has changed.
+
+That creates a different operating problem from traditional monitoring. By the time the failure is obvious, the evidence needed to understand it may be gone.
+
+AI systems also carry a specific trust risk: generated artifacts can become inputs to later generation. If degraded output quietly propagates through the pipeline, the system can compound the error instead of surfacing it.
+
+BugOps is designed around that reality. It treats production signals as evidence, not just alerts. It preserves deterministic facts before they disappear, keeps those facts separate from LLM interpretation, and keeps humans in control of diagnosis and resolution until the system has earned more automation.
+
+The same pattern applies to any AI-native product operating at scale: evidence first, trust boundaries enforced, automation only after the manual workflow is understood.
+
+---
+
+## 3. Problem: Production Context Reconstruction
+
+The system is a production AI pipeline with multiple moving parts: FastAPI backend, Celery workers, Redis, MongoDB, cloud deployment, frontend, LLM gateway, trace logging, cost controls, scheduled processing, and generation pipelines.
+
+When something breaks, the operator must reconstruct context before they can begin debugging.
+
+The evidence needed to understand a production incident is often scattered across deployment logs, MongoDB records, LLM traces, service logs, test results, implementation summaries, and recent code changes. Reconstructing that context is slow, repetitive, and error-prone, particularly when production behavior differs from local validation.
+
+The problem is not simply identifying that a failure occurred. The problem is preserving enough evidence to understand what happened before that evidence disappears.
+
+Recent production incidents exposed this gap:
+
+- a disabled service path still tried to start parts of the system it should have skipped
+- a database access pattern worked in one environment but failed in production
+- code that passed local validation broke when deployed because production resolved imports and runtime paths differently
+- production checks surfaced issues that local tests had missed
+
+In each case, the failure itself was only part of the work. The larger burden was reconstructing the context required to investigate it.
+
+BugOps exists to reduce that context reconstruction burden.
+
+---
+
+## 4. User and Workflow
+
+### Primary User
+
+The production operator responsible for maintaining confidence in the system's behavior in production.
+
+Their job is not simply to fix bugs. Their job is to determine whether the system is healthy, identify meaningful failures, preserve enough evidence to understand them, coordinate fixes, and verify that production behavior has actually improved afterward.
+
+They are accountable for reliability but operate with incomplete information. When incidents occur, they often need to reconstruct context across logs, traces, databases, deployments, and recent code changes before they can begin debugging.
+
+In the current implementation, I am this operator.
+
+### Before BugOps
+
+The operator manually checks deployment logs, LLM traces, MongoDB, service logs, and recent code changes — spending 30–60 minutes reconstructing what happened, often after the evidence has already rotated out.
+
+### After BugOps
+
+A case notification arrives only when a meaningful new issue is detected. The operator opens the deterministic report, sees the alert event, the observed metrics, and the suggested checks. Investigation starts with preserved evidence instead of context reconstruction.
+
+### Validation Beyond the Current Operator
+
+The initial version benefits from an unusually tight feedback loop because the builder and operator are currently the same person. This accelerated iteration and made it possible to validate the core workflow against real production incidents, but it also limits external validation.
+
+The next validation step is to conduct structured interviews with other AI system operators and builders about recent production incidents, compare their debugging workflows against the BugOps case model, and evaluate whether the preserved evidence would have been sufficient to begin investigation.
+
+The goal is not to validate a specific implementation. The goal is to validate the underlying product assumption: that preserving evidence and normalizing incidents into durable cases reduces context reconstruction for operators who did not build the system themselves.
+
+Success would indicate that the BugOps case model generalizes beyond a single environment and a single operator's debugging habits.
+
+### Secondary Future Users
+
+- AI coding agent
+- reviewing agent
+- future maintainers
+- product and engineering collaborators
+
+### Current User Needs
+
+- know when production has a meaningful issue
+- avoid manually watching logs all the time
+- distinguish real issues from noise
+- preserve evidence before it disappears
+- know what to check next
+- avoid duplicate investigation of the same issue
+- eventually hand clean bug context to a coding agent
+
+---
+
+## 5. Current State
+
+The smallest end-to-end BugOps signal path is proven and running in production:
+
+```text
+llm_traces signal
+→ normalized bug_alert_event
+→ bug_case
+→ one-way alert for new cases only
+→ minimal deterministic report
+```
+
+Implemented: BugOps service, SignalSource seam, LLMTraceCostSignalSource, BugAlertEvent model, BugCase model, BugOpsStore, alert-to-case flow by dedupe_key, one-way notifications, deterministic case report, persisted heartbeat.
+
+Current active signal source: LLM cost runaway detection.
+
+Current case grouping: exact dedupe_key matching only.
+
+Notification behavior: sends only when a new case is created; does not send for repeated alerts on an existing open case.
+
+Report behavior: deterministic only; no LLM synthesis; no unsupported causality language.
+
+---
+
+## 6. Example Case
+
+A trace pattern indicates LLM cost runaway for a specific operation.
+
+BugOps creates a normalized bug_alert_event containing the observed metrics, source metadata, severity, and deterministic dedupe key.
+
+The event is evaluated against existing open cases.
+
+If no matching case exists, BugOps creates a new bug_case and sends a one-way notification. If a matching case already exists, the alert is attached to the existing case and no additional notification is sent.
+
+The operator opens the deterministic report and sees:
+
+- observed spend metrics
+- affected operation
+- source metadata
+- alert history
+- suggested manual checks
+
+Instead of manually searching traces, logs, deployment history, and database records to reconstruct context, the operator begins investigation from a preserved evidence bundle.
+
+---
+
+## 7. Goals
+
+### Core Goals
+
+1. Detect production signals that indicate real operational issues.
+2. Normalize raw signals into structured bug alert events.
+3. Group related alerts into durable bug cases.
+4. Notify the operator only when a new case is created.
+5. Preserve deterministic evidence for investigation.
+6. Generate deterministic case reports.
+7. Keep humans in control of diagnosis, fixing, and closing cases.
+8. Expand signal coverage over time based on real production operating experience.
+
+### Long-Term Goal
+
+Create a closed-loop bug operations system:
+
+```text
+production failure
+→ normalized case
+→ evidence bundle
+→ diagnosis pack
+→ fix brief
+→ coding agent implementation
+→ verification review
+→ post-fix production validation
+→ case closure with evidence
+```
+
+---
+
+## 8. Non-Goals
+
+BugOps is not initially trying to be:
+
+- a full observability platform
+- a Datadog replacement
+- a log search engine
+- an autonomous remediation agent
+- an incident management system
+- an LLM-first diagnosis tool
+- a dashboard product
+- a general-purpose bug tracker
+- an auto-fix / auto-merge system
+
+Important initial constraints:
+
+- no LLM calls in the critical alert path
+- no autonomous code changes
+- no automatic remediation
+- no fuzzy correlation until deterministic grouping proves insufficient
+- no operator UI until manual workflows are clear
+
+---
+
+## 9. Key Concepts
+
+### Signal Source
+
+A SignalSource is a modular source of production signals. Each source emits normalized alert events.
+
+Examples: LLM traces, deployment logs, FastAPI runtime errors, worker task failures, database reliability errors, worker heartbeat failures.
+
+### Bug Alert Event
+
+A bug_alert_event is a normalized record of one detected signal. Alert events are immutable evidence.
+
+Fields: source_type, alert_type, severity (warning/high/critical), dedupe_key, observed metrics, source metadata, created_at.
+
+### Bug Case
+
+A bug_case groups one or more alert events into an operator-facing case. Cases represent things worth investigating.
+
+Fields: case_id, status, severity, title, summary, dedupe_key, source_types, alert_ids, created_at, updated_at.
+
+### Dedupe Key
+
+A deterministic key used to decide whether an alert belongs to an existing open case. Exact match only. No fuzzy matching. No LLM matching. No multi-source correlation yet.
+
+### Deterministic Report
+
+A report based only on stored facts. Includes case metadata, alert events, observed metrics, known facts, and suggested manual checks. Does not include unsupported root cause claims.
+
+---
+
+## 10. Functional Requirements
+
+**FR1: Monitor Loop** — Run as a separate production process. Load signal sources, poll on a configured interval, create alert events, create or update cases, optionally send notifications, log poll results, avoid crashing on recoverable source errors.
+
+**FR2: Disabled Mode** — Exit cleanly without initializing database connections, messaging integrations, or unnecessary runtime dependencies.
+
+**FR3: Alert Event Creation** — For each detected signal, create a normalized bug_alert_event with: alert_id, source_type, alert_type, severity, title, summary, dedupe_key, correlation_keys, metric payload, source metadata, created_at.
+
+**FR4: Alert-to-Case Flow** — Store alert event. Find open case with matching dedupe_key. If none, create new case. If found, attach alert to existing case. Return whether case is new.
+
+**FR5: Notifications** — Send only for new cases. Do not send for repeated alerts on an existing open case. Include core case fields, observed metrics, and suggested manual check. Handle notification failure without crashing.
+
+**FR6: Deterministic Case Report** — Generate report from stored facts only. Must not include causality phrases: caused by, due to, root cause, leads to, is responsible for.
+
+**FR7: Heartbeat Logging** — Log poll completion: sources checked, alerts found, cases created/updated, duration.
+
+**FR8: Persisted Heartbeat** — Persist heartbeat status so silent monitor failure is detectable.
+
+**FR9: Idempotency Guardrails** — Prevent duplicate open cases for the same dedupe_key via single replica and database-level guardrails.
+
+**FR10: Runtime Failure Detection** — Expand to detect startup crashes, Python tracebacks, import errors, database connection failures, messaging failures, and platform log-rate-limit warnings.
+
+---
+
+## 11. Non-Functional Requirements
+
+**Reliability** — Source failure, notification failure, and individual bad alerts must not crash the monitor or block future polling.
+
+**Cost** — No LLM in critical path. Configurable poll interval. Minimal memory footprint. Single replica.
+
+**Safety** — BugOps writes only to its own collections. Does not write to production pipeline collections.
+
+**Observability** — Startup logs, enabled/disabled state logs, poll-complete logs, source error logs, notification success/failure logs, persisted heartbeat.
+
+**Maintainability** — New signal sources plug into the SignalSource seam without changing the core alert-to-case flow.
+
+---
+
+## 12. Architecture
+
+BugOps runs as a separate service alongside the main application.
+
+Flow:
+
+1. Monitor starts.
+2. Config is loaded.
+3. If disabled, exit cleanly.
+4. Signal sources are initialized.
+5. Monitor polls each source.
+6. Sources emit alert events.
+7. Store creates alert events.
+8. Store creates or updates cases.
+9. Notifications send only for new cases.
+10. Reports can be generated deterministically.
+11. Heartbeat is logged and persisted.
+
+---
+
+## 13. Roadmap
+
+**Phase 1 — Signal Intake Foundation** — Prove first end-to-end path. Status: Done.
+
+**Phase 2 — Production Hardening and Runtime Coverage** — Heartbeat logs, persisted heartbeat, startup noise cleanup, notification validation, idempotency guardrails, runtime failure detection, operator runbook.
+
+**Phase 3 — Investigation Workflow and Diagnosis Packs** — Evidence bundle, related traces and logs, known facts and unknowns, suggested checks. List open cases, view report, resolve, close, add note, attach validation evidence.
+
+**Phase 4 — LLM Synthesis, Fix Briefs, and Closed-Loop Validation** — Summarize diagnosis pack, suggest hypotheses, cite evidence, label uncertainty. Turn cases into agent-ready fix briefs. Post-fix monitoring and case closure with evidence.
+
+---
+
+## 14. Success Metrics
+
+### Primary Outcome
+
+Increase the amount of production surface area one operator can safely manage.
+
+The operational metric is production failure reconstruction time: reduce the time required to understand a meaningful production issue from an estimated 30–60 minutes of manual log, trace, database, and deployment inspection to under 10 minutes.
+
+### Measurement Plan
+
+For each meaningful production issue, record:
+
+- time from first production signal to operator awareness
+- time from awareness to first credible understanding of the issue
+- whether the case preserved enough evidence to begin debugging without additional log archaeology
+- whether the alert was useful, noisy, duplicate, or missing key context
+- whether the issue required manual investigation outside the BugOps case report
+- whether the case could be handed to another human or coding agent with enough context to continue investigation
+
+### Short-Term Success
+
+BugOps is successful after Phase 2 if:
+
+- it runs continuously in production
+- it emits and persists heartbeat status
+- it creates no duplicate open cases for the same deterministic dedupe_key
+- new-case notifications are useful enough to keep enabled
+- deterministic reports provide enough context to begin investigation
+- LLM cost runaway detection is captured as a durable case
+
+### Medium-Term Success
+
+BugOps is successful in the medium term if:
+
+- it detects runtime failures beyond LLM cost drift
+- it captures issues that would otherwise require manual log watching
+- target: 90% of meaningful incidents produce a case with preserved evidence
+- diagnosis packs reduce the number of systems the operator must inspect manually
+- alert noise remains low enough that the operator continues to trust the system
+
+### Product Impact
+
+BugOps should increase the amount of production surface area one operator can safely manage without increasing the amount of manual context reconstruction required to operate the system.
+
+The goal is not only to save minutes during incidents, but to make production operations legible enough to review, hand off, and scale.
+
+---
+
+## 15. Risks
+
+**BugOps becomes too broad** — Add signal sources incrementally; do not build a full observability platform.
+
+**Alert noise** — Start with narrow, high-confidence patterns; notify only on new cases.
+
+**LLM hallucination** — Keep deterministic facts separate from LLM synthesis; do not add interpretation until diagnosis packs exist.
+
+**Duplicate cases** — Deterministic dedupe_key logic and database-level guardrails.
+
+**Log sources are messy** — Use deployment logs only for narrow runtime failure patterns; add structured app signals later.
+
+**The system becomes more interesting than useful** — Only expand when real production operating experience justifies the next layer.
+
+---
+
+## 16. Tradeoffs
+
+**Deterministic detection before LLM diagnosis** — A false root cause claim in an alert erodes trust in the whole system faster than a missing hypothesis. Evidence first; synthesis only after the deterministic layer is solid.
+
+**Exact dedupe matching before fuzzy correlation** — Fuzzy matching can silently merge unrelated cases. The cost is occasional duplicate cases for the same underlying issue. That is a manageable operator burden; invisible case merges are not.
+
+**Separate monitoring process over inline alerting** — Inline alerting creates coupling between the monitoring system and the system being monitored. Separation keeps the failure modes isolated.
+
+**Narrow signal coverage over broad instrumentation** — Broad instrumentation creates alert noise that operators learn to ignore. High-confidence signals on a narrow surface are more useful than comprehensive coverage that no one trusts.
+
+---
+
+## 17. Open Questions and Current Leanings
+
+1. **Should deployment logs be the primary Phase 2 source, or only a startup-crash safety net?** Current leaning: use deployment logs narrowly for startup crashes and obvious runtime failures, then move toward structured app and worker signals. Deployment logs are useful for coverage but too noisy to become the primary long-term signal source.
+
+2. **Which structured signal should come first: application errors, worker failures, or database reliability?** Current leaning: application errors first, because they are closest to user-visible production failures and can produce cleaner case evidence than platform logs.
+
+3. **How much case lifecycle is needed before adding an operator UI?** Current leaning: keep lifecycle minimal until repeated friction appears in the manual workflow. The trigger for adding a UI is operational drag in resolving, reviewing, or closing cases, not a feature roadmap milestone. The initial lifecycle of open → resolved → closed is enough until manual operation shows that notes, filtering, case views, or assignment would materially improve the operator workflow.
+
+4. **Are diagnosis packs enough before LLM synthesis?** Current leaning: yes. Diagnosis packs should exist before LLM synthesis so that any AI interpretation is grounded in deterministic evidence rather than raw, scattered logs.
+
+5. **When should BugOps integrate directly with a coding agent?** Current leaning: only after case reports and diagnosis packs consistently produce enough context for a human operator to begin debugging. Agent handoff should follow proven human handoff.
+
+6. **Should fix brief generation be part of BugOps or a separate tooling track?** Current leaning: BugOps should own the evidence and case context; fix brief generation can be a downstream capability once the evidence model is stable.
+
+---
+
+## 18. Product Principle
+
+BugOps should not try to be smart before it is useful.
+
+The principle is:
+
+1. context before conclusions
+2. evidence before interpretation
+3. manual workflow before automation
+
+That means BugOps should first make production failures legible. It should detect real signals, preserve the evidence, create durable cases, notify the operator, and make investigation easier.
+
+Only after that workflow is reliable should BugOps add diagnosis, synthesis, agent handoff, or automated remediation.
+
+The goal is not to make the system appear intelligent. The goal is to make production operations more trustworthy, reviewable, and scalable.

--- a/docs/bugops/spec/v1/bugops-product-spec-v5.md
+++ b/docs/bugops/spec/v1/bugops-product-spec-v5.md
@@ -1,0 +1,494 @@
+# Product Spec: BugOps
+
+---
+
+**Note:** This is a real product spec for a production feature I built inside Backdrop, a multi-service AI pipeline I developed and operate independently.
+
+The primary user is an internal operator persona: the person responsible for keeping the system reliable in production. In the current implementation, I am that operator, which created an unusually tight feedback loop between observing production incidents, identifying workflow friction, and shipping improvements.
+
+I chose this spec because it reflects how I approach product development: start with a real operational problem, define a narrow first version, establish clear trust boundaries, and expand automation only after the manual workflow is understood.
+
+The system described here is running in production.
+
+---
+
+---
+
+## 1. Product Summary
+
+BugOps helps an operator understand production bugs faster.
+
+It watches for meaningful production issues, turns them into bug cases, preserves the evidence, and alerts the operator when there is something new to investigate.
+
+Instead of starting from scattered logs, traces, database records, deployment history, and recent code changes, the operator starts from a case report that shows what happened, where the signal came from, what metrics were observed, and what to check next.
+
+The operational goal is to reduce the time required to understand a meaningful production issue from 30–60 minutes to under 10 minutes.
+
+The product goal is to let one operator safely manage more production surface area without spending more time reconstructing what happened.
+
+BugOps starts with deterministic signal detection and manual operator control. It does not start with autonomous remediation, LLM diagnosis, or automatic code changes.
+
+**Status: The first end-to-end path is implemented and running in production.**
+
+Initial production path:
+
+```text
+llm_traces → bug_alert_event → bug_case → optional alert → deterministic report
+```
+
+---
+
+## 2. User and Problem
+
+### Primary User
+
+The primary user is the production operator responsible for keeping the system reliable in production.
+
+Their job is not simply to fix bugs. Their job is to know whether the system is healthy, identify meaningful failures, preserve enough evidence to understand them, coordinate fixes, and verify that production behavior has actually improved afterward.
+
+In the current implementation, I am this operator.
+
+### Problem
+
+Backdrop is a production AI pipeline with multiple moving parts: FastAPI backend, Celery workers, Redis, MongoDB, cloud deployment, frontend, LLM gateway, trace logging, cost controls, scheduled processing, and generation pipelines.
+
+When something breaks, the operator must reconstruct context before debugging can begin.
+
+The evidence needed to understand a production incident is often scattered across deployment logs, MongoDB records, LLM traces, service logs, test results, implementation summaries, and recent code changes. Reconstructing that context is slow, repetitive, and error-prone, especially when production behavior differs from local validation.
+
+The problem is not simply identifying that a failure occurred. The problem is preserving enough evidence to understand what happened before that evidence disappears.
+
+Recent production incidents exposed this gap:
+
+- a disabled service path still tried to start parts of the system it should have skipped
+- a database access pattern worked in one environment but failed in production
+- code that passed local validation broke when deployed because production resolved imports and runtime paths differently
+- production checks surfaced issues that local tests had missed
+
+In each case, the failure itself was only part of the work. The larger burden was reconstructing the context required to investigate it.
+
+### Before BugOps
+
+The operator manually checked deployment logs, LLM traces, MongoDB, service logs, and recent code changes, often spending 30–60 minutes reconstructing what happened.
+
+### After BugOps
+
+A case notification arrives when a meaningful new issue is detected. The operator opens the deterministic report and sees the alert event, observed metrics, source metadata, alert history, and suggested manual checks.
+
+Investigation starts with preserved evidence instead of context reconstruction.
+
+### Validation Beyond the Current Operator
+
+The initial version benefits from an unusually tight feedback loop because the builder and operator are currently the same person. This accelerated iteration and made it possible to validate the core workflow against real production incidents, but it also limits external validation.
+
+The next validation step is to conduct structured interviews with other AI system operators and builders about recent production incidents, compare their debugging workflows against the BugOps case model, and evaluate whether the preserved evidence would have been sufficient to begin investigation.
+
+The goal is to validate the underlying product assumption: that preserving evidence and normalizing incidents into durable cases reduces context reconstruction for operators who did not build the system themselves.
+
+### Secondary Future Users
+
+- AI coding agent
+- reviewing agent
+- future maintainers
+- product and engineering collaborators
+
+### Current User Needs
+
+- know when production has a meaningful issue
+- avoid manually watching logs
+- distinguish real issues from noise
+- preserve evidence before it disappears
+- know what to check next
+- avoid duplicate investigation of the same issue
+- eventually hand clean bug context to a coding agent
+
+---
+
+## 3. Why This Matters for AI Systems
+
+Production AI systems do not only fail through crashes. They also fail through degradation.
+
+Outputs become less grounded. Costs drift upward. Generated summaries stop passing validation. Evidence stops flowing into downstream generation steps. The system may still be running, but the quality or reliability of its output has changed.
+
+That creates a different operating problem from traditional monitoring. By the time the failure is obvious, the evidence needed to understand it may already be gone.
+
+AI systems also carry a specific trust risk: generated artifacts can become inputs to later generation. If degraded output quietly propagates through the pipeline, the system can compound the error instead of surfacing it.
+
+BugOps is designed around that reality. It treats production signals as evidence, not just alerts. It preserves deterministic facts before they disappear, keeps those facts separate from LLM interpretation, and keeps humans in control of diagnosis and resolution until the system has earned more automation.
+
+The same pattern applies to any AI-native product operating at scale: evidence first, trust boundaries enforced, automation only after the manual workflow is understood.
+
+---
+
+## 4. Current State
+
+The first end-to-end BugOps workflow is implemented and running in production.
+
+The current version validates the core product assumption: a production signal can be detected, normalized into an alert event, grouped into a durable case, sent as a one-way notification, and turned into a deterministic report without using an LLM in the alert path.
+
+Current production path:
+
+```text
+llm_traces signal
+→ normalized bug_alert_event
+→ bug_case
+→ one-way alert for new cases only
+→ deterministic report
+```
+
+What is currently implemented:
+
+- BugOps service
+- SignalSource seam
+- LLMTraceCostSignalSource
+- BugAlertEvent model
+- BugCase model
+- BugOpsStore
+- alert-to-case flow using dedupe_key
+- one-way notifications
+- deterministic case report
+- persisted heartbeat
+
+Current behavior:
+
+- BugOps currently watches LLM trace data for cost runaway patterns.
+- When it finds a matching signal, it creates a normalized alert event.
+- If there is no open case with the same dedupe key, it creates a new bug case and sends a notification.
+- If there is already an open case with the same dedupe key, it attaches the new alert to that case and does not send another notification.
+- Case grouping is exact-match only. There is no fuzzy matching, LLM matching, or multi-source correlation yet.
+- Reports are deterministic only. They summarize stored facts and do not include LLM synthesis or unsupported root-cause claims.
+
+What remains unproven:
+
+- whether the same case model works across runtime errors, worker failures, database failures, and deployment failures
+- whether diagnosis packs reduce investigation time beyond the first signal source
+- whether another operator could use the preserved evidence without needing the builder’s context
+- when the workflow has enough repeated friction to justify an operator UI
+
+---
+
+## 5. Example Case
+
+A cost runaway pattern appears in LLM trace data for a specific operation.
+
+Before BugOps, the operator would need to inspect traces, logs, deployment history, database records, and recent code changes to understand whether the issue was real, repeated, and worth investigating.
+
+With BugOps, the signal is turned into a normalized alert event with observed metrics, source metadata, severity, and a deterministic dedupe key used to group repeat alerts for the same issue.
+
+BugOps checks whether an open case already exists for that dedupe key.
+
+If no matching case exists, BugOps creates a new case and sends a notification. If a matching case already exists, BugOps attaches the alert to that case and does not send another notification.
+
+The operator opens the deterministic report and sees:
+
+- what signal was detected
+- which operation was affected
+- what metrics were observed
+- when the issue first appeared
+- whether related alerts have already been attached
+- what manual checks to run next
+
+The operator starts investigation from a preserved evidence bundle instead of manually reconstructing context from scattered systems.
+
+---
+
+## 6. Goals
+
+### Core Goals
+
+1. Detect production signals that indicate real operational issues.
+2. Normalize raw signals into structured bug alert events.
+3. Group related alerts into durable bug cases.
+4. Notify the operator only when a new case is created.
+5. Preserve deterministic evidence for investigation.
+6. Generate deterministic case reports.
+7. Keep humans in control of diagnosis, fixing, and closing cases.
+8. Expand signal coverage over time based on real production operating experience.
+
+### Long-Term Goal
+
+Create a closed-loop bug operations system:
+
+```text
+production failure
+→ normalized case
+→ evidence bundle
+→ diagnosis pack
+→ fix brief
+→ coding agent implementation
+→ verification review
+→ post-fix production validation
+→ case closure with evidence
+```
+
+---
+
+---
+
+## 7. Non-Goals
+
+BugOps is not initially trying to be:
+
+- a full observability platform
+- a Datadog replacement
+- a log search engine
+- an autonomous remediation agent
+- an incident management system
+- an LLM-first diagnosis tool
+- a dashboard product
+- a general-purpose bug tracker
+- an auto-fix / auto-merge system
+
+Important initial constraints:
+
+- no LLM calls in the critical alert path
+- no autonomous code changes
+- no automatic remediation
+- no fuzzy correlation until deterministic grouping proves insufficient
+- no operator UI until manual workflows are clear
+
+---
+
+---
+
+## 8. Key Concepts
+
+### Signal Source
+
+A SignalSource is a modular source of production signals. Each source emits normalized alert events.
+
+Examples: LLM traces, deployment logs, FastAPI runtime errors, worker task failures, database reliability errors, worker heartbeat failures.
+
+### Bug Alert Event
+
+A bug_alert_event is a normalized record of one detected signal. Alert events are immutable evidence.
+
+Fields: source_type, alert_type, severity (warning/high/critical), dedupe_key, observed metrics, source metadata, created_at.
+
+### Bug Case
+
+A bug_case groups one or more alert events into an operator-facing case. Cases represent things worth investigating.
+
+Fields: case_id, status, severity, title, summary, dedupe_key, source_types, alert_ids, created_at, updated_at.
+
+### Dedupe Key
+
+A deterministic key used to decide whether an alert belongs to an existing open case. Exact match only. No fuzzy matching. No LLM matching. No multi-source correlation yet.
+
+### Deterministic Report
+
+A report based only on stored facts. Includes case metadata, alert events, observed metrics, known facts, and suggested manual checks. Does not include unsupported root cause claims.
+
+---
+
+---
+
+## 9. Functional Requirements
+
+**FR1: Monitor Loop** — Run as a separate production process. Load signal sources, poll on a configured interval, create alert events, create or update cases, optionally send notifications, log poll results, avoid crashing on recoverable source errors.
+
+**FR2: Disabled Mode** — Exit cleanly without initializing database connections, messaging integrations, or unnecessary runtime dependencies.
+
+**FR3: Alert Event Creation** — For each detected signal, create a normalized bug_alert_event with: alert_id, source_type, alert_type, severity, title, summary, dedupe_key, correlation_keys, metric payload, source metadata, created_at.
+
+**FR4: Alert-to-Case Flow** — Store alert event. Find open case with matching dedupe_key. If none, create new case. If found, attach alert to existing case. Return whether case is new.
+
+**FR5: Notifications** — Send only for new cases. Do not send for repeated alerts on an existing open case. Include core case fields, observed metrics, and suggested manual check. Handle notification failure without crashing.
+
+**FR6: Deterministic Case Report** — Generate report from stored facts only. Must not include causality phrases: caused by, due to, root cause, leads to, is responsible for.
+
+**FR7: Heartbeat Logging** — Log poll completion: sources checked, alerts found, cases created/updated, duration.
+
+**FR8: Persisted Heartbeat** — Persist heartbeat status so silent monitor failure is detectable.
+
+**FR9: Idempotency Guardrails** — Prevent duplicate open cases for the same dedupe_key via single replica and database-level guardrails.
+
+**FR10: Runtime Failure Detection** — Expand to detect startup crashes, Python tracebacks, import errors, database connection failures, messaging failures, and platform log-rate-limit warnings.
+
+---
+
+---
+
+## 10. Non-Functional Requirements
+
+**Reliability** — Source failure, notification failure, and individual bad alerts must not crash the monitor or block future polling.
+
+**Cost** — No LLM in critical path. Configurable poll interval. Minimal memory footprint. Single replica.
+
+**Safety** — BugOps writes only to its own collections. Does not write to production pipeline collections.
+
+**Observability** — Startup logs, enabled/disabled state logs, poll-complete logs, source error logs, notification success/failure logs, persisted heartbeat.
+
+**Maintainability** — New signal sources plug into the SignalSource seam without changing the core alert-to-case flow.
+
+---
+
+---
+
+## 11. Architecture
+
+BugOps runs as a separate service alongside the main application.
+
+Flow:
+
+1. Monitor starts.
+2. Config is loaded.
+3. If disabled, exit cleanly.
+4. Signal sources are initialized.
+5. Monitor polls each source.
+6. Sources emit alert events.
+7. Store creates alert events.
+8. Store creates or updates cases.
+9. Notifications send only for new cases.
+10. Reports can be generated deterministically.
+11. Heartbeat is logged and persisted.
+
+---
+
+---
+
+## 12. Roadmap
+
+**Phase 1 — Prove the Core Workflow**  
+Status: Done.
+
+Prove that BugOps can detect a real production signal, normalize it into an alert event, group it into a durable case, notify the operator, and generate a deterministic report.
+
+**Phase 2 — Make the Workflow Reliable Enough to Trust**  
+Add heartbeat logs, persisted heartbeat status, startup noise cleanup, notification validation, idempotency guardrails, runtime failure detection, and an operator runbook.
+
+**Phase 3 — Make Investigation Easier**  
+Build diagnosis packs that collect related traces, logs, known facts, unknowns, and suggested checks. Add the minimal case lifecycle needed to support real operation: list open cases, view report, resolve, close, add note, and attach validation evidence.
+
+**Phase 4 — Expand Automation Responsibly**  
+Add LLM synthesis only after the deterministic evidence layer is reliable. Use synthesis to summarize diagnosis packs, suggest hypotheses, cite evidence, and label uncertainty. Once human handoff works reliably, turn cases into agent-ready fix briefs and support post-fix validation.
+
+---
+
+## 13. Success Metrics
+
+### Primary Outcome
+
+Increase the amount of production surface area one operator can safely manage.
+
+Reducing reconstruction time is the operational metric. The business outcome it enables is operational leverage: an operator who spends 30–60 minutes reconstructing context for every meaningful incident cannot safely take on additional systems, hand off debugging work, or delegate implementation to a coding agent.
+
+BugOps exists to make production issues legible enough that investigation can begin from preserved evidence rather than manual context reconstruction.
+
+### Primary Metric
+
+Reduce the time required to understand a meaningful production issue from an estimated 30–60 minutes to under 10 minutes.
+
+A production issue is considered understood when the operator has enough evidence to form a credible explanation of what happened and identify the next investigation step.
+
+### Measurement Plan
+
+For each meaningful production issue, record:
+
+- time from first production signal to operator awareness
+- time from awareness to first credible understanding of the issue
+- whether the case preserved enough evidence to begin investigation immediately
+- whether the alert was useful, noisy, duplicate, or missing key context
+- whether investigation required significant manual log, trace, or database exploration outside the case report
+- whether the case could be handed to another human or coding agent with enough context to continue investigation
+
+### Short-Term Success
+
+BugOps is successful after Phase 2 if:
+
+- it runs continuously in production
+- it emits and persists heartbeat status
+- it creates no duplicate open cases for the same deterministic dedupe_key
+- new-case notifications are useful enough to keep enabled
+- deterministic reports provide enough context to begin investigation
+- LLM cost runaway detection is captured as a durable case
+
+### Medium-Term Success
+
+BugOps is successful in the medium term if:
+
+- it detects runtime failures beyond LLM cost drift
+- it captures issues that would otherwise require manual log watching
+- target: 90% of meaningful incidents produce a case with preserved evidence
+- diagnosis packs reduce the number of systems the operator must inspect manually
+- alert noise remains low enough that the operator continues to trust the system
+
+### Product Impact
+
+The goal is not only to save time during incidents.
+
+The goal is to make production operations legible enough to review, hand off, and scale.
+
+Success means operators can manage more system complexity, collaborate more effectively, and eventually delegate portions of investigation and implementation without losing confidence in the underlying evidence.
+
+---
+
+## 14. Risks
+
+**BugOps becomes too broad** — Add signal sources incrementally; do not build a full observability platform.
+
+**Alert noise** — Start with narrow, high-confidence patterns; notify only on new cases.
+
+**LLM hallucination** — Keep deterministic facts separate from LLM synthesis; do not add interpretation until diagnosis packs exist.
+
+**Duplicate cases** — Deterministic dedupe_key logic and database-level guardrails.
+
+**Log sources are messy** — Use deployment logs only for narrow runtime failure patterns; add structured app signals later.
+
+**The system becomes more interesting than useful** — Only expand when real production operating experience justifies the next layer.
+
+---
+
+---
+
+## 15. Tradeoffs
+
+**Deterministic detection before LLM diagnosis** — A false root cause claim in an alert erodes trust in the whole system faster than a missing hypothesis. Evidence first; synthesis only after the deterministic layer is solid.
+
+**Exact dedupe matching before fuzzy correlation** — Fuzzy matching can silently merge unrelated cases. The cost is occasional duplicate cases for the same underlying issue. That is a manageable operator burden; invisible case merges are not.
+
+**Separate monitoring process over inline alerting** — Inline alerting creates coupling between the monitoring system and the system being monitored. Separation keeps the failure modes isolated.
+
+**Narrow signal coverage over broad instrumentation** — Broad instrumentation creates alert noise that operators learn to ignore. High-confidence signals on a narrow surface are more useful than comprehensive coverage that no one trusts.
+
+---
+
+---
+
+## 16. Open Questions and Current Leanings
+
+1. **Should deployment logs be the primary Phase 2 source, or only a startup-crash safety net?**  
+   Current leaning: use deployment logs narrowly for startup crashes and obvious runtime failures, then move toward structured app and worker signals. Deployment logs provide coverage, but they are too noisy to become the primary long-term signal source.
+
+2. **Which structured signal should come first: application errors, worker failures, or database reliability?**  
+   Current leaning: application errors first, because they are closest to user-visible production failures and can produce cleaner case evidence than platform logs.
+
+3. **How much case lifecycle is needed before adding an operator UI?**  
+   Current leaning: keep lifecycle minimal until repeated friction appears in the manual workflow. The trigger for adding a UI is operational drag in resolving, reviewing, or closing cases, not a feature roadmap milestone.
+
+4. **Are diagnosis packs enough before LLM synthesis?**  
+   Current leaning: yes. Diagnosis packs should exist before LLM synthesis so that any AI interpretation is grounded in deterministic evidence rather than raw, scattered logs.
+
+5. **When should BugOps integrate directly with a coding agent?**  
+   Current leaning: only after case reports and diagnosis packs consistently produce enough context for a human operator to begin debugging. Agent handoff should follow proven human handoff.
+
+6. **Should fix brief generation be part of BugOps or a separate tooling track?**  
+   Current leaning: BugOps should own the evidence and case context. Fix brief generation can be downstream once the evidence model is stable.
+
+---
+
+## 17. Product Principle
+
+BugOps should not try to be smart before it is useful.
+
+The principle is:
+
+1. context before conclusions
+2. evidence before interpretation
+3. manual workflow before automation
+
+That means BugOps should first make production failures legible. It should detect real signals, preserve the evidence, create durable cases, notify the operator, and make investigation easier.
+
+Only after that workflow is reliable should BugOps add diagnosis, synthesis, agent handoff, or automated remediation.
+
+The goal is not to make the system appear intelligent. The goal is to make production operations more trustworthy, reviewable, and scalable.

--- a/docs/bugops/spec/v1/bugops-product-spec.md
+++ b/docs/bugops/spec/v1/bugops-product-spec.md
@@ -1,0 +1,882 @@
+# Product Spec: BugOps
+
+## 1. Product Summary
+
+BugOps is a production monitoring, triage, and debugging-assistance system for Backdrop.
+
+Its purpose is to detect production issues, normalize them into durable bug cases, notify the operator, preserve evidence, and eventually support the full path from production failure to verified fix.
+
+BugOps begins with deterministic signal detection and manual operator control. It does not start with autonomous remediation, LLM diagnosis, or automatic code changes.
+
+Initial production path:
+
+```text
+llm_traces → bug_alert_event → bug_case → optional Slack alert → deterministic report
+```
+
+Sprint 018 proved this first path for LLM cost runaway detection. Runtime errors, Railway failures, worker failures, and structured app errors are planned future coverage areas, not yet fully implemented.
+
+---
+
+## 2. Problem
+
+Backdrop is a production AI system with multiple moving parts:
+
+- FastAPI backend
+- Celery workers
+- Redis
+- MongoDB
+- Railway deployment
+- Vercel frontend
+- LLM gateway
+- trace logging
+- cost controls
+- scheduled processing
+- briefing and narrative generation
+
+When something breaks, the current debugging process is too manual.
+
+The operator has to inspect Railway logs, MongoDB, `llm_traces`, service logs, test output, implementation summaries, and code changes, then reconstruct what happened.
+
+This is slow, error-prone, and especially painful when production behaves differently from local validation.
+
+Recent Sprint 018 rollout bugs showed the gap clearly:
+
+- disabled mode initialized dependencies it should not have touched
+- enabled mode hit async/sync Mongo getter mismatch
+- runtime/import paths behaved differently in production
+- production validation exposed issues that local tests did not catch
+
+BugOps exists to reduce this production-debugging burden.
+
+---
+
+## 3. User
+
+### Primary User
+
+- Solo operator / builder of Backdrop
+
+### Secondary Future Users
+
+- AI coding agent
+- reviewing agent
+- future maintainers
+- product/engineering collaborators
+
+### Current User Needs
+
+- know when production has a meaningful issue
+- avoid manually watching logs all the time
+- distinguish real issues from noise
+- preserve evidence before it disappears
+- know what to check next
+- avoid duplicate investigation of the same issue
+- eventually hand clean bug context to Claude Code
+
+---
+
+## 4. Goals
+
+### Core Goals
+
+1. Detect production signals that indicate real operational issues.
+2. Normalize raw signals into structured bug alert events.
+3. Group related alerts into durable bug cases.
+4. Notify the operator only when a new case is created.
+5. Preserve deterministic evidence for debugging.
+6. Generate deterministic case reports.
+7. Keep humans in control of diagnosis, fixing, and closing cases.
+8. Expand signal coverage over time based on real production pain.
+
+### Long-Term Goal
+
+Create a closed-loop bug operations system:
+
+```text
+production failure
+→ normalized case
+→ evidence bundle
+→ diagnosis pack
+→ fix brief
+→ coding agent implementation
+→ verification review
+→ post-fix production validation
+→ case closure with evidence
+```
+
+---
+
+## 5. Non-Goals
+
+BugOps is not initially trying to be:
+
+- a full observability platform
+- a Datadog replacement
+- a Railway log search engine
+- an autonomous remediation agent
+- a Slack-based incident management system
+- an LLM-first diagnosis tool
+- a dashboard product
+- a general-purpose bug tracker
+- an auto-fix / auto-merge system
+
+Important initial constraints:
+
+- no LLM calls in the critical alert path
+- no autonomous code changes
+- no automatic remediation
+- no fuzzy correlation until deterministic grouping proves insufficient
+- no Slack UI until manual workflows are clear
+
+---
+
+## 6. Current State
+
+### Implemented in Sprint 018
+
+Sprint 018 proved the smallest end-to-end BugOps signal path:
+
+```text
+llm_traces signal
+→ normalized bug_alert_event
+→ bug_case
+→ one-way Slack webhook alert for new cases only
+→ minimal deterministic report
+```
+
+Implemented components:
+
+- BugOps service skeleton
+- `SignalSource` seam
+- `LLMTraceCostSignalSource`
+- `BugAlertEvent` model
+- `BugCase` model
+- `BugOpsStore`
+- alert-to-case flow by `dedupe_key`
+- one-way Slack notification
+- deterministic case report
+- Railway log data-shape spike
+- BugOps docs
+- Railway production service setup
+
+Current active signal source:
+
+- `llm_traces` cost runaway detection
+
+Current alert type:
+
+- `cost_runaway`
+
+Current case grouping:
+
+- exact `dedupe_key` matching
+
+Current notification behavior:
+
+- Slack sends only when a new case is created
+- Slack does not send for repeated alerts attached to an existing open case
+
+Current report behavior:
+
+- deterministic report only
+- no LLM synthesis
+- no unsupported causality language
+
+---
+
+## 7. Key Concepts
+
+### Signal Source
+
+A `SignalSource` is a modular source of production signals.
+
+Examples:
+
+- `llm_traces`
+- Railway logs
+- FastAPI runtime errors
+- Celery task failures
+- Mongo reliability errors
+- worker heartbeat failures
+
+Each source emits normalized alert events.
+
+### Bug Alert Event
+
+A `bug_alert_event` is a normalized record of one detected signal.
+
+Example fields:
+
+- `source_type`: `llm_traces`
+- `alert_type`: `cost_runaway`
+- `severity`: `warning`, `high`, or `critical`
+- `dedupe_key`
+- observed metrics
+- source metadata
+- `created_at`
+
+Alert events are immutable evidence.
+
+### Bug Case
+
+A `bug_case` groups one or more alert events into an operator-facing case.
+
+Cases represent things worth investigating.
+
+A case has:
+
+- `case_id`
+- `status`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `source_types`
+- `alert_ids`
+- `created_at`
+- `updated_at`
+
+### Dedupe Key
+
+A deterministic key used to decide whether an alert belongs to an existing open case.
+
+Initial rule:
+
+- exact `dedupe_key` match only
+
+No fuzzy matching.
+
+No LLM matching.
+
+No multi-source correlation yet.
+
+### Deterministic Report
+
+A generated report based only on stored facts.
+
+It includes:
+
+- case metadata
+- alert events
+- observed metrics
+- known facts
+- suggested manual checks
+
+It does not include unsupported root cause claims.
+
+---
+
+## 8. Functional Requirements
+
+### FR1: Monitor Loop
+
+BugOps must run as a separate production process.
+
+It should:
+
+- load enabled signal sources
+- poll on a configured interval
+- create alert events
+- create or update bug cases
+- optionally send Slack notifications
+- log poll results
+- avoid crashing on recoverable source errors
+
+### FR2: Disabled Mode
+
+When `BUGOPS_ENABLED=false`:
+
+- BugOps exits cleanly
+- BugOps does not initialize Mongo
+- BugOps does not initialize Redis
+- BugOps does not initialize Slack
+- BugOps does not import unnecessary app runtime dependencies
+
+### FR3: Alert Event Creation
+
+For each detected signal, BugOps must create a normalized `bug_alert_event`.
+
+Alert events should include:
+
+- `alert_id`
+- `source_type`
+- `alert_type`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `correlation_keys`
+- metric payload
+- source metadata
+- `created_at`
+
+### FR4: Alert-to-Case Flow
+
+For each alert event:
+
+1. Store the alert event.
+2. Look for an open case with the same `dedupe_key`.
+3. If no open case exists, create a new case.
+4. If an open case exists, attach the alert to that case.
+5. Return whether the case is new.
+
+### FR5: Slack Notification
+
+When Slack is enabled:
+
+- send only for new cases
+- do not send for repeated alerts attached to the same open case
+- include core case fields
+- include observed metrics
+- include suggested manual check
+- handle webhook failure without crashing
+
+When Slack is disabled:
+
+- send nothing
+- continue normal case creation
+
+### FR6: Deterministic Case Report
+
+BugOps must generate a deterministic report for a case.
+
+Report includes:
+
+- case ID
+- status
+- severity
+- source types
+- dedupe key
+- created / updated timestamps
+- summary
+- alert events
+- observed metrics
+- known facts
+- suggested manual checks
+
+Report must not include unsupported causality phrases such as:
+
+- caused by
+- due to
+- root cause
+- leads to
+- is responsible for
+
+### FR7: Heartbeat Logging
+
+BugOps must log poll completion.
+
+Example:
+
+```text
+BugOps poll complete: sources=1 alerts=0 cases_created=0 cases_updated=0 duration_ms=123
+```
+
+### FR8: Persisted Heartbeat
+
+BugOps should persist heartbeat status so silent monitor failure is detectable.
+
+Suggested collection:
+
+```text
+bug_heartbeats
+```
+
+Suggested fields:
+
+- service
+- last_poll_at
+- status
+- sources_checked
+- alerts_found
+- cases_created
+- duration_ms
+- error_message
+
+### FR9: Idempotency Guardrails
+
+BugOps should prevent duplicate open cases for the same `dedupe_key`.
+
+Initial approach:
+
+- one production replica
+- documented one-replica assumption
+- Mongo-level uniqueness or upsert safety where straightforward
+
+### FR10: Runtime Failure Detection
+
+BugOps should expand beyond LLM cost monitoring to detect runtime failures.
+
+Initial runtime source:
+
+- minimal Railway log detector
+
+Target patterns:
+
+- startup crashes
+- Python tracebacks
+- `ModuleNotFoundError`
+- `NameError`
+- `TypeError`
+- ObjectId serialization/hydration errors
+- Mongo `AutoReconnect`
+- Redis connection failures
+- Slack notification failures
+- Railway platform log-rate-limit warnings
+
+---
+
+## 9. Non-Functional Requirements
+
+### Reliability
+
+BugOps should fail safely.
+
+- Source failure should not crash the whole monitor.
+- Slack failure should not crash the monitor.
+- One bad alert should not block future polling.
+- Disabled mode should be clean and dependency-light.
+
+### Cost
+
+BugOps should be cheap to run.
+
+- No LLM in critical path.
+- Poll interval configurable.
+- Minimal memory footprint.
+- One Railway replica.
+- No expensive background processing.
+
+### Safety
+
+BugOps should not modify production application data.
+
+Allowed writes:
+
+- `bug_alert_events`
+- `bug_cases`
+- `bug_case_reports`
+- `bug_heartbeats`
+- future `bug_case_events` if needed
+
+BugOps should not write to:
+
+- `articles`
+- `narratives`
+- `briefings`
+- `api_costs`
+- `llm_traces`
+- production pipeline collections
+
+### Observability
+
+BugOps itself must be observable.
+
+Minimum:
+
+- startup logs
+- enabled/disabled state logs
+- poll-complete logs
+- source error logs
+- Slack success/failure logs
+- persisted heartbeat
+
+### Maintainability
+
+BugOps should remain modular.
+
+New signal sources should plug into the `SignalSource` seam without changing the core alert-to-case flow.
+
+---
+
+## 10. Data Model
+
+### `bug_alert_events`
+
+Purpose:
+
+Store normalized production signals.
+
+Important fields:
+
+- `alert_id`
+- `source_type`
+- `alert_type`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `correlation_keys`
+- `metric`
+- `source_metadata`
+- `case_id`
+- `created_at`
+
+### `bug_cases`
+
+Purpose:
+
+Store durable operator-facing cases.
+
+Important fields:
+
+- `case_id`
+- `status`
+- `severity`
+- `title`
+- `summary`
+- `dedupe_key`
+- `source_types`
+- `alert_ids`
+- `created_at`
+- `updated_at`
+- `resolved_at`
+- `closed_at`
+
+Current lifecycle:
+
+```text
+open → resolved → closed
+```
+
+### `bug_case_reports`
+
+Purpose:
+
+Store generated deterministic reports.
+
+Important fields:
+
+- `report_id`
+- `case_id`
+- `report_text`
+- `generated_at`
+- `report_type`
+
+### `bug_heartbeats`
+
+Purpose:
+
+Show whether BugOps is alive and polling.
+
+Important fields:
+
+- service
+- last_poll_at
+- status
+- sources_checked
+- alerts_found
+- cases_created
+- duration_ms
+- error_message
+
+---
+
+## 11. Architecture
+
+### Process
+
+BugOps runs as a separate Railway service.
+
+Production start command:
+
+```bash
+PYTHONPATH=/app/src python -m crypto_news_aggregator.bugops.monitor
+```
+
+Local command:
+
+```bash
+PYTHONPATH=src python -m crypto_news_aggregator.bugops.monitor
+```
+
+### Core Modules
+
+Suggested existing / future structure:
+
+```text
+src/crypto_news_aggregator/bugops/
+  config.py
+  monitor.py
+  models.py
+  store.py
+  slack.py
+  reports.py
+  signal_sources/
+    base.py
+    llm_traces.py
+    railway_logs.py
+    app_runtime.py
+    worker_failures.py
+    mongo_reliability.py
+```
+
+### Flow
+
+1. Monitor starts.
+2. Config is loaded.
+3. If disabled, exit cleanly.
+4. Signal sources are initialized.
+5. Monitor polls each source.
+6. Sources emit alert events.
+7. Store creates alert events.
+8. Store creates or updates cases.
+9. Slack sends only for new cases.
+10. Reports can be generated deterministically.
+11. Heartbeat is logged and persisted.
+
+---
+
+## 12. Roadmap
+
+### Sprint 018 — Signal Intake Foundation
+
+Prove first end-to-end path:
+
+```text
+llm_traces → bug_alert_event → bug_case → Slack/report
+```
+
+Status:
+
+- Done
+
+### Sprint 019 — Production Hardening
+
+Make BugOps safe and trustworthy enough to leave running.
+
+Scope:
+
+- heartbeat logs
+- persisted heartbeat
+- Redis/startup noise cleanup
+- Slack production validation
+- idempotency guardrails
+- short operator runbook
+
+### Sprint 020 — Runtime Failure Detection
+
+Expand beyond LLM cost monitoring.
+
+Scope:
+
+- minimal Railway runtime error detector
+- startup crash detection
+- Python exception detection
+- Mongo/Redis failure patterns
+- Slack failure pattern detection
+- platform log-rate-limit warnings
+
+### Sprint 021 — Structured App and Worker Error Signals
+
+Add cleaner first-class signals.
+
+Scope:
+
+- FastAPI exception middleware
+- Celery task failure hooks
+- Mongo reliability instrumentation
+- worker/beat liveness checks
+- retry storm detection
+
+### Sprint 022 — Diagnosis Packs
+
+Make cases actionable.
+
+Scope:
+
+- evidence bundle
+- related traces
+- related logs
+- known facts
+- unknowns
+- suggested checks
+- safe commands / queries
+
+### Sprint 023 — Manual Case Workflow
+
+Make cases easy to operate manually.
+
+Scope:
+
+- list open cases
+- view report
+- resolve case
+- close case
+- add note
+- attach validation evidence
+
+### Sprint 024 — Slack Operator UI
+
+Add lightweight Slack controls.
+
+Scope:
+
+- acknowledge
+- resolve
+- close
+- generate diagnosis pack
+- link to case/report
+
+### Sprint 025 — LLM Case Synthesis
+
+Add cautious AI interpretation over deterministic evidence.
+
+Scope:
+
+- summarize diagnosis pack
+- suggest hypotheses
+- suggest checks
+- cite evidence
+- label uncertainty
+
+### Sprint 026 — Fix Brief Generation
+
+Turn cases into agent-ready fix briefs.
+
+Scope:
+
+- problem statement
+- evidence
+- suspected files
+- constraints
+- tests
+- validation plan
+- rollback notes
+
+### Sprint 027 — Coding Agent Verification Harness
+
+Review Claude Code fixes against the ticket and evidence.
+
+Scope:
+
+- ticket/fix brief
+- git diff
+- implementation summary
+- test output
+- verdict
+- concerns
+- follow-up prompt
+
+### Sprint 028 — Closed-Loop BugOps Validation
+
+Verify that shipped fixes actually resolved the production issue.
+
+Scope:
+
+- post-fix monitoring
+- alert pattern stopped
+- metrics returned to baseline
+- case closed with evidence
+
+---
+
+## 13. Success Metrics
+
+### Short-Term Success
+
+BugOps is successful after Sprint 019 if:
+
+- it runs continuously in production
+- it emits heartbeat logs
+- it does not create confusing startup noise
+- it does not duplicate open cases
+- Slack behavior is validated
+- it can detect and case LLM cost runaway
+- reports are deterministic and useful
+
+### Medium-Term Success
+
+BugOps is successful after Sprint 020–022 if:
+
+- it detects runtime failures beyond LLM cost
+- it catches startup/runtime issues that would otherwise require manual log watching
+- cases contain enough evidence to start debugging quickly
+- diagnosis packs reduce manual investigation time
+- alerts are useful enough to keep enabled
+
+### Long-Term Success
+
+BugOps is successful if:
+
+- production failures become durable cases
+- evidence is preserved automatically
+- the operator spends less time reconstructing what happened
+- Claude Code receives better bug context
+- fixes can be validated against the original production signal
+
+---
+
+## 14. Risks
+
+### Risk: BugOps becomes too broad
+
+Mitigation:
+
+Add signal sources incrementally. Do not build a full observability platform.
+
+### Risk: Alert noise
+
+Mitigation:
+
+Start with narrow, high-confidence patterns. Notify only on new cases.
+
+### Risk: LLM hallucination
+
+Mitigation:
+
+Keep deterministic facts separate from LLM synthesis. Do not add LLM interpretation until diagnosis packs exist.
+
+### Risk: Duplicate cases
+
+Mitigation:
+
+Use deterministic `dedupe_key` logic and Mongo-level guardrails.
+
+### Risk: Railway logs are messy
+
+Mitigation:
+
+Use Railway logs only for narrow runtime failure patterns. Add structured app signals later.
+
+### Risk: The system becomes more interesting than useful
+
+Mitigation:
+
+Only expand when real production pain justifies the next layer.
+
+---
+
+## 15. Open Questions
+
+1. Should Railway logs be the primary Sprint 020 source, or only a startup-crash safety net?
+2. Which structured signal should come first: FastAPI errors, Celery failures, or Mongo reliability?
+3. How much case lifecycle is needed before Slack UI?
+4. Are diagnosis packs enough before LLM synthesis?
+5. When should BugOps integrate with Claude Code?
+6. Should `bug_case_events` and `bug_tool_calls` remain in the model if unused?
+7. Should fix brief generation be part of BugOps or a separate tooling track?
+
+---
+
+## 16. Product Principle
+
+BugOps should not try to be smart before it is useful.
+
+The order is:
+
+1. detect real signals
+2. preserve evidence
+3. create cases
+4. notify the operator
+5. make cases actionable
+6. support fixes
+7. validate resolution
+
+Deterministic evidence comes first.
+
+LLM synthesis comes later.
+
+Automation comes after manual workflow pain is understood.
+

--- a/docs/bugops/system-design/00-core-system-architecture.md
+++ b/docs/bugops/system-design/00-core-system-architecture.md
@@ -1,0 +1,344 @@
+# BugOps Core System Architecture
+
+---
+
+## Purpose
+
+This document defines the permanent architecture of BugOps. It records decisions that are expensive to reverse. It is not a sprint plan or implementation blueprint.
+
+---
+
+## What Is BugOps
+
+BugOps is an incident management and investigation system for Backdrop. It monitors production health, detects failures, collects evidence, generates investigations, and produces structured implementation work for human review and coding-agent execution.
+
+BugOps does not remediate failures autonomously. BugOps does not manage implementation workflow, sprint planning, or task tracking.
+
+BugOps owns:
+
+```
+Production Signals → Operational Context → Actionable Work
+```
+
+BugOps does not own: log storage, notification delivery infrastructure, deployment systems, project management, or source system execution.
+
+---
+
+## Architecture Principles
+
+These principles are permanent. They function as tiebreakers for future design decisions.
+
+1. Deterministic before LLM
+2. Evidence before interpretation
+3. Outcome monitoring before component monitoring
+4. Operational cases before tickets
+5. Human approval before code changes
+6. False positives are worse than slower detection
+7. Absence of output is not failure unless output was expected
+8. Existing infrastructure before new infrastructure
+
+---
+
+## Architectural Non-Goals
+
+BugOps is not a log management platform, a project management platform, a ticket management platform, a workflow engine, a dashboard platform, a replacement for Sentry, or a replacement for PagerDuty.
+
+---
+
+## Top-Level Object
+
+BugCase is the single operational container in BugOps.
+
+A BugCase represents a production problem requiring investigation and potential remediation. Architecturally, BugCase fulfills the role commonly referred to in other systems as an incident.
+
+BugOps does not introduce a separate Incident object. There is no two-tier Signal → Incident → Case model. One container exists. It grows over time.
+
+BugCase may be renamed in the future if terminology becomes a meaningful constraint. That is a terminology decision, not an architecture decision.
+
+---
+
+## End-State Lifecycle
+
+```
+Signal
+→ BugCase
+→ Evidence Pack
+→ Investigation
+→ Ticket Draft
+→ Human Approval
+→ Coding Agent Handoff
+→ Validation
+→ Resolved
+```
+
+BugCase lifecycle states:
+
+```
+Open → Notified → Investigating → Ticket Generated → Human Approval → Fix In Progress → Validating → Resolved
+```
+
+This is the end-state lifecycle. Individual sprints may implement a smaller subset of states until the later pipeline stages exist. Sprint 018 currently implements open, resolved, and closed.
+
+Operator actions: acknowledge, mute, snooze, close, reopen.
+
+Resolved cases may reopen if recovery conditions fail after resolution.
+
+---
+
+## Dependency Graph
+
+BugOps owns a single hand-maintained DependencyGraph. It is the authoritative operational dependency map for outcome freshness detection, cascade suppression, blast radius, and investigation context.
+
+The graph represents operational outcome dependencies, not service topology. It is not a full architecture map of every service, worker, queue, or collection.
+
+The graph is deterministic and version-controlled. It is not inferred dynamically.
+
+First version:
+
+```
+scheduler → ingestion → articles → signals → narratives → briefings
+```
+
+The graph supports two traversal directions:
+
+**Upstream traversal** is used for cascade suppression. If a downstream detector fires while an upstream BugCase is already open, the downstream signal attaches to the upstream BugCase instead of creating a new one.
+
+**Downstream traversal** is used for blast radius. If a BugCase originates at ingestion, the potential blast radius includes articles, signals, narratives, and briefings.
+
+DependencyGraph is a shared architecture primitive. It is not an extension seam and is not pluggable. It evolves through deliberate versioning.
+
+---
+
+## BugCase Data Model
+
+Each BugCase contains:
+
+- `bugcase_id`
+- `severity`
+- `status`
+- `dedupe_key`
+- `root_subsystem`
+- `affected_subsystems`
+- `first_seen_at`
+- `last_seen_at`
+- `observation_count`
+- `blast_radius`
+- `recovery_candidate_at`
+- `resolution_type`
+- `confidence` *(optional — meaningful only when richer correlation exists)*
+- `correlation_reason` *(optional — meaningful only when richer correlation exists)*
+
+**root_subsystem** is the subsystem believed closest to the originating failure.
+
+**affected_subsystems** is the set of downstream subsystems impacted by the BugCase.
+
+**correlation_reason** records why signals were grouped into this BugCase. Optional until richer correlation logic exists. Do not invent values in deterministic-only sprints.
+
+**confidence** records estimated certainty of root cause attribution. Optional until richer correlation logic exists. Do not invent values in deterministic-only sprints.
+
+**recovery_candidate_at** records when recovery was first observed. It is internal metadata, not an operator-facing state.
+
+**resolution_type** records how a BugCase was ultimately resolved. Supports future learning and threshold tuning. Possible values: `real_issue`, `false_positive`, `duplicate`, `operator_error`, `expected_idle`. Not required in Sprint 020.
+
+---
+
+## Severity Model
+
+Severity is assigned deterministically at detection time and may be escalated as impact grows.
+
+**Critical:** scheduler unavailable, worker unavailable, database unavailable, multiple critical subsystems degraded.
+
+**High:** article ingestion stalled, briefing generation stalled, narrative refresh stalled.
+
+**Medium:** repeated runtime exceptions, partial subsystem degradation.
+
+**Low:** single runtime exception, non-impacting failures.
+
+---
+
+## Cascade Suppression
+
+BugOps implements deterministic upstream-wins cascade suppression.
+
+When a detector fires, BugOps checks for open BugCases associated with upstream dependency nodes using the DependencyGraph.
+
+If an upstream BugCase exists: the signal is attached to the upstream BugCase, `affected_subsystems` metadata is updated, no new BugCase is created, and no new Slack notification is sent.
+
+If no upstream BugCase exists: normal idempotency rules apply.
+
+Sprint 020 does not implement retroactive case merging, absorption, or root-cause reassignment. Those capabilities are deferred.
+
+---
+
+## Idempotency
+
+Freshness detectors use stable dedupe keys in the format:
+
+```
+detector_type:root_subsystem
+```
+
+Examples: `article_freshness:articles`, `signal_freshness:signals`, `narrative_freshness:narratives`, `briefing_freshness:briefings`.
+
+Dedupe is evaluated only against open BugCases. Resolved or closed cases with the same dedupe key do not suppress new cases.
+
+If an open BugCase exists with the same dedupe key, BugOps attaches the new observation, updates `last_seen_at` and `observation_count`, and sends no new notification.
+
+Processing order:
+
+1. Check for open upstream BugCase. Attach if found.
+2. Check for open BugCase with same dedupe key. Attach if found.
+3. Otherwise create new BugCase and notify.
+
+---
+
+## Time Authority
+
+BugOps uses internal persistence timestamps as the authoritative measure of system activity.
+
+For most artifacts, this means `inserted_at`: the moment an artifact was successfully persisted to the database.
+
+`published_at` is never authoritative for freshness decisions. It is an external timestamp and cannot be trusted.
+
+`fetched_at` may be used as diagnostic context but is not the primary freshness signal.
+
+`detected_at` records when BugOps observed a condition. It is used for BugOps case metadata, not source freshness.
+
+All freshness comparisons include a configurable clock tolerance buffer to avoid boundary-condition false positives. Default: 60 seconds.
+
+---
+
+## Idle vs Broken Detection
+
+Absence of output is only a failure when there is positive evidence that output was expected. This is one of the primary false-positive controls in BugOps and is elevated as a permanent architecture principle.
+
+The rule is not:
+```
+no output → failure
+```
+
+The rule is:
+```
+expected output + no output → failure
+```
+
+Each freshness detector must explicitly define:
+
+- last successful output
+- expected input or activity
+- failure condition
+- legitimate idle condition
+- recovery condition
+
+---
+
+## Recovery Model
+
+BugOps defines recovery based on outcome recovery, not component health.
+
+A subsystem is considered recovered when the expected artifact is being successfully produced again, measured by the same freshness authority used for failure detection.
+
+Recovery is not immediate. After a healthy signal is observed, the BugCase enters a recovery-candidate period tracked by `recovery_candidate_at`. The subsystem must remain healthy for a configurable Recovery Window before automatic resolution occurs.
+
+Recovery Window duration is configuration, not architecture.
+
+BugCase resolves as a unit. Partial resolution is not supported. Individual `affected_subsystems` recovery is tracked as metadata but does not close the case.
+
+---
+
+## Pipeline Seams
+
+BugOps produces a durable artifact at every major pipeline stage. Each artifact persists independently. Artifacts remain attached to the BugCase after the BugCase resolves or closes. Raw evidence may expire according to retention policy, but durable summaries and references remain.
+
+### Seam 1: BugCase → Evidence Pack
+
+- **Input:** eligible open BugCase
+- **Output:** Evidence Pack attached to the BugCase
+- **Owner:** EvidenceCollector
+- **Trigger:** configurable settling window after BugCase creation, or immediate collection for critical runtime failures
+- **Invariant:** evidence collection is deterministic and produces a durable artifact
+
+### Seam 2: Evidence Pack → Investigation
+
+- **Input:** completed Evidence Pack
+- **Output:** Investigation attached to the BugCase
+- **Owner:** InvestigationProvider
+- **Trigger:** Evidence Pack completion, subject to cost controls and eligibility rules
+- **Invariant:** Investigation interprets evidence. It does not replace evidence. The Evidence Pack remains inspectable independently.
+
+### Seam 3: Investigation → Ticket Draft
+
+- **Input:** completed Investigation
+- **Output:** one or more Ticket Drafts
+- **Owner:** TicketWriter
+- **Trigger:** human promotion, or explicit automation rule
+- **Invariant:** Ticket Drafts are proposed implementation work. They are not approved work. Human approval is required before coding-agent execution.
+
+### Seam 4: Ticket Draft → Validation
+
+- **Input:** approved Ticket Draft and implementation result
+- **Output:** Validation Run
+- **Owner:** ValidationRunner
+- **Trigger:** human validation request, or coding-agent handoff completion report
+- **Invariant:** Validation determines whether operational recovery is stable enough to resolve or reopen the BugCase.
+
+---
+
+## Extension Seams
+
+The following components are intentionally replaceable. Each defines an interface contract. Implementations may change without rewriting the core pipeline.
+
+- **SignalSource** — adds new detectors without changing the monitor loop.
+- **EvidenceCollector** — collects evidence for a BugCase. Can evolve from simple deterministic snapshots to richer context gathering.
+- **InvestigationProvider** — turns Evidence Packs into Investigations. Can swap models, prompts, retrieval strategies, or deterministic modes.
+- **TicketWriter** — turns Investigations into Ticket Drafts. Owns content generation.
+- **TicketExporter** — exports approved Ticket Drafts to an external workflow. Decoupled from content generation. Current implementation: repository markdown. Future: GitHub, Linear, or other targets.
+- **NotificationChannel** — sends operator-facing updates. Current implementation: Slack.
+- **ValidationRunner** — checks recovery or post-fix outcome. Expected to evolve significantly.
+
+---
+
+## Monitoring Topology
+
+BugOps runs as a separate process, independent from FastAPI, Celery Worker, and Celery Beat. This is a Sprint 018 architectural decision.
+
+Each SignalSource runs independently inside the BugOps polling loop. A failure in one detector logs the error, records the failed detector run, and does not stop the monitor or prevent other detectors from running.
+
+Detector execution is observable through structured logs or lightweight run records including: `detector_name`, `run_started_at`, `run_completed_at`, `status`, `error_type`, `error_message`, `duration_ms`.
+
+BugOps should eventually publish a heartbeat to infrastructure outside the BugOps process. If the heartbeat stops, an external mechanism alerts the operator. This protects against BugOps silently failing. External heartbeat implementation is deferred.
+
+---
+
+## Cost Controls
+
+No LLM call per signal. No LLM call per exception. No LLM over raw logs. One investigation per BugCase. Investigations rerun only after material evidence change.
+
+Evidence collection is deterministic.
+
+All BugOps LLM usage routes through the existing unified gateway for cost attribution and budget enforcement.
+
+---
+
+## Retention Policy
+
+The following represents the initial default retention policy. It is not immutable architecture and may be updated as operational needs evolve.
+
+| Artifact | Retention |
+|---|---|
+| runtime_error_events | 30 days |
+| raw evidence | 90 days |
+| BugCases | permanent |
+| Investigations | permanent |
+
+---
+
+## Evolution
+
+**Sprint 018:** SignalSource interface, BugCase, BugAlertEvent, Slack notifications, deterministic reports, separate monitor process.
+
+**Sprint 020:** outcome freshness signals, dependency graph, cascade suppression, idempotency, auto-resolution, detector isolation, notification behavior, deploy suppression.
+
+**Sprint 021:** Evidence Pack model, EvidenceCollector, InvestigationProvider, Investigator Agent.
+
+**Sprint 022:** TicketWriter, TicketExporter, ValidationRunner, human approval workflow, coding-agent handoff format.

--- a/docs/bugops/system-design/10-sprint-020-outcome-freshness-design.md
+++ b/docs/bugops/system-design/10-sprint-020-outcome-freshness-design.md
@@ -1,0 +1,483 @@
+# Sprint 020: Outcome Freshness Design
+
+---
+
+## Purpose
+
+This document is the implementation blueprint for Sprint 020. It covers
+the four freshness detectors, cascade suppression mechanics, idempotency,
+time authority application, recovery model implementation, auto-resolution,
+notification routing, detector isolation, deploy suppression, retention
+defaults, and success criteria.
+
+This document does not define new architecture. All decisions referenced
+here are locked in 00-core-system-architecture.md.
+
+---
+
+## Scope
+
+Sprint 020 implements:
+
+- Four outcome freshness detectors
+- DependencyGraph (first version)
+- Cascade suppression
+- Idempotency and dedupe
+- Auto-resolution with Recovery Window
+- Flapping protection
+- Notification routing rules
+- Detector isolation
+- Deploy suppression
+- Retention policy enforcement
+
+Sprint 020 does not implement:
+
+- Evidence Pack collection
+- Investigation generation
+- Ticket drafting or export
+- Retroactive case merging or absorption
+- External heartbeat
+- resolution_type population (field exists, not required this sprint)
+
+---
+
+## Freshness Detectors
+
+Each detector implements the five-part definition required by the
+Idle vs Broken architecture principle. Absence of output is only a
+failure when output was expected.
+
+---
+
+### ArticleFreshness
+
+Detects stalled article ingestion.
+
+**Last successful output**
+The most recent Article record with an `inserted_at` timestamp within
+the configured freshness window. `inserted_at` is authoritative.
+`published_at` is not used for freshness evaluation.
+
+**Expected input or activity**
+At least one RSS fetch attempt has completed within the current polling
+cycle, and at least one source historically produces articles during this
+time-of-day window. A fetch completing with zero new items is not
+independently a failure.
+
+**Failure condition**
+No Article has been inserted within the freshness window AND at least one
+source has produced articles during this time-of-day window in recent
+history. Both conditions must be true.
+
+**Legitimate idle condition**
+All monitored RSS sources have published no new content in recent history
+for this time-of-day window. Weekends, holidays, and low-activity periods
+are legitimate idle. Detection must account for source publishing patterns
+before raising a BugCase.
+
+**Recovery condition**
+At least one new Article is inserted with `inserted_at` within the
+freshness window, on a source that was previously stalled.
+
+**Severity:** High
+**Dedupe key:** `article_freshness:articles`
+
+---
+
+### SignalFreshness
+
+Detects stalled signal generation.
+
+**Last successful output**
+The most recent Signal record with an `inserted_at` timestamp within the
+configured freshness window.
+
+**Expected input or activity**
+At least one Article has been inserted recently enough that signal
+generation should have run. If no articles are present, signal generation
+has no input and cannot be expected to produce output.
+
+**Failure condition**
+Articles exist with `inserted_at` within the freshness window AND no new
+Signals have been generated within the freshness window.
+
+**Legitimate idle condition**
+No articles have been inserted recently. Signal generation has no input
+and is correctly idle.
+
+**Recovery condition**
+At least one new Signal is generated with `inserted_at` within the
+freshness window, corresponding to article input that was previously
+not producing signals.
+
+**Severity:** High
+**Dedupe key:** `signal_freshness:signals`
+
+---
+
+### NarrativeFreshness
+
+Detects stale narrative refresh.
+
+**Last successful output**
+The most recent Narrative record with an `updated_at` or `inserted_at`
+timestamp within the configured freshness window.
+
+**Expected input or activity**
+Sufficient signals exist to trigger narrative refresh.
+
+**Failure condition**
+Signals exist within the freshness window AND no Narrative has been
+updated or inserted within the freshness window.
+
+Job cadence tracking is deferred unless already available through
+existing metadata.
+
+**Legitimate idle condition**
+No signals have been generated recently. Narrative refresh has no
+meaningful input and is correctly idle.
+
+**Recovery condition**
+At least one Narrative is updated or inserted with a timestamp within
+the freshness window after the stall period.
+
+**Severity:** High
+**Dedupe key:** `narrative_freshness:narratives`
+
+---
+
+### BriefingFreshness
+
+Detects missing briefings.
+
+**Last successful output**
+The most recent Briefing record with an `inserted_at` timestamp within
+the configured freshness window. Briefings are expected on a known
+schedule. The freshness window is calibrated to that schedule.
+
+**Expected input or activity**
+The briefing generation window has elapsed. Narratives exist that are
+fresh enough to produce a briefing.
+
+**Failure condition**
+The briefing generation window has elapsed AND no Briefing has been
+inserted within the expected window AND fresh narratives exist as input.
+Briefing timestamps are corroborated against the known schedule before
+raising a BugCase.
+
+**Legitimate idle condition**
+The briefing generation window has not yet elapsed since the last
+successful briefing. Or no sufficiently fresh narratives exist to
+produce a briefing.
+
+**Recovery condition**
+A new Briefing is inserted with `inserted_at` within the expected
+window following the stall period.
+
+**Severity:** High
+**Dedupe key:** `briefing_freshness:briefings`
+
+---
+
+## DependencyGraph — First Version
+
+The DependencyGraph is a hand-maintained, version-controlled artifact.
+It represents operational outcome dependencies.
+
+```
+scheduler → ingestion → articles → signals → narratives → briefings
+```
+
+Each node corresponds to a subsystem. Each edge represents a dependency:
+the downstream node's output requires the upstream node to be functioning.
+
+The graph supports two traversal directions:
+
+**Upstream traversal (cascade suppression)**
+Walk from a detector's root_subsystem toward the root of the graph.
+Check for open BugCases at each upstream node. Stop at first match.
+
+**Downstream traversal (blast radius)**
+Walk from a BugCase's root_subsystem toward the leaves. All reachable
+nodes are candidates for affected_subsystems.
+
+The graph is not inferred dynamically. It does not represent every
+internal service, queue, or collection — only operational outcome
+dependencies relevant to freshness detection and cascade suppression.
+
+Version: 1.0. Changes require deliberate versioning.
+
+---
+
+## Cascade Suppression
+
+Processing order is deterministic and must not be varied:
+
+```
+1. Check for open upstream BugCase (DependencyGraph upstream traversal)
+   → If found: attach signal, update affected_subsystems, update
+     last_seen_at and observation_count. No new BugCase. No notification.
+     Stop.
+
+2. Check for open BugCase with same dedupe_key
+   → If found: attach signal, update last_seen_at and observation_count.
+     No new BugCase. No notification. Stop.
+
+3. Create new BugCase. Notify.
+```
+
+Upstream-wins is unconditional. A downstream detector does not create
+a new BugCase if any upstream node has an open BugCase, regardless of
+whether the downstream detector's condition appears independently severe.
+
+Sprint 020 does not implement retroactive merging. If an upstream BugCase
+is created after a downstream BugCase already exists, those cases remain
+separate. Retroactive merge is deferred.
+
+---
+
+## Idempotency
+
+**Dedupe key format:** `detector_type:root_subsystem`
+
+Examples:
+- `article_freshness:articles`
+- `signal_freshness:signals`
+- `narrative_freshness:narratives`
+- `briefing_freshness:briefings`
+
+**Dedupe scope:** open BugCases only. A resolved or closed BugCase with
+the same dedupe_key does not suppress a new case.
+
+**Attachment behavior on match:**
+- Increment `observation_count`
+- Update `last_seen_at`
+- Do not send a new notification
+- Do not change severity unless escalation rules apply (see Notification
+  Routing)
+
+---
+
+## Time Authority
+
+All freshness comparisons use `inserted_at` as the primary timestamp.
+
+`published_at` is never used for freshness decisions. It is an external
+timestamp and cannot be trusted.
+
+`fetched_at` may appear in diagnostic context attached to a BugCase but
+is not authoritative for freshness.
+
+`detected_at` records when BugOps observed a condition. It populates
+BugCase metadata. It is not used for source freshness decisions.
+
+**60-second tolerance buffer**
+All freshness window comparisons apply a configurable 60-second tolerance
+buffer before evaluating. This prevents boundary-condition false positives
+where an artifact arrives slightly after a strict deadline due to
+processing latency.
+
+**BriefingFreshness corroboration**
+Briefing freshness uses the known briefing schedule as a secondary
+corroboration signal. A briefing is only considered overdue if both:
+- `inserted_at` of the last briefing is outside the freshness window, AND
+- the scheduled generation window has elapsed according to the known
+  schedule plus the tolerance buffer.
+
+---
+
+## Recovery Model
+
+Recovery is defined as outcome recovery, not component health.
+
+**Recovery candidate entry**
+When a freshness detector runs and finds that the expected artifact is
+now being produced again (recovery condition met), `recovery_candidate_at`
+is set to the timestamp of the first healthy observation.
+
+`recovery_candidate_at` is internal metadata. It is not an
+operator-facing status.
+
+**Recovery Window**
+The BugCase must remain in healthy state for the full duration of the
+Recovery Window before automatic resolution. The Recovery Window is
+configurable. Default: 10 minutes.
+
+If the failure condition is re-observed before the Recovery Window
+elapses, `recovery_candidate_at` is cleared and the BugCase returns
+to active failure state.
+
+**Resolution unit**
+BugCase resolves as a unit. Partial resolution is not supported.
+Individual affected_subsystems may recover at different times; this
+is recorded in metadata but does not close the case. The case closes
+when the root_subsystem's recovery condition is met and the Recovery
+Window elapses.
+
+**Recovery Window units**
+Minutes. Configurable per environment. Defaults:
+- Production: 10 minutes
+- Development/test: 1 minute
+
+---
+
+## Auto-Resolution
+
+Auto-resolution triggers when:
+- The BugCase's root_subsystem recovery condition is met, AND
+- `recovery_candidate_at` is set, AND
+- The elapsed time since `recovery_candidate_at` is greater than or
+  equal to the Recovery Window
+
+Auto-resolution is blocked only when:
+- The recovery condition is re-violated before the Recovery Window
+  elapses (flapping protection, see below)
+- The BugCase has been manually closed by an operator
+
+Auto-resolution still applies to BugCases with active mute or snooze
+flags. Mute and snooze affect notification behavior only. A muted or
+snoozed BugCase that meets recovery conditions resolves normally.
+
+**Flapping protection**
+If a BugCase oscillates between healthy and failed states within a
+short window, auto-resolution is suspended and the BugCase is escalated
+to require manual operator review. A notification is sent indicating the
+flapping condition. Flapping thresholds are configurable. Initial
+defaults may be set during implementation.
+
+---
+
+## Notification Routing
+
+Notifications are driven by BugCase state changes, not raw detector
+observations.
+
+**Routing rules by severity:**
+
+| Severity | Trigger             | Channel | Behavior  |
+|----------|---------------------|---------|-----------|
+| Critical | BugCase created     | Slack   | Immediate |
+| Critical | Severity escalation | Slack   | Immediate |
+| High     | BugCase created     | Slack   | Immediate |
+| High     | Severity escalation | Slack   | Immediate |
+| Medium   | BugCase created     | Digest  | Batched   |
+| Low      | BugCase created     | Stored  | None      |
+
+**Deduplication**
+No new notification is sent for repeated observations against an open
+BugCase with the same dedupe_key, unless:
+- Severity increases
+- A new subsystem joins affected_subsystems
+- The BugCase reopens after resolution
+
+**Throttle**
+Notifications for the same BugCase are throttled to at most once per
+configurable throttle window, except for severity escalation events,
+which always notify immediately.
+
+**Reopen notification**
+When a resolved BugCase reopens, a new notification is sent at the
+BugCase's current severity regardless of throttle state.
+
+**Flapping notification**
+When flapping protection activates, a single notification is sent
+indicating the BugCase requires manual review.
+
+---
+
+## Detector Isolation
+
+Each detector runs inside an independent try/catch block within the
+BugOps polling loop.
+
+A failure in any single detector:
+- Logs a structured error
+- Does not halt the polling loop
+- Does not prevent other detectors from running
+
+**Observability**
+Detector runs are observable through structured logs. Persisted run
+records are optional in Sprint 020 if implementation cost is low.
+If persisted, the run record schema is:
+
+```
+detector_name       string
+run_started_at      timestamp
+run_completed_at    timestamp
+status              enum: success | failure | skipped
+error_type          string | null
+error_message       string | null
+duration_ms         integer
+```
+
+Detector run records are not operator-facing alerts.
+
+---
+
+## Deploy Suppression
+
+BugOps supports a maintenance mode for deploy suppression windows.
+
+**Suppression behavior:**
+- Notifications are suppressed during the suppression window
+- BugCases continue to be created and recorded
+- BugCases remain visible to operators
+- Detection, case creation, and auto-resolution logic are unaffected
+
+**Mute and snooze flags**
+BugCases may carry `muted_until` or `snoozed_until` timestamps.
+These are flags, not lifecycle statuses. They affect notification
+behavior only and do not block auto-resolution or case progression.
+
+**Suppression expiry**
+Suppression windows have a configurable duration and expire
+automatically. Manual deactivation is also supported.
+
+If implemented in Sprint 020, suppression expiry should send a summary
+notification for unresolved Critical/High BugCases that would have
+notified during the window.
+
+**Suppression scope**
+Sprint 020 implements suppression at the global level. Per-subsystem
+suppression is deferred.
+
+---
+
+## Retention Policy
+
+Default retention for artifacts created in Sprint 020:
+
+| Artifact                  | Retention            |
+|---------------------------|----------------------|
+| BugCases                  | Permanent            |
+| Detector run logs/records | 30 days if persisted |
+
+These values are configurable and not immutable architecture.
+
+---
+
+## Sprint 020 Success Criteria
+
+- All four freshness detectors run in the BugOps polling loop without
+  requiring changes to the monitor process structure
+- Each detector correctly distinguishes legitimate idle from broken
+  using the five-part definition
+- Cascade suppression correctly attaches downstream signals to upstream
+  BugCases rather than creating new ones
+- Idempotency correctly suppresses duplicate BugCases for repeated
+  observations of the same condition
+- A BugCase auto-resolves after the Recovery Window elapses without
+  re-violation
+- A BugCase does not auto-resolve if the failure condition recurs
+  during the Recovery Window
+- Flapping protection activates and notifies correctly under rapid
+  oscillation
+- A detector failure does not halt the polling loop or prevent other
+  detectors from running
+- Notifications route correctly by severity and are not re-sent for
+  repeated observations against the same open BugCase
+- BugCases with active mute or snooze flags resolve normally when
+  recovery conditions are met
+- Deploy suppression prevents notifications without suppressing case
+  creation or auto-resolution
+- Detector runs are observable through structured logs

--- a/docs/bugops/system-design/20-sprint-021-evidence-investigation-interface.md
+++ b/docs/bugops/system-design/20-sprint-021-evidence-investigation-interface.md
@@ -1,0 +1,219 @@
+# Sprint 021: Evidence & Investigation Interface
+
+---
+
+## Purpose
+
+This document defines the interfaces for Sprint 021. It covers the
+Evidence Pack interface, Evidence Pack durability contract, Investigation
+interface, InvestigationProvider contract, and persistence model.
+
+This document does not specify prompts, models, JSON schemas, acceptance
+criteria, or implementation thresholds. Those are deferred to Sprint 021
+implementation.
+
+All architecture decisions referenced here are locked in
+00-core-system-architecture.md.
+
+---
+
+## Scope
+
+Sprint 021 defines interfaces for:
+
+- Evidence Pack
+- EvidenceCollector
+- Investigation
+- InvestigationProvider
+
+Sprint 021 does not define:
+
+- Prompt content or prompt structure
+- Model selection or model configuration
+- JSON schemas for Evidence Pack or Investigation payloads
+- Acceptance criteria for investigation quality
+- Cost thresholds or budget controls beyond what is locked in architecture
+- Specific log formats or runtime error summary formats
+
+---
+
+## Evidence Pack Interface
+
+### What goes in
+
+An eligible open BugCase.
+
+A BugCase is eligible for evidence collection when:
+- It is active and not terminal (active means: open, notified,
+  investigating, or equivalent non-terminal state)
+- No Evidence Pack is already attached
+- The settling window has elapsed since `first_seen_at`, OR severity
+  is Critical and immediate collection is warranted
+
+The settling window allows additional signals to arrive and attach to
+the BugCase before evidence is frozen. This prevents an Evidence Pack
+from being collected against an incomplete picture of the failure.
+
+### What comes out
+
+A completed Evidence Pack attached to the BugCase.
+
+### What the Evidence Pack must contain
+
+- **Logs:** relevant log excerpts from the period surrounding the
+  BugCase's `first_seen_at` and `last_seen_at`
+- **Deploy context:** recent deployment events that overlap with or
+  precede the BugCase window
+- **System state:** scheduler status, worker status, and database
+  availability at the time of detection
+- **Related signals:** other BugCases or observations that share
+  subsystems with this BugCase, within a configurable lookback window
+- **Metrics:** artifact counts and freshness indicators for the
+  affected subsystems at time of detection (e.g., article count,
+  last inserted_at per subsystem)
+
+Evidence collection is deterministic. No LLM is involved in evidence
+collection.
+
+Evidence Packs record observed facts and references. They do not infer
+root cause.
+
+EvidenceCollector is an extension seam. The collector may evolve
+without changing the BugCase → Evidence Pack contract.
+
+### Settling window trigger rules
+
+- Default: collect after a configurable settling window following
+  `first_seen_at`
+- Exception: collect immediately for Critical severity BugCases where
+  evidence volatility is high (e.g., worker crash, scheduler failure)
+- If the BugCase resolves before the settling window elapses, evidence
+  collection still runs. Short-lived failures still matter for
+  operational learning and future investigation.
+
+---
+
+## Evidence Pack Durability Contract
+
+### What persists
+
+The completed Evidence Pack is a durable artifact. It persists
+independently of the BugCase lifecycle.
+
+The Evidence Pack remains attached and inspectable after:
+- The BugCase resolves
+- The BugCase closes
+- An Investigation is generated from it
+
+### What expires
+
+Raw evidence components (log excerpts, runtime snapshots) may expire
+according to the retention policy. Default: 90 days.
+
+Expiry applies to raw attached data only. The Evidence Pack record
+itself and its structural metadata persist permanently.
+
+### What remains permanent
+
+- Evidence Pack record and metadata
+- References to the originating BugCase
+- Timestamps of collection
+- Summary of what was collected (even after raw data expires)
+
+The Investigation generated from an Evidence Pack is a separate
+permanent artifact. It does not expire when raw evidence does.
+
+---
+
+## Investigation Interface
+
+### What goes in
+
+A completed Evidence Pack.
+
+### What comes out
+
+An Investigation attached to the BugCase containing:
+
+- **Summary:** a concise description of what the evidence shows
+- **Likely causes:** one or more candidate root causes ranked by
+  plausibility
+- **Evidence references:** specific pointers into the Evidence Pack
+  that support each candidate cause
+- **Verification steps:** concrete actions an operator or coding agent
+  can take to confirm or rule out each candidate cause
+
+### One current investigation per BugCase
+
+A BugCase has one current Investigation. Reruns may replace or
+supersede the current Investigation when material new evidence is
+attached. Rerun on immaterial change is not permitted.
+
+What constitutes material evidence change and how superseded
+Investigations are handled is determined during Sprint 021
+implementation and is not defined in this interface document.
+
+---
+
+## InvestigationProvider Contract
+
+### Inputs
+
+- Completed Evidence Pack
+- BugCase metadata (severity, root_subsystem, affected_subsystems,
+  first_seen_at, last_seen_at, observation_count)
+
+### Outputs
+
+- Summary
+- Likely causes
+- Evidence references
+- Verification steps
+
+### Constraints
+
+- One current Investigation per BugCase at a time
+- All LLM usage routes through the existing unified gateway for cost
+  attribution and budget enforcement
+- Investigation does not replace the Evidence Pack. The Evidence Pack
+  remains independently inspectable regardless of Investigation output.
+- InvestigationProvider is an extension seam. The implementation may
+  use an LLM, a deterministic rule engine, or a hybrid. The interface
+  contract does not change based on implementation strategy.
+
+---
+
+## Persistence Model
+
+### Durable artifacts
+
+| Artifact          | Retention   | Notes                                    |
+|-------------------|-------------|------------------------------------------|
+| Evidence Pack     | Permanent   | Record and metadata; raw data may expire |
+| Raw evidence data | 90 days     | Log excerpts, snapshots, runtime data    |
+| Investigation     | Permanent   | Does not expire when raw evidence does   |
+
+### Retention alignment
+
+Retention values here are consistent with the defaults established in
+00-core-system-architecture.md. They are configurable and not immutable
+architecture.
+
+---
+
+## Open Questions — Deferred to Sprint 021 Implementation
+
+The following are explicitly deferred. They are named here so they are
+not forgotten and not prematurely resolved.
+
+- Prompt content and structure for the InvestigationProvider
+- Model selection and configuration
+- JSON schema for Evidence Pack payload
+- JSON schema for Investigation output
+- Acceptance criteria for investigation quality
+- Definition of material evidence change for rerun eligibility
+- How superseded Investigations are stored or referenced
+- Specific log formats and log excerpt selection strategy
+- Runtime error summary format and redaction rules
+- Cost threshold and budget enforcement implementation detail
+- Settling window default value

--- a/docs/bugops/system-design/30-sprint-022-ticket-validation-interface.md
+++ b/docs/bugops/system-design/30-sprint-022-ticket-validation-interface.md
@@ -1,0 +1,321 @@
+# Sprint 022: Ticket & Validation Interface
+
+---
+
+## Purpose
+
+This document defines the interfaces for Sprint 022. It covers the
+Ticket Draft interface, TicketWriter contract, TicketExporter contract,
+human approval interface, coding agent handoff contract, validation
+interface, ValidationRunner contract, and reopen logic.
+
+This document does not specify ticket formats, validation thresholds,
+prompt content, model selection, or implementation detail. Those are
+deferred to Sprint 022 implementation.
+
+All architecture decisions referenced here are locked in
+00-core-system-architecture.md.
+
+---
+
+## Scope
+
+Sprint 022 defines interfaces for:
+
+- Ticket Draft
+- TicketWriter
+- TicketExporter
+- Human approval
+- Coding agent handoff
+- Validation
+- ValidationRunner
+- Reopen logic
+
+Sprint 022 does not define:
+
+- Ticket format or field schema
+- Validation thresholds or scoring rubrics
+- Prompt content or model selection for TicketWriter
+- Coding agent protocol or execution environment
+- Export target configuration beyond current implementation
+- Specific acceptance criteria format
+
+---
+
+## Ticket Draft Interface
+
+### What goes in
+
+A completed Investigation.
+
+### What comes out
+
+One or more Ticket Drafts attached to the BugCase.
+
+A single Investigation may produce multiple Ticket Drafts. Each Ticket
+Draft represents a discrete unit of proposed implementation work.
+The relationship is one Investigation to one or more Ticket Drafts.
+
+### Human promotion requirement
+
+Ticket Drafts are proposed work. They are not approved work.
+
+No Ticket Draft proceeds to coding agent execution without explicit
+human approval. This is a permanent architecture invariant and is not
+configurable.
+
+---
+
+## TicketWriter Contract
+
+### Inputs
+
+- Completed Investigation
+- BugCase metadata (severity, root_subsystem, affected_subsystems,
+  first_seen_at, last_seen_at)
+
+### Outputs
+
+One or more Ticket Drafts, each containing at minimum:
+
+- Title
+- Severity
+- Affected subsystem
+- Summary of evidence supporting this ticket
+- Likely cause being addressed
+- Verification steps
+- Acceptance criteria
+- Validation steps
+- File guidance (see below)
+
+**File Guidance**
+
+Each Ticket Draft includes a file guidance block to support coding agent
+execution. The TicketWriter populates this based on the Investigation.
+File guidance is a recommendation, not an authorization.
+
+```
+Likely files to inspect:
+  - path/to/relevant/file.py
+
+Likely files to modify:
+  - path/to/file.py
+
+Do not modify:
+  - path/to/protected_area/
+
+Unknowns:
+  - Exact file for [X] must be located during implementation
+```
+
+Unknown file locations are explicitly named rather than omitted.
+The coding agent is expected to locate unknowns during implementation.
+
+Exact field schema is deferred to Sprint 022 implementation.
+
+### Constraints
+
+- TicketWriter is an extension seam. Implementation may change without
+  altering the Investigation → Ticket Draft contract.
+- All LLM usage routes through the existing unified gateway for cost
+  attribution and budget enforcement.
+- TicketWriter owns content generation only. It does not own export
+  or delivery.
+- Ticket Drafts may propose code changes, configuration changes,
+  documentation changes, operational actions, or no-code follow-up.
+  The TicketWriter recommends likely files to inspect or modify based
+  on the Investigation. It does not authorize changes.
+- TicketWriter proposes. Human approves. Coding agent executes.
+
+---
+
+## TicketExporter Contract
+
+### What goes in
+
+An approved Ticket Draft.
+
+### What comes out
+
+An exported ticket in the target format, delivered to the target
+destination.
+
+### Current implementation
+
+Repository markdown. Approved Ticket Drafts are written as structured
+markdown files into the repository.
+
+### Future targets
+
+GitHub issues, Linear, PR comments, or other destinations. These are
+deferred and listed in 90-deferred-future-work.md.
+
+### Constraints
+
+- TicketExporter is an extension seam. Export targets may be added or
+  changed without altering the TicketWriter contract.
+- TicketExporter is decoupled from content generation. It receives a
+  finalized Ticket Draft and is responsible only for delivery.
+- TicketExporter does not modify Ticket Draft content.
+
+---
+
+## Human Approval Interface
+
+### Where review occurs
+
+The operator reviews Ticket Drafts before any coding agent execution.
+The review surface is not specified in this interface document. It may
+be a CLI command, an internal UI, or a direct file review depending on
+Sprint 022 implementation.
+
+### What the operator approves
+
+The operator approves a Ticket Draft for coding agent execution. Approval
+is per Ticket Draft, not per Investigation or per BugCase.
+
+An operator may approve some Ticket Drafts from an Investigation and
+decline others. Partial approval is supported.
+
+### What gets handed to the coding agent
+
+An approved Ticket Draft with all required fields populated. The coding
+agent receives a self-contained handoff artifact. It does not need
+direct access to BugOps internals at execution time. Relevant evidence
+and investigation excerpts may be included in the handoff artifact.
+
+---
+
+## Coding Agent Handoff Contract
+
+### What must be present
+
+The handoff artifact must contain sufficient context for a coding agent
+to execute the implementation work without requiring access to BugOps
+internals. At minimum:
+
+- Title
+- Affected subsystem
+- Summary of the problem being addressed
+- Likely cause
+- Verification steps
+- Acceptance criteria
+- Validation steps
+- File guidance (likely files to inspect, likely files to modify,
+  do not modify, unknowns)
+
+The coding agent receives a self-contained handoff artifact. It does not
+need direct access to BugOps internals at execution time. Relevant
+evidence and investigation excerpts may be included in the handoff
+artifact.
+
+### Format requirements
+
+Exact handoff format is deferred to Sprint 022 implementation. Format
+must be self-contained and not require the coding agent to query BugOps
+state at execution time.
+
+---
+
+## Validation Interface
+
+### What goes in
+
+- An implementation result (coding agent completion report or operator
+  attestation)
+- The approved Ticket Draft that was executed
+- The originating BugCase
+
+### What comes out
+
+A Validation Run attached to the BugCase, with one of three outcomes:
+
+- **Resolved:** recovery is stable and the BugCase closes
+- **Reopened:** recovery conditions are not met and the BugCase
+  returns to active state
+- **Manual review required:** validation cannot determine outcome
+  and escalates to the operator
+
+---
+
+## ValidationRunner Contract
+
+### Inputs
+
+- Implementation result
+- Approved Ticket Draft
+- BugCase metadata
+
+### Outputs
+
+- Validation Run record
+- Outcome: resolved, reopened, or manual review required
+
+### Constraints
+
+- ValidationRunner is an extension seam. It is expected to evolve
+  significantly as validation strategies mature.
+- Validation evaluates outcome recovery using the same freshness
+  authority as the original detector. Component liveness alone is
+  not sufficient for resolution.
+- Validation thresholds and scoring are deferred to Sprint 022
+  implementation.
+
+---
+
+## Reopen Logic
+
+### What triggers reopen
+
+A Validation Run that returns outcome: reopened causes the BugCase
+to return to active state.
+
+Reopen may also be triggered by the auto-resolution recovery model
+if recovery conditions fail after a BugCase has resolved (see
+00-core-system-architecture.md Recovery Model).
+
+### Reopen tracking
+
+Each reopen increments `reopen_count` on the BugCase.
+
+### Manual review escalation
+
+After a configurable number of reopen cycles, the BugCase requires
+manual operator review before further automated action is taken.
+The escalation threshold is configurable and is not defined in this
+interface document.
+
+---
+
+## Persistence Model
+
+### Durable artifacts
+
+| Artifact        | Retention | Notes                                          |
+|-----------------|-----------|------------------------------------------------|
+| Ticket Drafts   | Permanent | Persist after approval, export, and resolution |
+| Validation Runs | Permanent | Persist after BugCase resolves or closes       |
+
+### Retention alignment
+
+Retention values here are consistent with the defaults established in
+00-core-system-architecture.md. They are configurable and not immutable
+architecture.
+
+---
+
+## Open Questions — Deferred to Sprint 022 Implementation
+
+The following are explicitly deferred. They are named here so they are
+not forgotten and not prematurely resolved.
+
+- Ticket Draft field schema
+- Coding agent handoff format
+- Human approval review surface
+- Validation threshold and scoring logic
+- Definition of implementation result for ValidationRunner input
+- Acceptance criteria format
+- Manual review escalation threshold
+- Export target configuration for TicketExporter beyond repository
+  markdown
+- Prompt content and model selection for TicketWriter

--- a/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/chore-disable-coingecko-api.md
+++ b/docs/sprints/sprint-019-fresh-start-narrative-trust/tickets/chore-disable-coingecko-api.md
@@ -1,0 +1,165 @@
+---
+ticket_id: CHORE-001
+title: Disable CoinGecko API requests
+priority: medium
+severity: low
+status: COMPLETED
+date_created: 2026-05-17
+branch: chore/disable-coingecko-api
+effort_estimate: small
+---
+
+# CHORE-001: Disable CoinGecko API requests
+
+## Problem Statement
+
+The application was making continuous requests to the CoinGecko API via the background price monitoring task. This was consuming API quota without providing critical value to the current product phase. Need a way to disable these requests while preserving the ability to re-enable them later.
+
+---
+
+## Context
+
+The price monitoring system in `tasks/price_monitor.py` starts automatically during app lifespan and periodically checks cryptocurrency prices. This task was designed for price-based alerting but is not currently being used in the briefing pipeline.
+
+Related files:
+- `src/crypto_news_aggregator/main.py` — app lifespan startup
+- `src/crypto_news_aggregator/tasks/price_monitor.py` — background task
+- `src/crypto_news_aggregator/services/price_service.py` — API calls
+
+---
+
+## Task
+
+Disable CoinGecko API requests with multiple layers of protection:
+
+1. Disable background price monitor startup in app lifespan
+2. Add configuration flag to disable API calls at service level
+3. Ensure all price service methods return mock data when disabled
+4. Include documentation of the changes
+
+---
+
+## Files to Create
+
+None
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/main.py
+src/crypto_news_aggregator/core/config.py
+src/crypto_news_aggregator/services/price_service.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/tasks/price_monitor.py
+```
+
+---
+
+## Implementation Requirements
+
+- [x] Comment out `price_monitor.start()` in `main.py` lifespan to prevent background startup
+- [x] Add `COINGECKO_API_DISABLED` boolean config flag with environment variable support
+- [x] Update `get_bitcoin_price()` to check `COINGECKO_API_DISABLED` and return mock data
+- [x] Update `get_prices()` to check `COINGECKO_API_DISABLED` and return mock data
+- [x] Update `get_markets_data()` to check `COINGECKO_API_DISABLED` and return mock data
+- [x] Update `get_historical_prices()` to check `COINGECKO_API_DISABLED` and return mock data
+- [x] Include all modified docs in commit
+
+### Configuration
+
+```text
+COINGECKO_API_DISABLED=true  # Set to disable all CoinGecko API requests
+```
+
+### Commands to Run
+
+```bash
+# Verify the changes compiled
+python -c "from crypto_news_aggregator.core.config import get_settings; s = get_settings(); print(f'COINGECKO_API_DISABLED: {s.COINGECKO_API_DISABLED}')"
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [x] Code compiles without errors
+- [x] Config flag is properly typed and documented
+- [x] All price service methods have the disabled check
+
+### Manual Verification
+
+- [x] App starts without attempting CoinGecko API calls
+- [x] Price endpoints return mock data when feature disabled
+- [x] Flag can be toggled via environment variable
+
+---
+
+## Acceptance Criteria
+
+- [x] Price monitor background task is disabled in app startup
+- [x] COINGECKO_API_DISABLED config flag exists and can be set via env var
+- [x] All price service methods return mock data when disabled
+- [x] No real API calls are made to CoinGecko when disabled
+- [x] Code can be easily re-enabled by uncommenting lines or setting env var to false
+
+---
+
+## Impact
+
+**System Impact:**
+- Eliminates CoinGecko API quota consumption during development/testing phases
+- Preserves ability to re-enable price monitoring without code changes
+
+**User Impact:**
+- No impact to end users (price data not used in briefing pipeline)
+
+**Developer Impact:**
+- Simplifies local testing by removing external API dependency
+- Can set `COINGECKO_API_DISABLED=true` in `.env` for faster startup
+
+---
+
+## Related Tickets
+
+- None
+
+---
+
+## Completion Summary
+
+- **Branch:** `chore/disable-coingecko-api`
+- **Commit:** `7ad628a` — chore(api): disable CoinGecko API requests
+- **Changes made:**
+  - Commented out price_monitor import and startup in `main.py` lifespan
+  - Added `COINGECKO_API_DISABLED` boolean config flag with env override
+  - Updated 4 price service methods to check flag and return mock data
+  - Included all modified documentation files in commit
+- **Tests run:** Code compiles, config loads successfully
+- **Manual verification:** Price endpoints return mock data, no API calls made
+- **Deviations from plan:** None — implementation went smoothly
+
+---
+
+## Re-enabling Instructions
+
+To re-enable CoinGecko API when ready:
+
+**Option 1: Environment variable**
+```bash
+COINGECKO_API_DISABLED=false
+```
+
+**Option 2: Code change**
+Uncomment lines 127-132 in `src/crypto_news_aggregator/main.py`
+
+Both options preserve the original functionality without requiring additional refactoring.

--- a/docs/sprints/sprint-020/investigations/ALIGNMENT-INVESTIGATION-FINDINGS.md
+++ b/docs/sprints/sprint-020/investigations/ALIGNMENT-INVESTIGATION-FINDINGS.md
@@ -1,0 +1,346 @@
+# Sprint 020 Alignment Investigation - Findings
+
+Investigation Date: 2026-06-10  
+Investigator: Claude Code  
+Status: Investigation Only (No Code Changes)
+
+---
+
+## 1. Dedupe Key Format
+
+### Current Implementation
+
+**File & Line:** `src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py:121-123`
+
+```python
+def _get_dedupe_key(self, dt: datetime) -> str:
+    """Generate UTC hour-based dedupe key."""
+    return f"llm_traces:cost_runaway:{dt.strftime('%Y-%m-%d')}:{dt.strftime('%H')}"
+```
+
+**Usage in lookup:** `src/crypto_news_aggregator/bugops/store.py:52-61`
+
+```python
+async def find_open_case_by_dedupe_key(self, dedupe_key: str) -> Optional[BugCase]:
+    """Find an open case by dedupe key (ignores resolved/closed cases)."""
+    doc = await self.cases_collection.find_one({
+        "dedupe_key": dedupe_key,
+        "status": "open"
+    })
+    if doc:
+        doc = _normalize_mongo_doc(doc)
+        return BugCase(**doc)
+    return None
+```
+
+**Alternative format in railway_logs:** `src/crypto_news_aggregator/bugops/signal_sources/railway_logs.py:64-66`
+
+```python
+def _dedupe_key(pattern_name: str, ts: datetime) -> str:
+    hour_str = ts.strftime("%Y-%m-%d:%H")
+    return f"railway_logs:{pattern_name}:None:{hour_str}"
+```
+
+### Index Status
+
+**File:** `src/crypto_news_aggregator/db/mongodb.py`
+
+**Finding:** No BugOps-related indexes exist. The mongodb.py file defines indexes only for:
+- ARTICLE_INDEXES (lines 87-101)
+- ALERT_INDEXES (lines 103-120) — *these are for the legacy alerts collection, NOT bug_cases*
+- PRICE_HISTORY_INDEXES (lines 130-142)
+- TWEET_INDEXES (lines 122-128)
+- ENTITY_MENTIONS_INDEXES (lines 144+)
+
+There is **no `dedupe_key` index** on the `bug_cases` collection. The `find_open_case_by_dedupe_key()` method queries without an index.
+
+### Summary
+
+**What exists:**
+- Two different dedupe_key formats active in the codebase:
+  - LLM traces: `llm_traces:cost_runaway:YYYY-MM-DD:HH` (7 segments, colon-separated)
+  - Railway logs: `railway_logs:pattern_name:None:YYYY-MM-DD:HH` (5 segments, colon-separated)
+- No unique constraint or index on dedupe_key in bug_cases collection
+- Lookup is a simple equality query without an index
+
+**Gap:** Sprint 020 requires a new format `detector_type:root_subsystem` (e.g., `article_freshness:articles`), which is shorter and lacks the hour bucketing. This is a **breaking conflict** — existing cases use hour-bucketed keys and will not match freshness detector queries under the new format.
+
+**Action Required:**
+- Additive: Define dedupe_key format for all Sprint 020 detector types
+- Conflicting: Migrate existing cases or add a fallback to old format during a transition period
+- Additive: Add unique index on dedupe_key once format is finalized
+
+---
+
+## 2. BugAlertEvent Layer
+
+### BugAlertEvent Model
+
+**File & Lines:** `src/crypto_news_aggregator/bugops/models.py:31-60`
+
+```python
+class BugAlertEventCreate(BaseModel):
+    """Create a new alert event."""
+    alert_id: str
+    case_id: Optional[str] = None
+    source_type: str
+    source_id: str
+    alert_type: str
+    severity: AlertSeverity
+    status: AlertStatus = AlertStatus.NEW
+    title: str
+    summary: str
+    domain: list[str]
+    service: Optional[str] = None
+    operation: Optional[str] = None
+    model: Optional[str] = None
+    dedupe_key: str
+    correlation_keys: list[str] = Field(default_factory=list)
+    metric: dict = Field(default_factory=dict)
+    raw_sample_ref: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class BugAlertEvent(BugAlertEventCreate):
+    """Alert event persisted in database."""
+    id: Optional[str] = Field(default=None, alias="_id")
+
+    class Config:
+        populate_by_name = True
+```
+
+### BugCase Model
+
+**File & Lines:** `src/crypto_news_aggregator/bugops/models.py:62-89`
+
+```python
+class BugCaseCreate(BaseModel):
+    """Create a new case."""
+    case_id: str
+    status: CaseStatus = CaseStatus.OPEN
+    severity: AlertSeverity
+    alert_type: str
+    title: str
+    summary: str
+    dedupe_key: str
+    source_types: list[str]
+    alert_ids: list[str] = Field(default_factory=list)
+    correlation_keys: list[str] = Field(default_factory=list)
+    metric: dict = Field(default_factory=dict)
+    suggested_manual_check: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    resolved_at: Optional[datetime] = None
+    closed_at: Optional[datetime] = None
+    deterministic_report: Optional[str] = None
+
+
+class BugCase(BugCaseCreate):
+    """Case persisted in database."""
+    id: Optional[str] = Field(default=None, alias="_id")
+
+    class Config:
+        populate_by_name = True
+```
+
+### Processing Flow
+
+**File & Lines:** `src/crypto_news_aggregator/bugops/store.py:107-121`
+
+```python
+async def process_alert_event(self, event: BugAlertEventCreate) -> tuple[BugCase, bool]:
+    """Process alert event: create alert, find or create case by dedupe_key.
+
+    Returns:
+        Tuple of (case, is_new) where is_new is True only if a new case was created
+    """
+    alert = await self.create_alert_event(event)
+    case = await self.find_open_case_by_dedupe_key(alert.dedupe_key)
+    is_new = case is None
+    if is_new:
+        case = await self.create_case_from_alert(alert)
+    else:
+        case = await self.attach_alert_to_case(case.case_id, alert.alert_id)
+    return case, is_new
+```
+
+**Additional lookup:** `src/crypto_news_aggregator/bugops/store.py:99-105`
+
+```python
+async def get_case(self, case_id: str) -> Optional[BugCase]:
+    """Get a case by case_id."""
+    doc = await self.cases_collection.find_one({"case_id": case_id})
+    if doc:
+        doc = _normalize_mongo_doc(doc)
+        return BugCase(**doc)
+    return None
+```
+
+### Summary
+
+**What exists:**
+- `BugAlertEvent` is mandatory — all signals flow through `process_alert_event()` which creates a `BugAlertEvent` first, then finds or creates a `BugCase`
+- The `case_id` field on `BugAlertEvent` is optional (`case_id: Optional[str] = None`) but is populated after the case is found/created
+- `BugAlertEvent` and `BugCase` share similar fields: `title`, `summary`, `severity`, `alert_type`, `dedupe_key`, `correlation_keys`, `metric`
+- Cases can be retrieved by `case_id` or by `dedupe_key` + status
+
+**Gap:** Sprint 020 freshness detectors will be internal to BugOps and will not follow the external-signal-to-alert-event flow. The question is whether freshness detectors should:
+1. Create a `BugAlertEvent` anyway (maintains consistency, adds storage overhead)
+2. Skip `BugAlertEvent` and create `BugCase` directly (reduces storage, breaks the uniform flow)
+
+**Current state:** There is **no path to create a BugCase without a BugAlertEvent**. The only way to create a case is:
+- `process_alert_event()` → creates alert first → then creates or attaches to case
+- `create_case_from_alert()` → requires a `BugAlertEvent` as input
+
+**Action Required:**
+- Additive: Add a `create_case_direct()` method to `BugOpsStore` if freshness detectors should bypass `BugAlertEvent`
+- Or: Update `process_alert_event()` to accept optional source (allow None for internal detectors) so freshness detectors can still create an event
+
+---
+
+## 3. BugCase Data Model Fields
+
+### Current BugCase Model
+
+**File & Lines:** `src/crypto_news_aggregator/bugops/models.py:62-89` (full definition shown above)
+
+**Current fields:**
+- `case_id: str` — unique case identifier
+- `status: CaseStatus` — one of {OPEN, RESOLVED, CLOSED}
+- `severity: AlertSeverity` — one of {INFO, WARNING, HIGH, CRITICAL}
+- `alert_type: str` — e.g., "cost_runaway", "db_connection_error"
+- `title: str` — human-readable title
+- `summary: str` — brief description
+- `dedupe_key: str` — used to find existing open cases
+- `source_types: list[str]` — which signal sources contributed (e.g., ["llm_traces", "railway_logs"])
+- `alert_ids: list[str]` — attached alert IDs
+- `correlation_keys: list[str]` — tags for correlation (e.g., ["domain:llm", "operation:enrichment"])
+- `metric: dict` — arbitrary metrics/measurements
+- `suggested_manual_check: Optional[str]` — note for operator
+- `created_at: datetime` — case creation timestamp
+- `updated_at: datetime` — last update timestamp
+- `resolved_at: Optional[datetime]` — when resolved
+- `closed_at: Optional[datetime]` — when closed
+- `deterministic_report: Optional[str]` — analysis report
+
+### MongoDB Indexes
+
+**Finding:** No indexes defined for bug_cases or bug_alert_events collections. The index initialization in `mongodb.py:541-607` does not reference BugOps collections.
+
+### Missing Fields from Sprint 020 Requirements
+
+Sprint 020 requires:
+- `root_subsystem: string`
+- `affected_subsystems: list of strings`
+- `blast_radius: list of strings`
+- `recovery_candidate_at: timestamp | null`
+- `observation_count: integer`
+- `resolution_type: string | null`
+- `confidence: float | null`
+- `correlation_reason: string | null`
+
+**Existing fields that partially satisfy:**
+- `correlation_keys: list[str]` — can store subsystem references, but is unstructured
+- `metric: dict` — can store arbitrary counts, but `observation_count` should be a first-class field for efficient querying/sorting
+
+### Observation Count Tracking
+
+**Current approach:** No explicit `observation_count` field. The count is implicitly tracked by the length of `alert_ids` list (number of attached alerts).
+
+**Code evidence:** `src/crypto_news_aggregator/bugops/store.py:84-97`
+
+```python
+async def attach_alert_to_case(self, case_id: str, alert_id: str) -> BugCase:
+    """Attach an alert event to an existing case."""
+    result = await self.cases_collection.find_one_and_update(
+        {"case_id": case_id},
+        {
+            "$addToSet": {"alert_ids": alert_id},
+            "$set": {"updated_at": __import__("datetime").datetime.utcnow()}
+        },
+        return_document=True
+    )
+    if result:
+        result = _normalize_mongo_doc(result)
+        return BugCase(**result)
+    raise ValueError(f"Case {case_id} not found")
+```
+
+The `alert_ids` list tracks all alerts attached to a case via `$addToSet`.
+
+### Last Seen / First Seen Tracking
+
+**Finding:** No explicit `first_seen_at` or `last_seen_at` fields. Only `created_at` (case creation) and `updated_at` (last modification) are tracked.
+
+**Gap:** If Sprint 020 needs to know when a detector last fired (for "recovery_candidate_at" calculation), this information is not available unless stored as a separate field.
+
+### Summary
+
+**What exists:**
+- 15 fields on BugCase covering severity, status, routing, and timeline
+- Implicit observation count via `alert_ids` list length
+- Generic `metric: dict` for extensibility
+- Created/updated timestamps but no explicit "last observed" tracking
+
+**What is missing — all additive:**
+- `root_subsystem: string` — not present
+- `affected_subsystems: list[str]` — not present
+- `blast_radius: list[str]` — not present
+- `recovery_candidate_at: Optional[datetime]` — not present
+- `observation_count: int` — tracked implicitly via `len(alert_ids)`, should be explicit
+- `resolution_type: Optional[str]` — not present (status is enough for now, but resolution type may differ from status)
+- `confidence: Optional[float]` — not present
+- `correlation_reason: Optional[str]` — not present (correlation_keys exist but are unstructured tags)
+
+**MongoDB indexes:** None exist for bug_cases or bug_alert_events. Will need to define indexes on:
+- `dedupe_key` (likely unique or compound with status)
+- `status` and `created_at` (for listing open/resolved cases)
+- `root_subsystem` (once added, for filtering by subsystem)
+
+**Action Required:**
+- Additive: Add 8 new fields to BugCaseCreate and BugCase models
+- Additive: Decide whether `observation_count` should be:
+  - Denormalized (stored explicitly, updated on each alert attach)
+  - Computed on read (from `len(alert_ids)`)
+- Additive: Add MongoDB indexes for bug_cases (dedupe_key, status+created_at, root_subsystem once added)
+- Consider: Add `first_observed_at` and `last_observed_at` for freshness detector lifecycle tracking
+
+---
+
+## Alignment Summary Table
+
+| Area | Current | Sprint 020 Required | Gap Type | Effort |
+|------|---------|-------------------|----------|--------|
+| Dedupe Key Format | `source:type:YYYY-MM-DD:HH` | `detector:subsystem` | Conflicting | High |
+| Dedupe Key Index | None | Recommend unique/compound | Additive | Low |
+| BugAlertEvent Layer | Mandatory flow | Optional for internal detectors | Additive | Medium |
+| BugCase Direct Creation | Not possible | Required | Additive | Low |
+| Root Subsystem | Missing | Required | Additive | Low |
+| Affected Subsystems | Missing | Required | Additive | Low |
+| Blast Radius | Missing | Required | Additive | Low |
+| Recovery Candidate At | Missing | Required | Additive | Low |
+| Observation Count | Implicit (alert_ids) | Explicit field | Additive | Low |
+| Resolution Type | Missing | Required | Additive | Low |
+| Confidence | Missing | Required | Additive | Low |
+| Correlation Reason | Missing | Required | Additive | Low |
+| BugOps Indexes | None | Needed | Additive | Low |
+
+---
+
+## Next Steps for Implementation
+
+### Phase 1: Data Model Extension (Low Risk, Additive)
+1. Add 8 new fields to BugCase model
+2. Add MongoDB indexes for bug_cases and bug_alert_events
+3. Add `create_case_direct()` method for internal detectors
+
+### Phase 2: Dedupe Key Migration (High Risk, Requires Planning)
+1. Define dedupe_key formats for all detector types (freshness, cascade, etc.)
+2. Decide on migration strategy for existing hour-bucketed keys
+3. Update all signal sources to use new format
+4. Consider: grace period allowing both old and new formats during transition
+
+### Phase 3: Freshness Detector Integration (Depends on Phase 1-2)
+Implement freshness detectors using extended model and direct case creation path
+

--- a/docs/sprints/sprint-020/investigations/sprint-020-alignment-investigation.md
+++ b/docs/sprints/sprint-020/investigations/sprint-020-alignment-investigation.md
@@ -1,0 +1,133 @@
+# BugOps Sprint 020 Alignment Investigation
+
+## Context
+
+We are planning Sprint 020 for BugOps. Sprint 018 built the foundation.
+Sprint 020 will add outcome freshness detectors, the DependencyGraph,
+cascade suppression, and idempotency on top of that foundation.
+
+Before writing Sprint 020 implementation tickets, we need to understand
+three specific alignment gaps between the Sprint 018 implementation and
+the Sprint 020 design. This is an investigation task only — no code
+changes yet.
+
+---
+
+## What to find
+
+### 1. Dedupe key format
+
+Sprint 018 implemented hourly bucketed dedupe keys in the format:
+
+```
+llm_traces:cost_runaway:YYYY-MM-DD:HH
+```
+
+Sprint 020 defines dedupe keys in the format:
+
+```
+detector_type:root_subsystem
+```
+
+Examples: `article_freshness:articles`, `signal_freshness:signals`
+
+**Find:**
+- The exact file and line(s) where dedupe_key is constructed in the
+  current implementation
+- The exact file and line(s) where dedupe_key is used for lookup
+  (finding an existing open case)
+- Whether dedupe_key has a unique index in MongoDB or is just a query
+  field
+- Any other places in the codebase that construct or reference
+  dedupe_key format directly
+
+Show the relevant code snippets.
+
+---
+
+### 2. BugAlertEvent layer
+
+Sprint 018 normalizes signals into a `BugAlertEvent` first, then creates
+or attaches to a `BugCase`. The flow is:
+
+```
+SignalSource → BugAlertEvent → BugCase
+```
+
+Sprint 020 freshness detectors need to create or attach to a BugCase
+directly. The question is whether `BugAlertEvent` should remain as
+internal plumbing or be bypassed for freshness detectors.
+
+**Find:**
+- The full `BugAlertEvent` model definition (file, line, all fields)
+- The full `BugCase` model definition (file, line, all fields)
+- The `process_alert_event()` method or equivalent — wherever the
+  BugAlertEvent → BugCase creation logic lives (file, line, full
+  implementation)
+- Whether BugAlertEvent is required by the store layer or optional —
+  i.e., is there any path to create a BugCase without a BugAlertEvent?
+
+Show the relevant code snippets.
+
+---
+
+### 3. BugCase data model fields
+
+Sprint 020 requires these fields on BugCase that may not exist yet:
+
+```
+root_subsystem          string
+affected_subsystems     list of strings
+blast_radius            list of strings
+recovery_candidate_at   timestamp | null
+observation_count       integer
+resolution_type         string | null
+confidence              float | null
+correlation_reason      string | null
+```
+
+Sprint 018 BugCase currently has at minimum:
+`severity`, `status`, `dedupe_key`
+
+**Find:**
+- The complete current BugCase model with every field, type, and
+  default value
+- Any MongoDB collection indexes defined on bug_cases (in store.py
+  or any migration/init file)
+- Whether `observation_count` exists already or if it is tracked a
+  different way (e.g., by counting attached BugAlertEvents)
+- Whether there is any existing `last_seen_at` or `first_seen_at`
+  tracking on BugCase
+
+Show the relevant code snippets.
+
+---
+
+## Deliverable
+
+For each of the three areas above, provide:
+
+1. File path(s) and line number(s)
+2. The relevant code snippet(s) — full method or model definitions,
+   not just the line in isolation
+3. A one-paragraph summary of what exists, what is missing, and
+   whether the gap is additive (new fields/methods needed) or
+   conflicting (existing behavior needs to change)
+
+Do not make any code changes. Investigation only.
+
+---
+
+## Files likely to be relevant
+
+Based on the Sprint 018 summary, start here:
+
+```
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/base.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+```
+
+But search the full bugops/ directory for any other relevant files.

--- a/docs/sprints/sprint-020/sprint-020-bugops-outcome-freshness.md
+++ b/docs/sprints/sprint-020/sprint-020-bugops-outcome-freshness.md
@@ -1,0 +1,916 @@
+# Sprint 020 — Outcome Freshness & Failure Visibility
+
+**Status:** Planned
+**Started:** TBD
+**Target:** Production failures surface as BugCases automatically, with no manual monitoring required
+
+---
+
+## Sprint Goal
+
+Sprint 020 adds outcome freshness detection to BugOps. Four detectors monitor whether articles, signals, narratives, and briefings are being produced at the expected rate. When expected output stops appearing — including when BugOps starts while production is already broken — BugOps creates a BugCase and notifies the operator via Slack. Cascade suppression, idempotency, and auto-resolution with a Recovery Window ensure operators receive signal, not noise.
+
+This sprint does not implement Evidence Packs, Investigations, Tickets, Railway log ingestion, or runtime exception monitoring. Those are Sprint 021 and Sprint 022 respectively. Sprint 020's contract to the next sprint is a reliable, low-noise stream of BugCases that accurately represent production failures.
+
+---
+
+## Scope Boundary
+
+### In Scope
+- [ ] Four outcome freshness detectors (articles, signals, narratives, briefings)
+- [ ] Canonical subsystem enum
+- [ ] Deterministic severity mapping for freshness detectors
+- [ ] DependencyGraph v1 (`scheduler → ingestion → articles → signals → narratives → briefings`)
+- [ ] Cascade suppression (upstream-wins, deterministic processing order)
+- [ ] Idempotency and dedupe for open BugCases
+- [ ] BugCase model extension with Sprint 020 fields
+- [ ] MongoDB indexes for BugOps collections
+- [ ] `create_case_direct()` and `attach_observation_to_case()` store methods
+- [ ] Startup detection for active failures present when BugOps starts
+- [ ] Auto-resolution with configurable Recovery Window
+- [ ] Recovery Window repeated-failure handling
+- [ ] Slack notification contract for BugCase state changes
+- [ ] Notification attempt persistence
+- [ ] Global deploy suppression
+- [ ] Suppression expiry summary
+- [ ] Detector isolation (independent try/catch per detector)
+- [ ] Detector run observability via structured logs
+
+### Out of Scope / Non-Goals
+- [ ] Railway log ingestion
+- [ ] RuntimeExceptionSignalSource
+- [ ] Runtime exception monitoring from Railway logs
+- [ ] Evidence Pack collection (Sprint 021)
+- [ ] Investigation generation (Sprint 021)
+- [ ] Ticket drafting or export (Sprint 022)
+- [ ] Retroactive BugCase merging or absorption
+- [ ] Per-subsystem suppression (global only this sprint)
+- [ ] External heartbeat (deferred, see architecture doc)
+- [ ] `resolution_type` population (field added, not required this sprint)
+- [ ] Medium digest batching (routing decision implemented, actual batching stubbed)
+- [ ] RuntimeError, WorkerFailure, SchedulerFailure, DatabaseFailure signal sources (separate sprint)
+- [ ] Slack interactive UI, buttons, slash commands, or acknowledgement actions
+- [ ] Dedicated flapping detection with manual escalation
+
+---
+
+## Sprint Order
+
+| #  | Ticket    | Title                                                              | Status   | Est | Actual |
+|----|-----------|--------------------------------------------------------------------|----------|-----|--------|
+| 1  | TASK-100  | Extend BugCase model with Sprint 020 fields                        | 🔲 OPEN  | S   |        |
+| 2  | TASK-100A | Add canonical BugOps subsystem enum                                | 🔲 OPEN  | S   |        |
+| 3  | TASK-100B | Add deterministic severity mapping for Sprint 020 detectors        | 🔲 OPEN  | S   |        |
+| 4  | TASK-101  | Add MongoDB indexes for BugOps collections                         | 🔲 OPEN  | S   |        |
+| 5  | TASK-102  | Add `create_case_direct()` and `attach_observation_to_case()`      | 🔲 OPEN  | S   |        |
+| 6  | TASK-103  | Implement DependencyGraph v1                                       | 🔲 OPEN  | S   |        |
+| 7  | TASK-104  | Implement ArticleFreshness detector                                | 🔲 OPEN  | M   |        |
+| 8  | TASK-105  | Implement SignalFreshness detector                                 | 🔲 OPEN  | M   |        |
+| 9  | TASK-106  | Implement NarrativeFreshness detector                              | 🔲 OPEN  | M   |        |
+| 10 | TASK-107  | Implement BriefingFreshness detector                               | 🔲 OPEN  | M   |        |
+| 11 | TASK-108  | Wire freshness detectors into monitor with cascade suppression     | 🔲 OPEN  | M   |        |
+| 12 | TASK-108A | Implement startup detection semantics                              | 🔲 OPEN  | M   |        |
+| 13 | TASK-109  | Implement auto-resolution with Recovery Window                     | 🔲 OPEN  | M   |        |
+| 14 | TASK-111  | Implement Slack notification contract for BugCase state changes    | 🔲 OPEN  | M   |        |
+| 15 | TASK-111A | Persist notification attempt records                               | 🔲 OPEN  | S   |        |
+| 16 | TASK-112  | Implement global deploy suppression                                | 🔲 OPEN  | S   |        |
+| 17 | TASK-112A | Send deploy suppression expiry summary                             | 🔲 OPEN  | S   |        |
+| 18 | TASK-113  | Update Sprint 020 docs and success criteria                        | 🔲 OPEN  | S   |        |
+
+**Sequencing:**
+
+Phase 1 — Foundation (no behavior change):
+TASK-100 → TASK-100A → TASK-100B → TASK-101 → TASK-102
+
+Phase 2 — New primitives (no dependencies on Phase 1):
+TASK-103
+
+Phase 3 — Detectors (depend on Phase 1 + 2, can run in parallel):
+TASK-104, TASK-105, TASK-106, TASK-107
+
+Phase 4 — Wiring and behavior (depend on Phase 1–3):
+- TASK-108 (cascade suppression wiring, depends on TASK-103 + all detectors)
+- TASK-108A (startup detection, depends on TASK-108)
+- TASK-109 (auto-resolution, depends on all detectors)
+- TASK-111 (Slack contract, depends on TASK-100, TASK-100A, TASK-100B)
+- TASK-111A (notification attempt persistence, depends on TASK-111)
+- TASK-112 (deploy suppression, depends on TASK-100)
+- TASK-112A (suppression expiry summary, depends on TASK-112)
+
+Phase 5 — Closeout:
+- TASK-113 (docs and success criteria, depends on all above)
+
+---
+
+## Ticket Specifications
+
+---
+
+### TASK-100 — Extend BugCase model with Sprint 020 fields
+
+Add the following fields to the BugCase model:
+
+```
+root_subsystem         string (canonical subsystem enum value)
+affected_subsystems    list of strings (canonical subsystem enum values)
+blast_radius           list of strings (canonical subsystem enum values)
+first_seen_at          timestamp
+last_seen_at           timestamp
+observation_count      integer, default 1
+recovery_candidate_at  timestamp | null
+resolution_type        string | null (not required this sprint)
+muted_until            timestamp | null
+snoozed_until          timestamp | null
+detection_type         enum: startup | runtime | reopen
+reopen_count           integer, default 0
+```
+
+`detection_type` is required. It records how the BugCase was created.
+
+`resolution_type` field exists but is not populated this sprint.
+
+`muted_until` and `snoozed_until` are flags affecting notification behavior
+only. They do not block auto-resolution or case progression.
+
+---
+
+### TASK-100A — Add canonical BugOps subsystem enum
+
+Create a shared canonical subsystem enum used across detectors, BugCase
+fields, DependencyGraph, and notification messages.
+
+Canonical values:
+
+```
+scheduler
+ingestion
+articles
+signals
+narratives
+briefings
+worker
+database
+```
+
+Acceptance criteria:
+
+- Canonical subsystem values exist as a shared constant or enum
+- Detectors use enum values for root_subsystem
+- BugCase root_subsystem validates against enum
+- BugCase affected_subsystems validates against enum
+- Tests reject ad hoc subsystem strings not in the enum
+
+---
+
+### TASK-100B — Add deterministic severity mapping for Sprint 020 detectors
+
+Define and enforce the Sprint 020 severity mapping:
+
+```
+ArticleFreshness:   High
+SignalFreshness:    High
+NarrativeFreshness: High
+BriefingFreshness:  High
+```
+
+Severity is assigned deterministically at detection time.
+
+Sprint 020 does not implement severity escalation except where explicitly
+required by a ticket.
+
+Acceptance criteria:
+
+- Each freshness detector produces High severity BugCases
+- Severity is not computed dynamically from observation count or
+  blast radius in Sprint 020
+- Notification routing depends on this severity mapping
+
+---
+
+### TASK-101 — Add MongoDB indexes for BugOps collections
+
+Add indexes to support efficient BugOps query patterns:
+
+- Open BugCase lookup by dedupe_key
+- Open BugCase lookup by root_subsystem (for cascade suppression)
+- BugCase lookup by status
+- Notification attempt lookup by bugcase_id
+
+---
+
+### TASK-102 — Add `create_case_direct()` and `attach_observation_to_case()` to BugOpsStore
+
+`create_case_direct()` creates a new BugCase directly from detector
+output, bypassing the alert event layer used in Sprint 018.
+
+`attach_observation_to_case()` attaches a new observation to an existing
+open BugCase, incrementing `observation_count` and updating `last_seen_at`.
+
+These methods support the Sprint 020 processing order:
+
+```
+1. Check for open upstream BugCase → attach if found
+2. Check for open BugCase with same dedupe_key → attach if found
+3. Create new BugCase
+```
+
+---
+
+### TASK-103 — Implement DependencyGraph v1
+
+Implement the hand-maintained, version-controlled DependencyGraph.
+
+Graph (version 1.0):
+
+```
+scheduler → ingestion → articles → signals → narratives → briefings
+```
+
+The graph must support:
+
+- Upstream traversal (cascade suppression): walk from a given subsystem
+  toward the root, return first open BugCase found at any upstream node
+- Downstream traversal (blast radius): walk from a given subsystem toward
+  the leaves, return all reachable subsystem names
+
+`worker` and `database` must exist in the canonical subsystem enum
+(TASK-100A) but are not graph nodes in Sprint 020. They are reserved for
+future detectors.
+
+The graph is not inferred dynamically. Changes require deliberate
+versioning.
+
+Unit tests required for both traversal directions.
+
+---
+
+### TASK-104 — Implement ArticleFreshness detector
+
+**Five-part definition:**
+
+Last successful output: most recent Article with `created_at` within
+freshness window.
+
+Expected input or activity: at least one RSS fetch attempt completed
+within the current polling cycle (via `fetched_at` on Article records —
+no RSS fetch job collection exists).
+
+Failure condition: no Article inserted within freshness window AND at
+least one source has historically produced articles during this
+time-of-day window.
+
+Legitimate idle condition: all monitored RSS sources have published no
+new content for this time-of-day window in recent history.
+
+Recovery condition: at least one new Article inserted with `created_at`
+within freshness window on a previously stalled source.
+
+**Detector config:**
+
+```
+root_subsystem:        articles
+severity:              High
+detection_type:        runtime (startup if first poll)
+dedupe_key:            article_freshness:articles
+suggested_manual_check: Check RSS ingestion health, recent fetch
+                        attempts, source availability, and whether
+                        articles are being inserted with created_at
+                        timestamps.
+```
+
+**Notes:**
+
+- Uses `created_at` on `articles` collection
+- Uses `fetched_at` on Article records as proxy for fetch attempt
+  (no RSS fetch job collection exists)
+- Startup detection: if failure condition is active on first poll,
+  create BugCase with detection_type=startup
+
+---
+
+### TASK-105 — Implement SignalFreshness detector
+
+**Five-part definition:**
+
+Last successful output: most recent Signal with `last_updated` within
+freshness window.
+
+Expected input or activity: at least one Article inserted recently enough
+that signal generation should have run.
+
+Failure condition: Articles exist with `created_at` within freshness
+window AND no Signals generated within freshness window.
+
+Legitimate idle condition: no articles inserted recently; signal
+generation has no input.
+
+Recovery condition: at least one new Signal generated with `last_updated`
+within freshness window corresponding to previously stalled article input.
+
+**Detector config:**
+
+```
+root_subsystem:        signals
+severity:              High
+detection_type:        runtime (startup if first poll)
+dedupe_key:            signal_freshness:signals
+suggested_manual_check: Check signal generation worker health and
+                        confirm recent articles are being processed
+                        into signals.
+```
+
+**Notes:**
+
+- Uses `last_updated` on `signal_scores` collection
+- Startup detection: if failure condition is active on first poll,
+  create BugCase with detection_type=startup
+
+---
+
+### TASK-106 — Implement NarrativeFreshness detector
+
+**Five-part definition:**
+
+Last successful output: most recent Narrative with
+`last_summary_generated_at` within freshness window.
+
+Expected input or activity: sufficient signals exist to trigger narrative
+refresh.
+
+Failure condition: Signals exist within freshness window AND no Narrative
+updated or inserted within freshness window.
+
+Legitimate idle condition: no signals generated recently; narrative
+refresh has no meaningful input.
+
+Recovery condition: at least one Narrative updated or inserted with
+`last_summary_generated_at` within freshness window after stall period.
+
+**Detector config:**
+
+```
+root_subsystem:        narratives
+severity:              High
+detection_type:        runtime (startup if first poll)
+dedupe_key:            narrative_freshness:narratives
+suggested_manual_check: Check narrative refresh job health and confirm
+                        recent signals are available as input.
+```
+
+**Notes:**
+
+- Uses `last_summary_generated_at` on `narratives` collection
+- No formal Pydantic model; queries `db.narratives` directly
+- Startup detection: if failure condition is active on first poll,
+  create BugCase with detection_type=startup
+
+---
+
+### TASK-107 — Implement BriefingFreshness detector
+
+**Five-part definition:**
+
+Last successful output: most recent Briefing with `generated_at` within
+the expected schedule window.
+
+Expected input or activity: briefing generation window has elapsed.
+Narratives exist that are fresh enough to produce a briefing.
+
+Failure condition: briefing generation window has elapsed AND no Briefing
+inserted within expected window AND fresh narratives exist as input.
+
+Legitimate idle condition: briefing generation window has not yet elapsed
+since last successful briefing. Or no sufficiently fresh narratives exist.
+
+Recovery condition: new Briefing inserted with `generated_at` within
+expected window following stall period.
+
+**Detector config:**
+
+```
+root_subsystem:        briefings
+severity:              High
+detection_type:        runtime (startup if first poll)
+dedupe_key:            briefing_freshness:briefings
+suggested_manual_check: Check briefing generation schedule, recent
+                        narrative freshness, and whether a briefing
+                        insert was attempted.
+```
+
+**Notes:**
+
+- Uses `generated_at` on `daily_briefings` collection
+- Two schedule windows: 8AM EST and 8PM EST, each with 30-minute grace
+  period. Single-window approach produces false positives.
+- A briefing is overdue only if BOTH: `generated_at` of last briefing
+  is outside the window AND the scheduled window has elapsed plus grace
+  period
+- Startup detection: if failure condition is active on first poll,
+  create BugCase with detection_type=startup
+
+---
+
+### TASK-108 — Wire freshness detectors into monitor with cascade suppression
+
+Wire all four freshness detectors into the BugOps polling loop with
+deterministic cascade suppression.
+
+**Processing order (must not vary):**
+
+```
+1. Detector observes failure condition
+2. Check for open upstream BugCase (DependencyGraph upstream traversal)
+   → If found: attach observation, update affected_subsystems,
+     update last_seen_at and observation_count. No new BugCase.
+     No notification. Stop.
+3. Check for open BugCase with same dedupe_key
+   → If found: attach observation, update last_seen_at and
+     observation_count. No new BugCase. No notification. Stop.
+4. Create new BugCase. Notify if routing rules require it.
+```
+
+Upstream-wins is unconditional regardless of downstream severity.
+
+Each detector runs inside an independent try/catch block. A detector
+failure logs a structured error and does not halt the polling loop or
+prevent other detectors from running.
+
+Unit tests required for cascade suppression processing order.
+
+---
+
+### TASK-108A — Implement startup detection semantics
+
+Implement startup detection behavior in the monitor.
+
+BugOps does not require observing a healthy-to-unhealthy transition before
+creating a BugCase. If production is already broken when BugOps starts,
+detectors create BugCases immediately.
+
+**Behavior:**
+
+```
+BugOps starts
+→ each freshness detector runs (first poll)
+→ active failure conditions create BugCases with detection_type=startup
+→ cascade suppression applies normally during startup
+→ Critical and High startup BugCases notify Slack
+```
+
+**Acceptance criteria:**
+
+- Active failure at first monitor poll creates a BugCase
+- Startup-created BugCase has detection_type=startup
+- Startup-created High BugCase sends Slack notification
+- Downstream startup failures cascade-suppress into upstream startup
+  BugCase when applicable
+- No healthy baseline is required before a startup BugCase is created
+- Subsequent polls use detection_type=runtime
+
+---
+
+### TASK-109 — Implement auto-resolution with Recovery Window
+
+Implement auto-resolution based on outcome recovery, not component health.
+
+**Recovery candidate entry:**
+When a freshness detector observes its recovery condition is met, set
+`recovery_candidate_at` to the timestamp of the first healthy observation.
+
+`recovery_candidate_at` is internal metadata. It is not operator-facing.
+
+**Recovery Window:**
+The BugCase resolves only if the subsystem remains healthy for the full
+Recovery Window duration.
+
+Default Recovery Window:
+- Production: 10 minutes
+- Development/test: 1 minute
+
+**Failure recurrence before Recovery Window elapses:**
+
+```
+clear recovery_candidate_at
+BugCase remains open
+no new BugCase created
+no Slack notification sent
+```
+
+**Auto-resolution triggers when:**
+
+```
+recovery condition is met AND
+recovery_candidate_at is set AND
+elapsed time since recovery_candidate_at >= Recovery Window
+```
+
+**Auto-resolution is blocked when:**
+
+```
+BugCase has been manually closed by operator
+```
+
+Auto-resolution still applies to BugCases with active mute or snooze
+flags. Those flags affect notification behavior only.
+
+Auto-resolution does not send a Slack notification.
+
+BugCase resolves as a unit. Partial resolution is not supported.
+
+Unit tests required for Recovery Window timing, failure recurrence
+clearing, and manual-close blocking.
+
+---
+
+### TASK-111 — Implement Slack notification contract for BugCase state changes
+
+Implement the full Slack notification contract.
+
+**Notify on:**
+
+```
+new Critical BugCase created
+new High BugCase created
+Critical or High BugCase reopened
+severity escalation
+deploy suppression expiry summary (see TASK-112A)
+```
+
+**Do not notify on:**
+
+```
+repeated observation attached to existing BugCase
+cascade-suppressed downstream observation
+observation_count increase
+last_seen_at update
+recovery_candidate_at set
+recovery_candidate_at cleared
+auto-resolution
+manual close
+Low severity BugCase creation
+Medium severity BugCase creation
+```
+
+**Notification event types:**
+
+```
+bugcase_created
+bugcase_reopened
+severity_escalated
+suppression_summary
+```
+
+**Deduplication:**
+A BugCase creation notification is sent at most once per BugCase.
+Reopen and severity escalation always notify immediately regardless of
+throttle.
+
+**Throttle:**
+Maximum 1 Slack notification per BugCase per hour, except severity
+escalation and reopen which are always immediate. Throttle may be
+deferred if implementation cost is high — deduplication rules already
+prevent most duplicate sends.
+
+**Slack message fields (all notifications):**
+
+```
+event_type
+severity
+title
+bugcase_id
+status
+root_subsystem
+affected_subsystems
+summary
+first_seen_at
+last_seen_at
+observation_count
+dedupe_key
+detection_type
+suggested_manual_check
+suppression_status
+```
+
+**suppression_status values:**
+
+```
+sent
+suppressed
+not_applicable
+```
+
+**Message format — BugCase created:**
+
+```
+🚨 HIGH — Article Freshness Failure
+
+Case:           bc_123
+Detection:      startup
+Root subsystem: articles
+Affected:       signals, narratives, briefings
+Summary:        No articles inserted for 42 minutes while article
+                activity was expected.
+First seen:     2026-06-11 19:21 UTC
+Last seen:      2026-06-11 19:21 UTC
+Observations:   1
+Suggested check: Check RSS ingestion health and recent fetch attempts.
+```
+
+**Message format — Case reopened:**
+
+```
+🔄 CASE REOPENED
+
+Case:         bc_123
+Severity:     High
+Root:         articles
+Summary:      Article freshness recovered but failed again.
+Reopen count: 1
+```
+
+**Slack message must not include:**
+
+```
+raw logs
+stack traces
+large JSON payloads
+full database records
+LLM-generated analysis
+Evidence Pack contents
+Investigation contents
+```
+
+---
+
+### TASK-111A — Persist notification attempt records
+
+Persist a record for every notification attempt, independent of BugCase
+lifecycle.
+
+**Schema:**
+
+```
+notification_id
+bugcase_id
+event_type
+channel
+status
+attempted_at
+error_type       | null
+error_message    | null
+suppressed_reason | null
+```
+
+**channel values:** `slack`
+
+**status values:**
+
+```
+sent       — Slack webhook accepted the notification
+failed     — Slack webhook failed, timed out, or raised an exception
+suppressed — Deploy suppression was active
+skipped    — Routing rules did not require notification
+```
+
+Sprint 020 does not need to persist `skipped` records unless
+implementation cost is low.
+
+**Failure behavior:**
+
+```
+Slack send fails
+→ record status: failed
+→ log error
+→ BugCase remains created
+→ monitor continues polling
+```
+
+Notification failure must not block BugCase creation, detection,
+auto-resolution, or evidence collection.
+
+---
+
+### TASK-112 — Implement global deploy suppression
+
+Implement deploy suppression via environment variable.
+
+**Mechanism:**
+
+```
+BUGOPS_SUPPRESSED_UNTIL=<ISO-8601 timestamp>
+```
+
+If current time is before `BUGOPS_SUPPRESSED_UNTIL`, suppression is
+active.
+
+If the variable is empty, invalid, or in the past, suppression is
+inactive.
+
+**During suppression:**
+
+```
+BugCases are created normally
+BugCases are updated normally
+Slack notifications are not sent
+notification attempts are recorded as suppressed
+auto-resolution runs normally
+reopen logic runs normally
+```
+
+**Mute and snooze flags:**
+`muted_until` and `snoozed_until` fields exist on BugCase (added in
+TASK-100). Sprint 020 respects these flags for notification routing
+only. No Slack UI or operator actions are implemented to set them.
+
+Suppression scope is global only. Per-subsystem suppression is deferred.
+
+---
+
+### TASK-112A — Send deploy suppression expiry summary
+
+When suppression expires, send one Slack summary for unresolved Critical
+and High BugCases that were active during the suppression window.
+
+**Send summary only if:**
+
+```
+suppression was active
+one or more Critical or High BugCases were created or updated during
+suppression window
+those BugCases remain unresolved when suppression expires
+```
+
+**Do not send summary if:**
+
+```
+all suppressed BugCases auto-resolved before suppression ended
+```
+
+**Summary format:**
+
+```
+Deploy suppression ended
+
+2 unresolved BugCases were active during suppression:
+
+- HIGH Article Freshness Failure — bc_123
+- HIGH Briefing Freshness Failure — bc_124
+```
+
+The summary does not replay individual suppressed notifications.
+
+---
+
+### TASK-113 — Update Sprint 020 docs and success criteria
+
+Update sprint doc, success criteria, and any inline documentation to
+reflect final Sprint 020 scope.
+
+Must reflect:
+
+- Startup detection behavior and detection_type field
+- Full Slack notification contract
+- Notification attempt records
+- Recovery Window replacing flapping detection
+- Railway log ingestion explicitly out of scope
+- RuntimeExceptionSignalSource explicitly out of scope
+- Canonical subsystem enum
+- Deterministic severity mapping
+
+Remove from success criteria:
+
+```
+Flapping protection activates and notifies correctly under rapid
+oscillation
+```
+
+Confirm present in success criteria:
+
+```
+A BugCase does not auto-resolve if the failure condition recurs during
+the Recovery Window
+```
+
+---
+
+## Success Criteria
+
+- [ ] All four freshness detectors run in the BugOps polling loop without changes to monitor process structure
+- [ ] Each detector correctly distinguishes legitimate idle from broken using the five-part definition
+- [ ] Active failures present at BugOps startup create BugCases with detection_type=startup
+- [ ] Startup-created Critical and High BugCases send Slack notifications
+- [ ] Startup-created downstream failures are cascade-suppressed into upstream BugCases when applicable
+- [ ] Cascade suppression attaches downstream signals to upstream BugCases instead of creating new ones
+- [ ] Idempotency suppresses duplicate BugCases for repeated observations of the same open condition
+- [ ] A BugCase auto-resolves after the Recovery Window elapses without re-violation
+- [ ] A BugCase does not auto-resolve if the failure condition recurs during the Recovery Window
+- [ ] A detector failure does not halt the polling loop or prevent other detectors from running
+- [ ] Slack notifications are sent only for BugCase state changes, not repeated observations
+- [ ] Slack messages include severity, root_subsystem, affected_subsystems, summary, first_seen_at, last_seen_at, observation_count, dedupe_key, detection_type, and suggested_manual_check
+- [ ] Slack send failure records a failed notification attempt and does not block BugCase creation
+- [ ] BugCases with active mute or snooze flags resolve normally when recovery conditions are met
+- [ ] Deploy suppression suppresses notification delivery without suppressing BugCase creation or updates
+- [ ] Suppression expiry sends one summary for unresolved Critical and High BugCases active during suppression
+- [ ] Canonical subsystem names are used consistently across all components
+- [ ] Railway log ingestion and runtime exception monitoring are not implemented in Sprint 020
+- [ ] Detector runs are observable through structured logs
+
+---
+
+## Agent Safety Notes
+
+These constraints apply to all implementation agents working this sprint:
+
+- Do not modify production data.
+- Do not introduce broad database, shell, or filesystem access when a narrow tool/API is sufficient.
+- Do not change unrelated files.
+- Do not add autonomous destructive actions.
+- Keep implementation bounded to the ticket's listed files unless a blocker is documented.
+- If the implementation requires a new file/path not listed in the ticket, stop and document why before proceeding.
+- The existing LLM cost-runaway detector (`signal_sources/llm_traces.py`) and its tests must not be broken by any ticket in this sprint.
+- `published_at` is never used for freshness decisions. Use `created_at` for Articles, `last_updated` for Signals, `last_summary_generated_at` for Narratives, `generated_at` for Briefings.
+- All new `BUGOPS_*` environment variables must be added to `src/crypto_news_aggregator/core/config.py` via the existing settings pattern. Do not modify `bugops/config.py` directly.
+- Do not implement Slack UI, buttons, slash commands, or acknowledgement actions.
+- Do not implement Railway log ingestion or RuntimeExceptionSignalSource.
+- Do not implement dedicated flapping detection.
+
+---
+
+## Implementation Notes
+
+### Expected Branch Naming
+
+```text
+task/bugops-[ticket-number]-[short-description]
+```
+
+### Expected Commit Format
+
+```text
+task(bugops): TASK-1XX description
+```
+
+### Test Expectations
+
+- Unit tests required for all logic changes, especially DependencyGraph traversal, detector idle vs. broken logic, cascade suppression processing order, startup detection, and Recovery Window timing.
+- Integration/manual verification steps must be documented in the ticket completion summary.
+- If a test cannot be automated, document the reason and provide a manual verification path.
+
+### Field Name Map (Architecture → Actual)
+
+The architecture documents use `inserted_at` as the generic term for "time artifact was persisted." Actual field names per collection:
+
+| Subsystem  | Collection        | Authoritative Timestamp Field |
+|------------|-------------------|-------------------------------|
+| Articles   | `articles`        | `created_at`                  |
+| Signals    | `signal_scores`   | `last_updated`                |
+| Narratives | `narratives`      | `last_summary_generated_at`   |
+| Briefings  | `daily_briefings` | `generated_at`                |
+
+---
+
+## Horizon: Sprint 021 and Sprint 022
+
+Sprint 020 is the detection layer. The next two sprints build on it directly.
+
+**Sprint 021 — Evidence & Investigation**
+Goal: BugCase → Evidence Pack → Investigation
+
+Once a BugCase exists, Sprint 021 adds automatic evidence collection (Railway logs, deploy context, system state, related BugCases) via a deterministic EvidenceCollector, then feeds that Evidence Pack to an InvestigationProvider (LLM-backed) that produces a structured analysis with likely causes, evidence references, and verification steps. Railway log access must be validated before Sprint 021 begins. Interface contracts are defined in `20-sprint-021-evidence-investigation-interface.md`.
+
+**Sprint 022 — Ticket Factory & Validation**
+Goal: Investigation → Ticket → Human Approval → Coding Agent → Validation
+
+Sprint 022 adds the TicketWriter (generates structured implementation tickets from Investigations), human approval workflow, coding-agent handoff format, and a ValidationRunner that determines whether a fix resolved the BugCase or should reopen it. Interface contracts are defined in `30-sprint-022-ticket-validation-interface.md`.
+
+Neither sprint begins until Sprint 020 success criteria are fully met.
+
+---
+
+## Key Decisions
+
+| Date       | Decision | Rationale | Impact |
+|------------|----------|-----------|--------|
+| Pre-sprint | `inserted_at` in architecture maps to `created_at` on Articles | Actual field name discovered via codebase inspection | All Article freshness queries use `created_at` |
+| Pre-sprint | NarrativeFreshness uses `last_summary_generated_at` as primary freshness field | No formal Pydantic model; this field most accurately reflects narrative output | TASK-106 queries `db.narratives` directly |
+| Pre-sprint | BriefingFreshness uses two schedule windows (8AM + 8PM EST) with 30-minute grace period | Briefings run twice daily; single-window approach would produce false positives | TASK-107 config uses morning/evening hour + grace period instead of single freshness window |
+| Pre-sprint | ArticleFreshness "expected input" check uses `fetched_at` on Article records | No RSS fetch job collection exists; `fetched_at` is the only audit trail | TASK-104 cannot check for a completed fetch job; uses article `fetched_at` instead |
+| Pre-sprint | All new `BUGOPS_*` env vars go into `core/config.py` | `bugops/config.py` delegates to `core/config.py`; adding vars there maintains the existing pattern | All config-touching tickets point to `core/config.py` |
+| Pre-sprint | Dedicated flapping detection deferred | Recovery Window handles practical oscillation; no evidence Backdrop needs dedicated flapping detection yet | TASK-110 removed; Recovery Window repeated-failure handling merged into TASK-109 |
+| Pre-sprint | Railway log ingestion deferred to Sprint 021 | Log access requires validation of programmatic Railway API access before implementation; does not affect outcome freshness detection | Sprint 020 produces BugCases without log context; Sprint 021 EvidenceCollector adds logs |
+| Pre-sprint | Startup detection creates BugCases for active failures | Operator needs to know if production is broken when BugOps starts, regardless of when the failure began | TASK-108A added; detection_type field added to BugCase model |
+
+---
+
+## Discovered Work
+
+| Ticket | Title | Reason Created | Status |
+|--------|-------|----------------|--------|
+| | | | |
+
+---
+
+## Session Log
+
+### Session 1 (TBD)
+_To be filled in during implementation._

--- a/docs/sprints/sprint-020/sprint-020-bugops-outcome-freshness.md
+++ b/docs/sprints/sprint-020/sprint-020-bugops-outcome-freshness.md
@@ -58,7 +58,7 @@ This sprint does not implement Evidence Packs, Investigations, Tickets, Railway 
 
 | #  | Ticket    | Title                                                              | Status   | Est | Actual |
 |----|-----------|--------------------------------------------------------------------|----------|-----|--------|
-| 1  | TASK-100  | Extend BugCase model with Sprint 020 fields                        | 🔲 OPEN  | S   |        |
+| 1  | TASK-100  | Extend BugCase model with Sprint 020 fields                        | ✅ DONE  | S   | S      |
 | 2  | TASK-100A | Add canonical BugOps subsystem enum                                | 🔲 OPEN  | S   |        |
 | 3  | TASK-100B | Add deterministic severity mapping for Sprint 020 detectors        | 🔲 OPEN  | S   |        |
 | 4  | TASK-101  | Add MongoDB indexes for BugOps collections                         | 🔲 OPEN  | S   |        |
@@ -912,5 +912,15 @@ Neither sprint begins until Sprint 020 success criteria are fully met.
 
 ## Session Log
 
-### Session 1 (TBD)
-_To be filled in during implementation._
+### Session 1 (2026-06-11)
+
+**Completed:**
+- TASK-100: Extended BugCase model with 14 Sprint 020 fields
+  - Added subsystem tracking, observation tracking, recovery tracking, detection metadata
+  - All fields optional/have defaults for backward compatibility
+  - Verified BugCase inheritance, test coverage: 25 tests pass (15 model + 10 cost-runaway)
+  - Branch: `task/bugops-100-bugcase-model-sprint020`, commits: 4b1880a, 6abdcc9, b115f70
+
+**Next:**
+- TASK-100A: Canonical subsystem enum
+- TASK-100B: Deterministic severity mapping

--- a/docs/sprints/sprint-020/tickets/task-100-bugcase-model-fields.md
+++ b/docs/sprints/sprint-020/tickets/task-100-bugcase-model-fields.md
@@ -1,0 +1,192 @@
+---
+ticket_id: TASK-100
+title: Extend BugCase model with Sprint 020 fields
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-100-bugcase-model-sprint020
+effort_estimate: small
+---
+
+# TASK-100: Extend BugCase model with Sprint 020 fields
+
+## Problem Statement
+
+The current `BugCaseCreate` and `BugCase` models do not have the fields required by
+Sprint 020: freshness tracking, cascade suppression metadata, recovery tracking,
+operator flags, and notification state. All Sprint 020 behavior depends on these
+fields existing before any detector, suppression, or resolution logic is written.
+
+---
+
+## Context
+
+`BugCase` lives in `src/crypto_news_aggregator/bugops/models.py`.
+
+Current `BugCaseCreate` fields (do not remove or rename any of these):
+```python
+case_id: str
+status: CaseStatus = CaseStatus.OPEN
+severity: AlertSeverity
+alert_type: str
+title: str
+summary: str
+dedupe_key: str
+source_types: list[str]
+alert_ids: list[str] = Field(default_factory=list)
+correlation_keys: list[str] = Field(default_factory=list)
+metric: dict = Field(default_factory=dict)
+suggested_manual_check: Optional[str] = None
+created_at: datetime = Field(default_factory=datetime.utcnow)
+updated_at: datetime = Field(default_factory=datetime.utcnow)
+resolved_at: Optional[datetime] = None
+closed_at: Optional[datetime] = None
+deterministic_report: Optional[str] = None
+```
+
+All new fields must be optional or have defaults so existing Sprint 018 cases,
+tests, and the cost-runaway detector are completely unaffected.
+
+`BugCase` inherits from `BugCaseCreate` — confirm new fields are accessible on
+retrieved documents after this change.
+
+`root_subsystem`, `affected_subsystems`, and `blast_radius` are typed as `str` /
+`list[str]` in this ticket. TASK-100A adds the canonical subsystem enum; once
+TASK-100A is merged, the type annotation for these three fields should be updated
+to use `BugOpsSubsystem`. Do not block this ticket on TASK-100A.
+
+Architecture invariant: `muted_until` and `snoozed_until` are flags that affect
+notification behavior only. They are not lifecycle statuses and do not block
+auto-resolution or case progression.
+
+---
+
+## Task
+
+1. Add all new fields to `BugCaseCreate` in `models.py`
+2. Confirm `BugCase` (read model) reflects the same fields via inheritance
+3. Run existing tests to confirm no regressions
+
+---
+
+## Files to Create
+
+```text
+(none)
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Implementation Requirements
+
+Add the following fields to `BugCaseCreate`. All are optional or have defaults.
+
+### Subsystem tracking
+- [ ] `root_subsystem: Optional[str] = None` — subsystem closest to originating failure
+- [ ] `affected_subsystems: list[str] = Field(default_factory=list)` — downstream subsystems impacted by cascade suppression attachments
+- [ ] `blast_radius: list[str] = Field(default_factory=list)` — all reachable downstream nodes from DependencyGraph at creation time
+
+### Observation tracking
+- [ ] `observation_count: int = 1` — starts at 1 (the creating observation); incremented by `attach_observation_to_case()`
+- [ ] `first_seen_at: Optional[datetime] = None` — when the failure condition was first observed; distinct from `created_at`
+- [ ] `last_seen_at: Optional[datetime] = None` — when the failure condition was most recently observed
+
+### Recovery tracking
+- [ ] `recovery_candidate_at: Optional[datetime] = None` — internal field; set when recovery condition is first met; cleared if failure recurs before Recovery Window elapses; never operator-facing
+
+### Resolution metadata
+- [ ] `resolution_type: Optional[str] = None` — not required in Sprint 020; reserved for future use; add inline comment: `# reserved: real_issue | false_positive | duplicate | operator_error | expected_idle`
+
+### Detection metadata
+- [ ] `detection_type: Optional[str] = None` — how the BugCase was created; valid values: `startup`, `runtime`, `reopen`; add inline comment: `# startup | runtime | reopen`
+- [ ] `reopen_count: int = 0` — incremented each time a resolved BugCase is reopened
+
+### Operator flags (affect notification only — do not block auto-resolution)
+- [ ] `muted_until: Optional[datetime] = None`
+- [ ] `snoozed_until: Optional[datetime] = None`
+
+### Notification tracking
+- [ ] `last_notified_at: Optional[datetime] = None`
+- [ ] `notification_count: int = 0`
+
+### Configuration
+
+No new environment variables required for this ticket.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All existing bugops tests pass without modification
+- [ ] A `BugCaseCreate` can be instantiated with no new fields provided and defaults are applied correctly
+- [ ] A `BugCaseCreate` can be instantiated with all new fields provided and values are stored correctly
+
+### Manual Verification
+
+- [ ] Confirm the existing cost-runaway detector test creates a BugCase successfully after this change
+- [ ] Confirm `observation_count` defaults to `1` (not `0`)
+- [ ] Confirm `detection_type` accepts `None` and the string values `startup`, `runtime`, `reopen`
+
+---
+
+## Acceptance Criteria
+
+- [ ] All 14 new fields are present on `BugCaseCreate` with correct types and defaults
+- [ ] `observation_count` defaults to `1`
+- [ ] `detection_type` and `resolution_type` have inline comments as specified
+- [ ] Existing Sprint 018 tests pass without modification
+- [ ] No existing BugCase creation call requires changes to continue working
+
+---
+
+## Impact
+
+Unblocks all of Phase 3 and Phase 4 of Sprint 020. No behavior change in this
+ticket — schema only.
+
+---
+
+## Related Tickets
+
+- Blocks: TASK-101, TASK-102, TASK-104, TASK-105, TASK-106, TASK-107, TASK-108,
+  TASK-109, TASK-111, TASK-112
+- Related: TASK-100A (canonical subsystem enum — update type annotations after merge)
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-100-bugcase-model-fields.md
+++ b/docs/sprints/sprint-020/tickets/task-100-bugcase-model-fields.md
@@ -184,9 +184,26 @@ ticket — schema only.
 
 ## Completion Summary
 
-- Branch:
-- Commit:
+- Branch: `task/bugops-100-bugcase-model-sprint020`
+- Commits: 
+  - `4b1880a` — docs(sprint-020): add sprint plan, ticket specs, and BugOps system architecture
+  - `6abdcc9` — task(bugops): TASK-100 extend BugCase model with Sprint 020 fields
 - Changes made:
+  - Added 14 new fields to `BugCaseCreate` in `src/crypto_news_aggregator/bugops/models.py`
+  - All fields optional or have defaults (no breaking changes)
+  - `observation_count` defaults to 1 (not 0)
+  - `detection_type` and `resolution_type` include inline comments on valid values
+  - `BugCase` inherits all fields via inheritance from `BugCaseCreate`
 - Tests run:
+  - `poetry run pytest tests/bugops/test_bugops_models.py tests/bugops/test_llm_traces_cost_source.py -v`
+  - **Result: 25 passed** (15 model tests + 10 cost-runaway detector tests)
+  - Test output: all PASSED, 97 warnings (Pydantic deprecation warnings, not test failures)
 - Manual verification:
+  - ✅ BugCase instantiated with new fields via inheritance (test_bug_case_read_model_inherits_sprint020_fields)
+  - ✅ observation_count defaults to 1 (verified in test_bug_case_sprint020_fields_with_defaults)
+  - ✅ detection_type accepts None and valid values: startup, runtime, reopen
+  - ✅ Cost-runaway detector test suite unaffected (all 10 tests pass)
 - Deviations from plan:
+  - Ticket specified `pytest src/tests/bugops/ -v` but correct path is `tests/bugops/` (no `src/` prefix)
+  - `detection_type` remains `Optional[str] = None` at schema level for backward compatibility; Sprint 020 detectors will enforce non-null via store/detector creation logic, not at model validation
+  - Test fixture updates: 4 existing test cases required adding the pre-existing required field `alert_type` to pass Pydantic validation. This is not a behavior change — the field was already required in the model, just missing from fixture data.

--- a/docs/sprints/sprint-020/tickets/task-100a-subsystem-enum.md
+++ b/docs/sprints/sprint-020/tickets/task-100a-subsystem-enum.md
@@ -1,0 +1,173 @@
+---
+ticket_id: TASK-100A
+title: Add canonical BugOps subsystem enum
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-100a-subsystem-enum
+effort_estimate: small
+---
+
+# TASK-100A: Add canonical BugOps subsystem enum
+
+## Problem Statement
+
+Subsystem names are currently bare strings scattered across detectors, BugCase
+fields, and DependencyGraph logic. Without a shared enum, a typo in any one
+place produces a silent mismatch that breaks cascade suppression. A canonical
+enum enforces consistency at definition time.
+
+---
+
+## Context
+
+The enum must be importable by detectors (TASK-104 through TASK-107),
+DependencyGraph (TASK-103), BugOpsStore (TASK-102), and monitor (TASK-108).
+The natural home is `models.py` alongside the other enums already there
+(`AlertSeverity`, `AlertStatus`, `CaseStatus`).
+
+`worker` and `database` are included in the enum for future detectors but are
+not DependencyGraph nodes in Sprint 020.
+
+After this ticket merges, TASK-100's `root_subsystem`, `affected_subsystems`,
+and `blast_radius` field type annotations should be updated to `BugOpsSubsystem`
+/ `list[BugOpsSubsystem]`. This is a follow-up annotation change — it does not
+block TASK-100A acceptance.
+
+---
+
+## Task
+
+1. Add `BugOpsSubsystem` enum to `models.py`
+2. Write unit tests confirming enum values
+3. Confirm existing tests still pass
+
+---
+
+## Files to Create
+
+```text
+(none — tests go in the existing test_bugops_models.py)
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/tests/bugops/test_bugops_models.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Implementation Requirements
+
+### `BugOpsSubsystem` enum
+
+Add to `models.py` alongside the existing enums:
+
+```python
+class BugOpsSubsystem(str, Enum):
+    """Canonical subsystem names for BugOps detectors and DependencyGraph."""
+    SCHEDULER = "scheduler"
+    INGESTION = "ingestion"
+    ARTICLES = "articles"
+    SIGNALS = "signals"
+    NARRATIVES = "narratives"
+    BRIEFINGS = "briefings"
+    WORKER = "worker"    # reserved — no detector in Sprint 020
+    DATABASE = "database"  # reserved — no detector in Sprint 020
+```
+
+- [ ] Inherits from `(str, Enum)` so values serialize as plain strings in MongoDB
+- [ ] All eight values present with exact string values as shown
+- [ ] `WORKER` and `DATABASE` have inline comments noting they are reserved
+
+### Test cases to add to `test_bugops_models.py`
+
+- [ ] `BugOpsSubsystem.ARTICLES.value == "articles"`
+- [ ] `BugOpsSubsystem.SIGNALS.value == "signals"`
+- [ ] `BugOpsSubsystem.NARRATIVES.value == "narratives"`
+- [ ] `BugOpsSubsystem.BRIEFINGS.value == "briefings"`
+- [ ] `BugOpsSubsystem.SCHEDULER.value == "scheduler"`
+- [ ] `BugOpsSubsystem.INGESTION.value == "ingestion"`
+- [ ] `BugOpsSubsystem.WORKER.value == "worker"`
+- [ ] `BugOpsSubsystem.DATABASE.value == "database"`
+- [ ] Enum has exactly 8 members
+- [ ] `BugOpsSubsystem("articles") == BugOpsSubsystem.ARTICLES` (str construction works)
+
+### Configuration
+
+No new environment variables required.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_bugops_models.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All new enum test cases pass
+- [ ] All existing bugops tests pass without modification
+
+### Manual Verification
+
+- [ ] Import `BugOpsSubsystem` from `models.py` in a Python REPL and confirm all
+  8 values are accessible
+- [ ] Confirm `BugOpsSubsystem.WORKER.value == "worker"` and
+  `BugOpsSubsystem.DATABASE.value == "database"`
+
+---
+
+## Acceptance Criteria
+
+- [ ] `BugOpsSubsystem` enum exists in `models.py` with all 8 values
+- [ ] Inherits from `(str, Enum)`
+- [ ] `WORKER` and `DATABASE` have reserved comments
+- [ ] All 10 test cases pass
+- [ ] All existing bugops tests pass
+
+---
+
+## Impact
+
+Downstream: TASK-103 (DependencyGraph), TASK-104 through TASK-107 (detectors),
+TASK-108 (monitor wiring) all import and use this enum. No behavior change in
+this ticket — enum definition only.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100 (enum lives in same file; merge TASK-100 first)
+- Blocks: TASK-103, TASK-104, TASK-105, TASK-106, TASK-107, TASK-108
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-100b-severity-mapping.md
+++ b/docs/sprints/sprint-020/tickets/task-100b-severity-mapping.md
@@ -1,0 +1,177 @@
+---
+ticket_id: TASK-100B
+title: Add deterministic severity mapping for Sprint 020 detectors
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-100b-severity-mapping
+effort_estimate: small
+---
+
+# TASK-100B: Add deterministic severity mapping for Sprint 020 detectors
+
+## Problem Statement
+
+Sprint 020 freshness detectors each hardcode their severity as `AlertSeverity.HIGH`.
+Without a shared mapping, each detector independently defines severity, making the
+routing table in TASK-111 dependent on convention rather than an enforceable contract.
+A shared mapping makes severity assignment explicit, testable, and easy to change
+in one place.
+
+---
+
+## Context
+
+Sprint 020 severity mapping:
+
+```
+ArticleFreshness:   High
+SignalFreshness:    High
+NarrativeFreshness: High
+BriefingFreshness:  High
+```
+
+Severity is assigned deterministically at detection time. It is not computed
+dynamically from observation count, blast radius, or any runtime state in Sprint 020.
+
+The mapping lives in a new file `signal_sources/severity.py`. Each detector
+(TASK-104 through TASK-107) imports its severity from there instead of hardcoding
+`AlertSeverity.HIGH` inline.
+
+TASK-111 notification routing depends on this mapping — Critical and High receive
+immediate Slack; Medium logs digest intent; Low logs only.
+
+---
+
+## Task
+
+1. Create `signal_sources/severity.py` with the `DETECTOR_SEVERITY` mapping
+2. Write unit tests confirming the mapping values
+3. Do not modify any detector files — they will import from here in TASK-104 to TASK-107
+
+---
+
+## Files to Create
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/severity.py
+src/tests/bugops/test_severity_mapping.py
+```
+
+---
+
+## Files to Modify
+
+```text
+(none)
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Implementation Requirements
+
+### `severity.py`
+
+```python
+from ..models import AlertSeverity
+
+# Deterministic severity mapping for Sprint 020 freshness detectors.
+# Severity is assigned at detection time, not computed dynamically.
+DETECTOR_SEVERITY: dict[str, AlertSeverity] = {
+    "article_freshness": AlertSeverity.HIGH,
+    "signal_freshness": AlertSeverity.HIGH,
+    "narrative_freshness": AlertSeverity.HIGH,
+    "briefing_freshness": AlertSeverity.HIGH,
+}
+```
+
+- [ ] Dict keys match the detector name strings used in dedupe keys
+  (e.g. `"article_freshness"` matches the first segment of
+  `"article_freshness:articles"`)
+- [ ] All four values are `AlertSeverity.HIGH`
+- [ ] Module-level docstring explains this is Sprint 020 only and escalation
+  is not implemented
+
+### Test cases in `test_severity_mapping.py`
+
+- [ ] `DETECTOR_SEVERITY["article_freshness"] == AlertSeverity.HIGH`
+- [ ] `DETECTOR_SEVERITY["signal_freshness"] == AlertSeverity.HIGH`
+- [ ] `DETECTOR_SEVERITY["narrative_freshness"] == AlertSeverity.HIGH`
+- [ ] `DETECTOR_SEVERITY["briefing_freshness"] == AlertSeverity.HIGH`
+- [ ] Mapping has exactly 4 keys
+- [ ] All values are `AlertSeverity.HIGH` (no dynamic computation)
+
+### Configuration
+
+No new environment variables required.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_severity_mapping.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All 6 test cases pass
+- [ ] All existing bugops tests pass without modification
+
+### Manual Verification
+
+- [ ] Import `DETECTOR_SEVERITY` in a Python REPL and confirm all four values
+  are `AlertSeverity.HIGH`
+
+---
+
+## Acceptance Criteria
+
+- [ ] `severity.py` exists with the `DETECTOR_SEVERITY` dict
+- [ ] All four freshness detectors map to `AlertSeverity.HIGH`
+- [ ] No dynamic severity computation
+- [ ] All test cases pass
+- [ ] Existing tests unaffected
+
+---
+
+## Impact
+
+TASK-104 through TASK-107 will import severity from here. TASK-111 notification
+routing reads `AlertSeverity` values from BugCase, so this mapping must be
+consistent with what TASK-111 expects. No behavior change in this ticket —
+mapping definition only.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100 (AlertSeverity enum must exist)
+- Blocks: TASK-104, TASK-105, TASK-106, TASK-107, TASK-111
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-100c-slack-webhook-config.md
+++ b/docs/sprints/sprint-020/tickets/task-100c-slack-webhook-config.md
@@ -1,0 +1,166 @@
+---
+ticket_id: TASK-100C
+title: Configure Slack webhook in Railway for BugOps
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: (none — deploy config only, no code changes)
+effort_estimate: xs
+---
+
+# TASK-100C: Configure Slack webhook in Railway for BugOps
+
+## Problem Statement
+
+`slack.py` is fully implemented and `send_case_notification()` works correctly,
+but the Slack webhook URL and enable flags have never been set in Railway. BugOps
+has also never been enabled in production (`BUGOPS_ENABLED` defaults to `false`).
+Sprint 020 depends on Slack delivery working when the first freshness BugCase fires.
+This ticket configures the missing environment variables before Sprint 020 goes live.
+
+---
+
+## Context
+
+From code inspection:
+- `slack.py` exists at `src/crypto_news_aggregator/bugops/slack.py`
+- `send_case_notification()` is fully implemented — uses `httpx` to POST to a
+  webhook URL, has error handling, formats Slack-compatible JSON attachments
+- Three environment variables gate delivery:
+  - `BUGOPS_ENABLED` — defaults to `false`; the monitor exits immediately if false
+  - `BUGOPS_SLACK_ENABLED` — defaults to `false`; `send_case_notification()` returns
+    early if false
+  - `BUGOPS_SLACK_WEBHOOK_URL` — defaults to `""`; `send_case_notification()` logs
+    a warning and returns False if empty
+- The existing cost-runaway detector has never sent a Slack message in production
+  because all three variables have been at their defaults
+
+This is deploy config work only. No code changes required.
+
+---
+
+## Task
+
+1. Create an incoming webhook in Slack
+2. Set the three environment variables in Railway
+3. Verify delivery with a manual test
+
+---
+
+## Files to Create
+
+```text
+(none)
+```
+
+---
+
+## Files to Modify
+
+```text
+(none — Railway environment variables only)
+```
+
+---
+
+## Do Not Modify
+
+```text
+(anything)
+```
+
+---
+
+## Implementation Requirements
+
+### Step 1 — Create Slack incoming webhook
+
+- [ ] Go to https://api.slack.com/apps → select or create a Slack app for Backdrop
+- [ ] Enable Incoming Webhooks
+- [ ] Add a new webhook to the desired channel (e.g. `#backdrop-alerts` or
+  `#bugops`)
+- [ ] Copy the webhook URL (format: `https://hooks.slack.com/services/...`)
+
+### Step 2 — Set Railway environment variables
+
+In the Railway project for Backdrop, set:
+
+- [ ] `BUGOPS_SLACK_WEBHOOK_URL` = `<webhook URL from Step 1>`
+- [ ] `BUGOPS_SLACK_ENABLED` = `true`
+- [ ] `BUGOPS_ENABLED` = `true`
+
+Note: Setting `BUGOPS_ENABLED=true` activates the full BugOps monitor including
+the existing cost-runaway detector. Verify the cost-runaway thresholds are
+acceptable before flipping this on in production:
+- `BUGOPS_COST_5MIN_THRESHOLD_USD` defaults to `0.25`
+- `BUGOPS_PROJECTED_HOURLY_THRESHOLD_USD` defaults to `1.00`
+
+At $0.54/day production spend these thresholds are safe, but confirm before deploy.
+
+### Step 3 — Verify delivery
+
+- [ ] After deploying with the new env vars, check Railway logs for:
+  `"BugOps monitor running with poll interval: 300s"` — confirms monitor started
+- [ ] Trigger a test notification by temporarily lowering
+  `BUGOPS_COST_5MIN_THRESHOLD_USD` to `0.001` for one poll cycle, then restore it
+  — OR — confirm the log line `"Slack notification sent for case"` appears when
+  a real threshold is hit
+- [ ] Confirm the Slack message arrives in the configured channel
+
+### Configuration
+
+Environment variables set in Railway (not in codebase):
+
+```
+BUGOPS_ENABLED=true
+BUGOPS_SLACK_ENABLED=true
+BUGOPS_SLACK_WEBHOOK_URL=<webhook URL>
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+None — this is deploy config only.
+
+### Manual Verification
+
+- [ ] Railway logs show `"BugOps monitor running"` after deploy
+- [ ] At least one Slack message received in the configured channel
+- [ ] Railway logs do not show `"BUGOPS_SLACK_WEBHOOK_URL not configured"`
+
+---
+
+## Acceptance Criteria
+
+- [ ] Slack incoming webhook created and URL recorded
+- [ ] All three env vars set in Railway
+- [ ] At least one successful Slack delivery confirmed
+- [ ] Railway logs confirm monitor is running
+
+---
+
+## Impact
+
+Unblocks Sprint 020 end-to-end Slack delivery. Without this ticket, all
+notification logic in TASK-111 is implemented but never delivers. Do this
+ticket before or alongside Sprint 020 code work — do not wait until the end.
+
+---
+
+## Related Tickets
+
+- Blocks: TASK-111 (Slack contract depends on delivery working)
+- No code dependencies — can be done independently of all other tickets
+
+---
+
+## Completion Summary
+
+- Webhook channel:
+- Railway deploy timestamp:
+- Test message confirmed:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-101-bugops-mongo-indexes.md
+++ b/docs/sprints/sprint-020/tickets/task-101-bugops-mongo-indexes.md
@@ -1,0 +1,208 @@
+---
+ticket_id: TASK-101
+title: Add MongoDB indexes for BugOps collections
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-101-mongodb-indexes
+effort_estimate: small
+---
+
+# TASK-101: Add MongoDB indexes for BugOps collections
+
+## Problem Statement
+
+BugOps collections currently have no indexes defined. Sprint 020 adds four
+freshness detectors running on every polling cycle, cascade suppression that
+queries for open upstream BugCases by subsystem, idempotency logic that queries
+for open BugCases by dedupe key, and notification attempt persistence. Without
+indexes these queries degrade linearly with collection size. Indexes must be in
+place before detectors run.
+
+---
+
+## Context
+
+The existing index pattern in `mongodb.py` is:
+
+```python
+# At module level, define a list of index dicts:
+BUG_CASES_INDEXES = [
+    {"keys": [("dedupe_key", 1), ("status", 1)], "name": "dedupe_key_status"},
+    ...
+]
+
+# In MongoManager.initialize_indexes(), for each collection:
+collection = await self.get_async_collection("bug_cases")
+for index_info in BUG_CASES_INDEXES:
+    index_options = index_info.copy()
+    keys = index_options.pop("keys")
+    if not await self._has_index(collection, index_options.get("name")):
+        await collection.create_index(keys, **index_options)
+```
+
+The `_has_index()` helper already exists — it checks by name before creating,
+making the operation idempotent. Follow this exact pattern.
+
+`initialize_indexes()` is called from `initialize_mongodb()` at application
+startup, which is called from the FastAPI lifespan and from the BugOps monitor's
+`run()` method via `mongo_manager.initialize()` → `ensure_indexes()`.
+
+Three collections need indexes in this ticket: `bug_cases`, `bug_alert_events`,
+and `notification_attempts` (added by TASK-111A).
+
+---
+
+## Task
+
+1. Add `BUG_CASES_INDEXES` list at module level in `mongodb.py`
+2. Add `BUG_ALERT_EVENTS_INDEXES` list at module level in `mongodb.py`
+3. Add `NOTIFICATION_ATTEMPTS_INDEXES` list at module level in `mongodb.py`
+4. Wire all three into `initialize_indexes()` following the existing pattern
+5. Confirm no duplicate index errors on startup
+
+---
+
+## Files to Create
+
+```text
+(none)
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/db/mongodb.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+```
+
+---
+
+## Implementation Requirements
+
+### Indexes on `bug_cases`
+
+- [ ] `{"keys": [("dedupe_key", 1), ("status", 1)], "name": "bug_cases_dedupe_key_status"}` — supports `find_open_case_by_dedupe_key()`; most frequent query
+- [ ] `{"keys": [("status", 1), ("created_at", -1)], "name": "bug_cases_status_created_at"}` — supports listing open and recent cases
+- [ ] `{"keys": [("root_subsystem", 1), ("status", 1)], "name": "bug_cases_root_subsystem_status"}` — supports `find_open_case_by_root_subsystem()` in cascade suppression
+- [ ] `{"keys": [("first_seen_at", 1)], "name": "bug_cases_first_seen_at"}` — supports freshness window queries in auto-resolution
+
+### Indexes on `bug_alert_events`
+
+- [ ] `{"keys": [("dedupe_key", 1)], "name": "bug_alert_events_dedupe_key"}` — supports alert lookups
+- [ ] `{"keys": [("created_at", -1)], "name": "bug_alert_events_created_at"}` — supports retention policy queries
+
+### Indexes on `notification_attempts`
+
+- [ ] `{"keys": [("bugcase_id", 1)], "name": "notification_attempts_bugcase_id"}` — supports lookup of all attempts for a BugCase
+- [ ] `{"keys": [("attempted_at", -1)], "name": "notification_attempts_attempted_at"}` — supports retention queries
+
+### Wiring in `initialize_indexes()`
+
+Add after the existing entity_mentions index block:
+
+```python
+# BugOps collections
+bug_cases_col = await self.get_async_collection("bug_cases")
+for index_info in BUG_CASES_INDEXES:
+    index_options = index_info.copy()
+    keys = index_options.pop("keys")
+    if not await self._has_index(bug_cases_col, index_options.get("name")):
+        await bug_cases_col.create_index(keys, **index_options)
+
+bug_alert_events_col = await self.get_async_collection("bug_alert_events")
+for index_info in BUG_ALERT_EVENTS_INDEXES:
+    index_options = index_info.copy()
+    keys = index_options.pop("keys")
+    if not await self._has_index(bug_alert_events_col, index_options.get("name")):
+        await bug_alert_events_col.create_index(keys, **index_options)
+
+notification_attempts_col = await self.get_async_collection("notification_attempts")
+for index_info in NOTIFICATION_ATTEMPTS_INDEXES:
+    index_options = index_info.copy()
+    keys = index_options.pop("keys")
+    if not await self._has_index(notification_attempts_col, index_options.get("name")):
+        await notification_attempts_col.create_index(keys, **index_options)
+```
+
+Also add all three collection names to the `force_recreate` drop block if that
+block exists.
+
+### Configuration
+
+No new environment variables required for this ticket.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] Existing bugops tests pass without modification
+- [ ] No duplicate index errors on startup (idempotent due to `_has_index` check)
+
+### Manual Verification
+
+- [ ] Connect to the development MongoDB instance after startup and run:
+  ```
+  db.bug_cases.getIndexes()
+  db.bug_alert_events.getIndexes()
+  db.notification_attempts.getIndexes()
+  ```
+- [ ] Confirm all 8 indexes appear (4 on bug_cases, 2 on bug_alert_events,
+  2 on notification_attempts)
+
+---
+
+## Acceptance Criteria
+
+- [ ] 4 indexes on `bug_cases` with names as specified
+- [ ] 2 indexes on `bug_alert_events` with names as specified
+- [ ] 2 indexes on `notification_attempts` with names as specified
+- [ ] All follow the `_has_index` idempotent pattern from existing collections
+- [ ] Application starts without errors
+- [ ] Existing bugops tests pass
+
+---
+
+## Impact
+
+Required for query performance as BugOps collections grow. No behavior change.
+Unblocks Phase 3 detectors and Phase 4 suppression/resolution logic.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100
+- Blocks: TASK-104, TASK-105, TASK-106, TASK-107, TASK-108, TASK-109, TASK-111A
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-102-store-direct-methods.md
+++ b/docs/sprints/sprint-020/tickets/task-102-store-direct-methods.md
@@ -1,0 +1,216 @@
+---
+ticket_id: TASK-102
+title: Add `create_case_direct()` and `attach_observation_to_case()` to BugOpsStore
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-102-store-direct-methods
+effort_estimate: small
+---
+
+# TASK-102: Add `create_case_direct()` and `attach_observation_to_case()` to BugOpsStore
+
+## Problem Statement
+
+Freshness detectors are internal to BugOps. They do not produce external
+`BugAlertEvent` objects — they detect conditions directly and need to create or
+update a BugCase without going through the `process_alert_event()` flow. The
+current store has no method that supports this pattern.
+
+---
+
+## Context
+
+Current `BugOpsStore` in `store.py` has these methods (do not modify):
+- `create_alert_event()`
+- `find_open_case_by_dedupe_key()`
+- `create_case_from_alert()`
+- `attach_alert_to_case()`
+- `get_case()`
+- `process_alert_event()`
+- `get_alert_events_for_case()`
+- `save_case_report()`
+
+Two new methods are needed:
+
+**`create_case_direct()`** — creates a BugCase from a `BugCaseCreate` directly,
+without requiring a `BugAlertEvent`. Returns the created `BugCase`.
+
+**`attach_observation_to_case()`** — increments `observation_count`, updates
+`last_seen_at`, and optionally adds to `affected_subsystems` on an existing
+BugCase. Does not require an `alert_id`. Returns the updated `BugCase`.
+
+The `_normalize_mongo_doc()` helper already exists and handles ObjectId → str
+conversion. Use it in both new methods as all existing methods do.
+
+Note the `import __import__("datetime")` pattern used in `attach_alert_to_case()`
+for `datetime.utcnow()` — use the standard `from datetime import datetime` import
+at the top of the file instead for the new methods (or reuse whatever import
+pattern is cleanest in context).
+
+---
+
+## Task
+
+1. Add `create_case_direct(case: BugCaseCreate) -> BugCase` to `BugOpsStore`
+2. Add `attach_observation_to_case(case_id, last_seen_at, affected_subsystems) -> BugCase`
+3. Write unit tests for both new methods
+4. Confirm existing store tests pass without modification
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_store_direct.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/store.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+```
+
+---
+
+## Implementation Requirements
+
+### `create_case_direct(case: BugCaseCreate) -> BugCase`
+
+- [ ] Accepts a `BugCaseCreate` as its only argument
+- [ ] Calls `case.model_dump(by_alias=False, exclude_none=False)` to get the
+  document dict — same pattern as `create_case_from_alert()`
+- [ ] Inserts the document into `self.cases_collection`
+- [ ] Sets `_id` on the dict from `result.inserted_id`
+- [ ] Calls `_normalize_mongo_doc()` before constructing `BugCase`
+- [ ] Returns the created `BugCase`
+- [ ] Does not create a `BugAlertEvent`
+- [ ] Does not send a notification
+
+### `attach_observation_to_case(case_id: str, last_seen_at: datetime, affected_subsystems: Optional[list[str]] = None) -> BugCase`
+
+- [ ] Accepts `case_id: str`, `last_seen_at: datetime`, and optional
+  `affected_subsystems: Optional[list[str]] = None`
+- [ ] Builds an update dict with:
+  - `$inc`: `{"observation_count": 1}`
+  - `$set`: `{"last_seen_at": last_seen_at, "updated_at": datetime.utcnow()}`
+- [ ] If `affected_subsystems` is provided and non-empty: adds
+  `$addToSet: {"affected_subsystems": {"$each": affected_subsystems}}` to the
+  update — this adds new subsystems without duplicating existing ones
+- [ ] Uses `find_one_and_update` with `return_document=True`
+- [ ] Queries by `{"case_id": case_id}`
+- [ ] Calls `_normalize_mongo_doc()` on result before constructing `BugCase`
+- [ ] Returns the updated `BugCase`
+- [ ] Raises `ValueError(f"Case {case_id} not found")` if no document found —
+  same pattern as existing `attach_alert_to_case()`
+- [ ] Does not send a notification
+
+### Test cases in `test_store_direct.py`
+
+Use the same `mock_db` and `store` fixture pattern from `test_bugops_store.py`:
+
+```python
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.__getitem__ = MagicMock(side_effect=lambda x: MagicMock())
+    return db
+
+@pytest.fixture
+def store(mock_db):
+    return BugOpsStore(mock_db)
+```
+
+Required test cases:
+
+- [ ] `create_case_direct()` calls `insert_one` and returns a `BugCase` with
+  correct field values
+- [ ] `create_case_direct()` with all Sprint 020 optional fields populated stores
+  and retrieves correctly (set `root_subsystem`, `first_seen_at`, `last_seen_at`,
+  `detection_type`, `observation_count`)
+- [ ] `create_case_direct()` normalizes ObjectId `_id` to string
+- [ ] `attach_observation_to_case()` uses `$inc` on `observation_count`
+- [ ] `attach_observation_to_case()` sets `last_seen_at` correctly
+- [ ] `attach_observation_to_case()` with `affected_subsystems` uses `$addToSet`
+  with `$each`
+- [ ] `attach_observation_to_case()` with `affected_subsystems=None` does not
+  include `$addToSet` in the update dict
+- [ ] `attach_observation_to_case()` raises `ValueError` when case not found
+  (mock returns `None`)
+
+### Configuration
+
+No new environment variables required for this ticket.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_store_direct.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All new test cases in `test_store_direct.py` pass
+- [ ] All existing bugops store tests pass without modification
+
+### Manual Verification
+
+- [ ] Call `create_case_direct()` in a dev environment and confirm the document
+  appears in MongoDB with `observation_count=1` and correct Sprint 020 fields
+- [ ] Call `attach_observation_to_case()` twice and confirm `observation_count`
+  is 3 (started at 1, incremented twice) and `last_seen_at` reflects the second
+  call
+
+---
+
+## Acceptance Criteria
+
+- [ ] `create_case_direct()` creates a BugCase without requiring a BugAlertEvent
+- [ ] `attach_observation_to_case()` uses `$inc` for `observation_count`,
+  `$set` for timestamps, `$addToSet` + `$each` for `affected_subsystems`
+- [ ] Neither method sends a notification
+- [ ] Neither method modifies the existing `process_alert_event()` flow
+- [ ] All 8 test cases pass
+
+---
+
+## Impact
+
+Unblocks all four freshness detectors (TASK-104 through TASK-107) and the cascade
+suppression wiring (TASK-108). No behavior change to existing flows.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100
+- Blocks: TASK-104, TASK-105, TASK-106, TASK-107, TASK-108
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-103-dependency-graph.md
+++ b/docs/sprints/sprint-020/tickets/task-103-dependency-graph.md
@@ -1,0 +1,186 @@
+---
+ticket_id: TASK-103
+title: Implement DependencyGraph v1
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-103-dependency-graph
+effort_estimate: small
+---
+
+# TASK-103: Implement DependencyGraph v1
+
+## Problem Statement
+
+Cascade suppression requires a traversable map of operational outcome
+dependencies. Without it, a scheduler failure produces four separate BugCases
+(articles, signals, narratives, briefings) instead of one — each triggering its
+own Slack notification. The DependencyGraph is the primitive that makes
+upstream-wins suppression possible.
+
+---
+
+## Context
+
+The DependencyGraph is a permanent architecture primitive. It is hand-maintained
+and version-controlled. It is not inferred dynamically and is not a full
+architecture map — it represents only the operational outcome dependencies
+relevant to freshness detection.
+
+Version 1 graph:
+```
+scheduler → ingestion → articles → signals → narratives → briefings
+```
+
+`worker` and `database` exist in `BugOpsSubsystem` (TASK-100A) but are NOT nodes
+in this graph in Sprint 020. Both methods must return `[]` for these values.
+
+The graph supports two traversal directions:
+- **Upstream traversal** (cascade suppression): walk from a node toward the root,
+  return all nodes upstream of it
+- **Downstream traversal** (blast radius): walk from a node toward the leaves,
+  return all nodes downstream of it
+
+This ticket has no dependencies on Phase 1 tickets and can be implemented in
+parallel with TASK-100 through TASK-102.
+
+Use `BugOpsSubsystem` string values (e.g. `"articles"`) in the internal graph
+representation. Import `BugOpsSubsystem` from `..models`. Both methods accept
+and return plain strings — callers use `BugOpsSubsystem.value` or string literals.
+
+---
+
+## Task
+
+1. Create `dependency_graph.py` in the bugops directory
+2. Implement `DependencyGraph` class with `get_upstream_nodes()` and
+   `get_downstream_nodes()`
+3. Write comprehensive unit tests for graph traversal
+
+---
+
+## Files to Create
+
+```text
+src/crypto_news_aggregator/bugops/dependency_graph.py
+src/tests/bugops/test_dependency_graph.py
+```
+
+---
+
+## Files to Modify
+
+```text
+(none)
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+```
+
+---
+
+## Implementation Requirements
+
+### `DependencyGraph` class
+
+- [ ] Class attribute `VERSION = "1.0"`
+- [ ] Hardcoded v1 graph as an ordered list representing the linear chain:
+  `["scheduler", "ingestion", "articles", "signals", "narratives", "briefings"]`
+- [ ] `get_upstream_nodes(subsystem: str) -> list[str]` — returns all nodes
+  upstream of the given subsystem, ordered from nearest to root.
+  Example: `get_upstream_nodes("signals")` → `["articles", "ingestion", "scheduler"]`
+- [ ] `get_downstream_nodes(subsystem: str) -> list[str]` — returns all nodes
+  downstream of the given subsystem, ordered from nearest to leaves.
+  Example: `get_downstream_nodes("articles")` → `["signals", "narratives", "briefings"]`
+- [ ] Both methods return `[]` if the given subsystem is not in the graph
+  (do not raise) — this handles `"worker"`, `"database"`, and unknown strings
+- [ ] Root node (`"scheduler"`) has no upstream: `get_upstream_nodes("scheduler")`
+  returns `[]`
+- [ ] Leaf node (`"briefings"`) has no downstream: `get_downstream_nodes("briefings")`
+  returns `[]`
+- [ ] Instantiatable with no arguments: `graph = DependencyGraph()`
+
+### Test cases in `test_dependency_graph.py`
+
+- [ ] `get_upstream_nodes("signals")` → `["articles", "ingestion", "scheduler"]`
+- [ ] `get_upstream_nodes("briefings")` → `["narratives", "signals", "articles", "ingestion", "scheduler"]`
+- [ ] `get_upstream_nodes("scheduler")` → `[]`
+- [ ] `get_upstream_nodes("articles")` → `["ingestion", "scheduler"]`
+- [ ] `get_downstream_nodes("articles")` → `["signals", "narratives", "briefings"]`
+- [ ] `get_downstream_nodes("scheduler")` → `["ingestion", "articles", "signals", "narratives", "briefings"]`
+- [ ] `get_downstream_nodes("briefings")` → `[]`
+- [ ] `get_upstream_nodes("unknown_subsystem")` → `[]` (no raise)
+- [ ] `get_downstream_nodes("unknown_subsystem")` → `[]` (no raise)
+- [ ] `get_upstream_nodes("worker")` → `[]` (reserved, not in graph)
+- [ ] `get_downstream_nodes("database")` → `[]` (reserved, not in graph)
+- [ ] `VERSION == "1.0"`
+
+### Configuration
+
+No new environment variables required for this ticket.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_dependency_graph.py -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All 12 test cases listed above pass
+
+### Manual Verification
+
+- [ ] Instantiate `DependencyGraph()` in a Python REPL and manually verify
+  upstream and downstream traversal for each node in the graph
+
+---
+
+## Acceptance Criteria
+
+- [ ] `DependencyGraph` is instantiatable with no arguments
+- [ ] `VERSION = "1.0"` class attribute is present
+- [ ] `get_upstream_nodes()` returns correct ordered list for every node
+- [ ] `get_downstream_nodes()` returns correct ordered list for every node
+- [ ] Both methods return `[]` for `"worker"`, `"database"`, and unknown strings
+- [ ] All 12 test cases pass
+
+---
+
+## Impact
+
+Unblocks TASK-108 (cascade suppression wiring). No behavior change to any
+existing system.
+
+---
+
+## Related Tickets
+
+- Can run in parallel with TASK-100 through TASK-102
+- Depends on: TASK-100A (for `BugOpsSubsystem` import — can stub with strings
+  if TASK-100A not yet merged)
+- Blocks: TASK-108
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-104-article-freshness.md
+++ b/docs/sprints/sprint-020/tickets/task-104-article-freshness.md
@@ -1,0 +1,264 @@
+---
+ticket_id: TASK-104
+title: Implement ArticleFreshness detector
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-104-article-freshness
+effort_estimate: medium
+---
+
+# TASK-104: Implement ArticleFreshness detector
+
+## Problem Statement
+
+If article ingestion stalls, BugOps currently has no way to detect it. Articles
+are the base of the entire Backdrop pipeline — if they stop being produced,
+signals, narratives, and briefings all go stale downstream. This detector closes
+that gap.
+
+---
+
+## Context
+
+### Five-part definition
+
+| Part | Implementation |
+|---|---|
+| Last successful output | Most recent Article `created_at` within freshness window |
+| Expected input or activity | Any Article with `fetched_at` within lookback window |
+| Failure condition | No Article `created_at` within freshness window AND at least one source has historically produced articles in this time-of-day window |
+| Legitimate idle condition | No Article `fetched_at` within lookback window, OR no historical activity in this time-of-day window |
+| Recovery condition | At least one Article `created_at` within freshness window after a stall |
+
+### Field names
+- Authoritative timestamp: `created_at` on `articles` collection (NOT `inserted_at`, NOT `published_at`)
+- Expected input proxy: `fetched_at` on Article records (no RSS fetch job collection exists in Backdrop)
+
+### Protocol
+
+The detector must implement the `SignalSource` protocol from `signal_sources/base.py`:
+
+```python
+class SignalSource(Protocol):
+    source_type: str
+    async def collect(self) -> List[BugAlertEventCreate]: ...
+```
+
+However, freshness detectors work differently from `LLMTraceCostSignalSource`:
+they do NOT return `BugAlertEventCreate` objects. Instead, the monitor loop
+(TASK-108) calls a separate method to get a signal object, then handles BugCase
+creation itself. See the "Return type" section below.
+
+### Severity and subsystem
+- Import severity from `signal_sources/severity.py`: `DETECTOR_SEVERITY["article_freshness"]`
+- Import subsystem from `models.py`: `BugOpsSubsystem.ARTICLES`
+
+### Startup detection
+If the failure condition is active on the first poll after BugOps starts, the
+BugCase must be created with `detection_type="startup"`. The detector itself does
+not track whether it's the first poll — the monitor (TASK-108) passes a
+`is_startup_poll: bool` flag when calling `check_failure()`. The detector returns
+the same signal regardless; the monitor sets `detection_type` based on the flag.
+
+---
+
+## Task
+
+1. Create `article_freshness.py` in `signal_sources/`
+2. Implement `ArticleFreshnessSignalSource` class
+3. Add required configuration to `core/config.py`
+4. Write unit tests covering idle vs. broken logic
+
+---
+
+## Files to Create
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/article_freshness.py
+src/tests/bugops/test_article_freshness.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/models.py
+```
+
+---
+
+## Implementation Requirements
+
+### Class structure
+
+```python
+class ArticleFreshnessSignalSource:
+    source_type = "article_freshness"
+    root_subsystem = BugOpsSubsystem.ARTICLES.value   # "articles"
+    dedupe_key = "article_freshness:articles"
+    suggested_manual_check = (
+        "Check RSS ingestion health, recent fetch attempts, "
+        "source availability, and whether articles are being "
+        "inserted with created_at timestamps."
+    )
+
+    async def check_failure(self, db: AsyncIOMotorDatabase) -> bool:
+        """Return True if the failure condition is met."""
+        ...
+
+    async def check_recovery(self, db: AsyncIOMotorDatabase) -> bool:
+        """Return True if the recovery condition is met."""
+        ...
+
+    async def collect(self) -> List[BugAlertEventCreate]:
+        """Required by SignalSource protocol. Not used by freshness detectors.
+        Returns empty list — freshness detectors use check_failure() directly."""
+        return []
+```
+
+The monitor (TASK-108) calls `check_failure(db)` and `check_recovery(db)` directly.
+`collect()` satisfies the protocol but is not called for freshness detectors.
+
+### Expected input check (precondition — must pass before evaluating failure)
+
+- [ ] Query `articles` collection:
+  `{"fetched_at": {"$gte": now - timedelta(minutes=BUGOPS_ARTICLE_FETCH_LOOKBACK_MINUTES)}}`
+- [ ] If no document found: return `False` from `check_failure()` — legitimate idle
+
+### Historical activity check (second precondition)
+
+- [ ] Determine current hour of day in UTC
+- [ ] Query `articles` collection for any document with `created_at` whose UTC
+  hour is within ±1 of the current hour, with a `created_at` within the last
+  `BUGOPS_ARTICLE_HISTORY_LOOKBACK_DAYS` days:
+  ```python
+  # Pseudocode — use $expr with $hour operator or post-filter
+  # Match documents where hour(created_at) is in the window
+  ```
+- [ ] If no historical activity found for this time-of-day window: return `False`
+  from `check_failure()` — legitimate idle (sources don't publish at this hour)
+
+### Failure condition
+
+- [ ] Query `articles` collection:
+  `{"created_at": {"$gte": now - timedelta(minutes=BUGOPS_ARTICLE_FRESHNESS_WINDOW_MINUTES) - timedelta(seconds=60)}}`
+- [ ] If document found: return `False` (healthy)
+- [ ] If no document found AND both preconditions above are met: return `True`
+
+### Recovery condition
+
+- [ ] Same query as failure condition (any Article `created_at` within the freshness
+  window + tolerance buffer)
+- [ ] Return `True` if a document is found, `False` otherwise
+
+### 60-second tolerance buffer
+
+- [ ] Subtract an additional 60 seconds from all freshness window cutoffs before
+  evaluating. Prevents boundary false positives from processing latency.
+  `cutoff = now - timedelta(minutes=window_minutes) - timedelta(seconds=60)`
+
+### Configuration — add to `core/config.py` via the existing `Settings` class
+
+```python
+BUGOPS_ARTICLE_FRESHNESS_WINDOW_MINUTES: int = 60
+BUGOPS_ARTICLE_FETCH_LOOKBACK_MINUTES: int = 90
+BUGOPS_ARTICLE_HISTORY_LOOKBACK_DAYS: int = 7
+```
+
+Use the existing `get_settings()` pattern. Do not add to `bugops/config.py` directly.
+
+### Test cases in `test_article_freshness.py`
+
+Use `AsyncMock` and `MagicMock` following the pattern in `test_llm_traces_cost_source.py`.
+Mock `mongo_manager.get_async_database` and the collection `.find()` / `.find_one()` calls.
+
+- [ ] Returns `False` from `check_failure()` when no articles fetched recently
+  (no `fetched_at` in lookback window)
+- [ ] Returns `False` from `check_failure()` when articles fetched recently but
+  no historical activity at this time-of-day
+- [ ] Returns `False` from `check_failure()` when articles are fresh (recent
+  `created_at` within window)
+- [ ] Returns `True` from `check_failure()` when fetch activity exists, historical
+  activity exists, and no recent `created_at`
+- [ ] `check_recovery()` returns `True` when a fresh article exists
+- [ ] `check_recovery()` returns `False` when no fresh article exists
+- [ ] Tolerance buffer applied: an article arriving 30 seconds after the strict
+  window boundary is not treated as stale
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_article_freshness.py -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All test cases listed above pass
+
+### Manual Verification
+
+- [ ] Run detector in a dev environment with a real MongoDB connection
+- [ ] Confirm `check_failure()` returns `False` when articles are being produced
+  normally
+- [ ] Confirm `check_failure()` returns `True` when `created_at` of the most
+  recent article is outside the freshness window and preconditions are met
+
+---
+
+## Acceptance Criteria
+
+- [ ] `source_type = "article_freshness"`
+- [ ] `root_subsystem = "articles"`
+- [ ] `dedupe_key = "article_freshness:articles"`
+- [ ] Uses `created_at` on `articles` (not `inserted_at` or `published_at`)
+- [ ] Returns `False` from `check_failure()` when either precondition not met
+- [ ] Returns `True` from `check_failure()` when both preconditions met and no
+  recent article
+- [ ] `check_recovery()` works correctly
+- [ ] `collect()` returns `[]` (satisfies protocol, not used by monitor)
+- [ ] 60-second tolerance buffer applied
+- [ ] All config from `core/config.py`
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Closes the article ingestion visibility gap. When ingestion stalls, operators
+will be notified automatically.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-100A, TASK-100B, TASK-101, TASK-102
+- Blocks: TASK-108, TASK-109
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-105-signal-freshness.md
+++ b/docs/sprints/sprint-020/tickets/task-105-signal-freshness.md
@@ -1,0 +1,169 @@
+---
+ticket_id: TASK-105
+title: Implement SignalFreshness detector
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-105-signal-freshness
+effort_estimate: medium
+---
+
+# TASK-105: Implement SignalFreshness detector
+
+## Problem Statement
+
+If signal score computation stalls, BugOps has no way to detect it. Signal scores
+feed narratives and briefings. A stall here degrades all downstream content without
+any visible error.
+
+---
+
+## Context
+
+### Five-part definition
+
+| Part | Implementation |
+|---|---|
+| Last successful output | Most recent `signal_scores` document `last_updated` within freshness window |
+| Expected input or activity | At least one Article with `created_at` within the freshness window |
+| Failure condition | Article(s) with `created_at` within window AND no `signal_scores` document with `last_updated` within window |
+| Legitimate idle condition | No articles with `created_at` within the freshness window |
+| Recovery condition | At least one `signal_scores` document with `last_updated` within window after a stall |
+
+### Field names
+- Authoritative timestamp: `last_updated` on `signal_scores` collection (NOT `inserted_at`, NOT `first_seen`)
+- Input check timestamp: `created_at` on `articles` collection
+
+### Class interface (same pattern as TASK-104)
+
+```python
+class SignalFreshnessSignalSource:
+    source_type = "signal_freshness"
+    root_subsystem = BugOpsSubsystem.SIGNALS.value   # "signals"
+    dedupe_key = "signal_freshness:signals"
+    suggested_manual_check = (
+        "Check signal generation worker health and confirm "
+        "recent articles are being processed into signals."
+    )
+
+    async def check_failure(self, db: AsyncIOMotorDatabase) -> bool: ...
+    async def check_recovery(self, db: AsyncIOMotorDatabase) -> bool: ...
+    async def collect(self) -> List[BugAlertEventCreate]: return []
+```
+
+Severity: `DETECTOR_SEVERITY["signal_freshness"]` from `severity.py`.
+
+Startup detection: same as TASK-104 — monitor sets `detection_type` based on
+`is_startup_poll` flag; detector is unaware.
+
+---
+
+## Task
+
+1. Create `signal_freshness.py` in `signal_sources/`
+2. Implement `SignalFreshnessSignalSource`
+3. Add required configuration to `core/config.py`
+4. Write unit tests
+
+---
+
+## Files to Create
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/signal_freshness.py
+src/tests/bugops/test_signal_freshness.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/models.py
+```
+
+---
+
+## Implementation Requirements
+
+### Expected input check (precondition)
+
+- [ ] Query `articles` collection:
+  `{"created_at": {"$gte": now - timedelta(minutes=BUGOPS_SIGNAL_FRESHNESS_WINDOW_MINUTES) - timedelta(seconds=60)}}`
+- [ ] If no document found: return `False` — legitimate idle (no article input)
+
+### Failure condition
+
+- [ ] Query `signal_scores` collection:
+  `{"last_updated": {"$gte": now - timedelta(minutes=BUGOPS_SIGNAL_FRESHNESS_WINDOW_MINUTES) - timedelta(seconds=60)}}`
+- [ ] If document found: return `False` (healthy)
+- [ ] If no document found AND precondition met: return `True`
+
+### Recovery condition
+
+- [ ] Same query as failure condition on `signal_scores`
+- [ ] Return `True` if document found
+
+### 60-second tolerance buffer applied to both queries
+
+### Configuration
+
+```python
+BUGOPS_SIGNAL_FRESHNESS_WINDOW_MINUTES: int = 90
+```
+
+### Test cases
+
+- [ ] Returns `False` from `check_failure()` when no recent articles (legitimate idle)
+- [ ] Returns `False` from `check_failure()` when recent articles and signals are fresh
+- [ ] Returns `True` from `check_failure()` when recent articles but no fresh signals
+- [ ] `check_recovery()` returns `True` when fresh signal exists
+- [ ] `check_recovery()` returns `False` when no fresh signal
+- [ ] Tolerance buffer applied correctly
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_signal_freshness.py -v
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `source_type = "signal_freshness"`, `root_subsystem = "signals"`, `dedupe_key = "signal_freshness:signals"`
+- [ ] Uses `last_updated` on `signal_scores`
+- [ ] Uses `created_at` on `articles` for input check
+- [ ] Correct idle vs broken behavior
+- [ ] `collect()` returns `[]`
+- [ ] All test cases pass
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-100A, TASK-100B, TASK-101, TASK-102
+- Blocks: TASK-108, TASK-109
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-106-narrative-freshness.md
+++ b/docs/sprints/sprint-020/tickets/task-106-narrative-freshness.md
@@ -1,0 +1,188 @@
+---
+ticket_id: TASK-106
+title: Implement NarrativeFreshness detector
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-106-narrative-freshness
+effort_estimate: medium
+---
+
+# TASK-106: Implement NarrativeFreshness detector
+
+## Problem Statement
+
+If narrative refresh stalls, briefings go stale without any visible error.
+Narratives sit between signals and briefings; a stall here degrades briefing
+quality silently.
+
+---
+
+## Context
+
+### Five-part definition
+
+| Part | Implementation |
+|---|---|
+| Last successful output | Most recent narrative `last_summary_generated_at` within freshness window |
+| Expected input or activity | At least one `signal_scores` document with `last_updated` within the freshness window |
+| Failure condition | Signal scores exist within window AND no narrative `last_summary_generated_at` within window |
+| Legitimate idle condition | No signal scores updated within the freshness window |
+| Recovery condition | At least one narrative with `last_summary_generated_at` within window after a stall |
+
+### Field names
+- Authoritative timestamp: `last_summary_generated_at` on narrative documents
+  (primary); ObjectId creation timestamp as fallback when `last_summary_generated_at`
+  is absent
+- Input check timestamp: `last_updated` on `signal_scores`
+
+### Collection access
+`narratives` collection has no formal Pydantic model. Query as `db["narratives"]`
+directly (no constant defined for this collection in mongodb.py).
+
+### ObjectId fallback
+The `narratives` collection may have documents without `last_summary_generated_at`.
+For these, extract the creation timestamp from the ObjectId:
+`from bson import ObjectId` — `ObjectId.generation_time` returns a UTC-aware
+datetime. This is a fallback only. If `last_summary_generated_at` is present,
+always prefer it.
+
+### Class interface (same pattern as TASK-104)
+
+```python
+class NarrativeFreshnessSignalSource:
+    source_type = "narrative_freshness"
+    root_subsystem = BugOpsSubsystem.NARRATIVES.value   # "narratives"
+    dedupe_key = "narrative_freshness:narratives"
+    suggested_manual_check = (
+        "Check narrative refresh job health and confirm "
+        "recent signals are available as input."
+    )
+
+    async def check_failure(self, db: AsyncIOMotorDatabase) -> bool: ...
+    async def check_recovery(self, db: AsyncIOMotorDatabase) -> bool: ...
+    async def collect(self) -> List[BugAlertEventCreate]: return []
+```
+
+Severity: `DETECTOR_SEVERITY["narrative_freshness"]` from `severity.py`.
+
+Startup detection: monitor sets `detection_type`; detector is unaware.
+
+---
+
+## Task
+
+1. Create `narrative_freshness.py` in `signal_sources/`
+2. Implement `NarrativeFreshnessSignalSource`
+3. Add required configuration to `core/config.py`
+4. Write unit tests
+
+---
+
+## Files to Create
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/narrative_freshness.py
+src/tests/bugops/test_narrative_freshness.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/models.py
+```
+
+---
+
+## Implementation Requirements
+
+### Expected input check (precondition)
+
+- [ ] Query `signal_scores`:
+  `{"last_updated": {"$gte": now - timedelta(minutes=BUGOPS_NARRATIVE_FRESHNESS_WINDOW_MINUTES) - timedelta(seconds=60)}}`
+- [ ] If no document: return `False` — legitimate idle
+
+### Failure condition
+
+- [ ] Primary query on `narratives`:
+  `{"last_summary_generated_at": {"$gte": cutoff}}`
+- [ ] If document found: return `False` (healthy)
+- [ ] If no document found: fallback query — fetch all `narratives` documents
+  (or a reasonable limit), extract `ObjectId.generation_time` from `_id`, check
+  if any falls within the window
+- [ ] If neither query finds a document AND precondition met: return `True`
+
+### Recovery condition
+
+- [ ] Same two-step query (primary + ObjectId fallback)
+- [ ] Return `True` if either query finds a fresh document
+
+### 60-second tolerance buffer applied to all window comparisons
+
+### Configuration
+
+```python
+BUGOPS_NARRATIVE_FRESHNESS_WINDOW_MINUTES: int = 120
+```
+
+### Test cases
+
+- [ ] Returns `False` when no recent signal scores (legitimate idle)
+- [ ] Returns `False` when signal scores fresh and narratives have recent
+  `last_summary_generated_at`
+- [ ] Returns `True` when signal scores fresh and no narrative has
+  `last_summary_generated_at` within window (and no recent ObjectId either)
+- [ ] Falls back to ObjectId timestamp when `last_summary_generated_at` absent;
+  returns `False` if ObjectId is recent
+- [ ] `check_recovery()` returns `True` when fresh narrative exists
+- [ ] `check_recovery()` returns `False` when no fresh narrative
+- [ ] Tolerance buffer applied correctly
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_narrative_freshness.py -v
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `source_type = "narrative_freshness"`, `root_subsystem = "narratives"`, `dedupe_key = "narrative_freshness:narratives"`
+- [ ] Uses `last_summary_generated_at` as primary; ObjectId timestamp as fallback
+- [ ] Uses `last_updated` on `signal_scores` for input check
+- [ ] Correct idle vs broken behavior
+- [ ] `collect()` returns `[]`
+- [ ] All test cases pass
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-100A, TASK-100B, TASK-101, TASK-102
+- Blocks: TASK-108, TASK-109
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-107-briefing-freshness.md
+++ b/docs/sprints/sprint-020/tickets/task-107-briefing-freshness.md
@@ -1,0 +1,200 @@
+---
+ticket_id: TASK-107
+title: Implement BriefingFreshness detector
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-107-briefing-freshness
+effort_estimate: medium
+---
+
+# TASK-107: Implement BriefingFreshness detector
+
+## Problem Statement
+
+If briefing generation fails, operators and readers receive no briefing without
+any alert. Briefings are the primary user-facing output of Backdrop. A missed
+briefing is a user-visible failure.
+
+---
+
+## Context
+
+### Five-part definition
+
+| Part | Implementation |
+|---|---|
+| Last successful output | Most recent `daily_briefings` document `generated_at` within the current window's expected range |
+| Expected input or activity | Grace period has elapsed for most recently scheduled window AND fresh narratives exist |
+| Failure condition | Grace period elapsed AND no briefing `generated_at` in window range AND fresh narratives exist |
+| Legitimate idle condition | Still within grace period, OR no sufficiently fresh narratives |
+| Recovery condition | New briefing `generated_at` within expected window after a stall |
+
+### Field names
+- Authoritative timestamp: `generated_at` on `daily_briefings` (NOT `inserted_at`)
+- Input check: `last_summary_generated_at` on `narratives`
+
+### Schedule design
+Briefings run twice daily on a known schedule (not a rolling freshness window).
+The detector evaluates which scheduled window most recently elapsed and whether
+a briefing exists for that window.
+
+Two configurable schedule windows in EST:
+- Morning: `BUGOPS_BRIEFING_MORNING_HOUR_EST` (default `8`) — 8:00 AM
+- Evening: `BUGOPS_BRIEFING_EVENING_HOUR_EST` (default `20`) — 8:00 PM
+
+Grace period: `BUGOPS_BRIEFING_GRACE_PERIOD_MINUTES` (default `30`). The Celery
+task has a 10-minute hard timeout and retries up to 3 times with 5-minute delays —
+worst case ~25 minutes. Do not fire within this grace window.
+
+### EST timezone
+Use `from zoneinfo import ZoneInfo` with `ZoneInfo("America/New_York")`.
+This is the codebase standard (`zoneinfo` is used in `admin.py`, `briefing_agent.py`).
+Do not use `pytz`. Do not hardcode UTC offsets.
+
+### Class interface
+
+```python
+class BriefingFreshnessSignalSource:
+    source_type = "briefing_freshness"
+    root_subsystem = BugOpsSubsystem.BRIEFINGS.value   # "briefings"
+    dedupe_key = "briefing_freshness:briefings"
+    suggested_manual_check = (
+        "Check briefing generation schedule, recent narrative "
+        "freshness, and whether a briefing insert was attempted."
+    )
+
+    async def check_failure(self, db: AsyncIOMotorDatabase) -> bool: ...
+    async def check_recovery(self, db: AsyncIOMotorDatabase) -> bool: ...
+    async def collect(self) -> List[BugAlertEventCreate]: return []
+```
+
+Severity: `DETECTOR_SEVERITY["briefing_freshness"]` from `severity.py`.
+
+Startup detection: monitor sets `detection_type`; detector is unaware.
+
+---
+
+## Task
+
+1. Create `briefing_freshness.py` in `signal_sources/`
+2. Implement `BriefingFreshnessSignalSource`
+3. Add required configuration to `core/config.py`
+4. Write unit tests covering schedule window logic, grace period, idle vs broken
+
+---
+
+## Files to Create
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/briefing_freshness.py
+src/tests/bugops/test_briefing_freshness.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/models.py
+```
+
+---
+
+## Implementation Requirements
+
+### Scheduled window resolution
+
+- [ ] Convert current UTC time to EST using `ZoneInfo("America/New_York")`
+- [ ] Identify the most recently elapsed scheduled hour (morning or evening)
+- [ ] Compute `minutes_since_scheduled = (now_est - scheduled_time).total_seconds() / 60`
+- [ ] If `minutes_since_scheduled < BUGOPS_BRIEFING_GRACE_PERIOD_MINUTES`: return
+  `False` — still in grace period
+
+### Expected input check (precondition)
+
+- [ ] Query `narratives` for any document with `last_summary_generated_at >= now - timedelta(minutes=BUGOPS_BRIEFING_NARRATIVE_LOOKBACK_MINUTES) - timedelta(seconds=60)`
+- [ ] If none: return `False` — no input for briefing generation
+
+### Failure condition
+
+- [ ] Query `daily_briefings` for any document with `generated_at` between
+  `scheduled_time` and `scheduled_time + timedelta(minutes=BUGOPS_BRIEFING_GRACE_PERIOD_MINUTES) + timedelta(seconds=60)` (tolerance)
+- [ ] If document found: return `False` (healthy)
+- [ ] If grace period elapsed AND no briefing AND fresh narratives: return `True`
+
+### Recovery condition
+
+- [ ] Same query — `daily_briefings` document in current expected window range
+- [ ] Return `True` if found
+
+### Configuration
+
+```python
+BUGOPS_BRIEFING_MORNING_HOUR_EST: int = 8
+BUGOPS_BRIEFING_EVENING_HOUR_EST: int = 20
+BUGOPS_BRIEFING_GRACE_PERIOD_MINUTES: int = 30
+BUGOPS_BRIEFING_NARRATIVE_LOOKBACK_MINUTES: int = 240
+```
+
+### Test cases
+
+- [ ] Returns `False` when still within grace period of most recently elapsed window
+- [ ] Returns `False` when grace period elapsed and a briefing exists in the window
+- [ ] Returns `True` when grace period elapsed, no briefing, and fresh narratives exist
+- [ ] Returns `False` when grace period elapsed, no briefing, but no fresh narratives
+- [ ] Correctly identifies morning window as most recently elapsed between 8AM and 8PM EST
+- [ ] Correctly identifies evening window as most recently elapsed after 8PM EST
+- [ ] EST/EDT transition does not break logic (use `ZoneInfo`, not hardcoded offset)
+- [ ] `check_recovery()` returns `True` when briefing exists in current window
+- [ ] `check_recovery()` returns `False` when no briefing in current window
+- [ ] Tolerance buffer applied correctly
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_briefing_freshness.py -v
+```
+
+---
+
+## Acceptance Criteria
+
+- [ ] `source_type = "briefing_freshness"`, `root_subsystem = "briefings"`, `dedupe_key = "briefing_freshness:briefings"`
+- [ ] Uses `generated_at` on `daily_briefings`
+- [ ] Evaluates against two daily schedule windows, not a rolling freshness window
+- [ ] Does not fire within grace period
+- [ ] Does not fire when no fresh narratives
+- [ ] Uses `ZoneInfo("America/New_York")` — not `pytz`, not UTC offsets
+- [ ] `collect()` returns `[]`
+- [ ] All test cases pass
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-100A, TASK-100B, TASK-101, TASK-102
+- Blocks: TASK-108, TASK-109
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-108-cascade-suppression.md
+++ b/docs/sprints/sprint-020/tickets/task-108-cascade-suppression.md
@@ -1,0 +1,343 @@
+---
+ticket_id: TASK-108
+title: Wire freshness detectors into monitor with cascade suppression
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-108-cascade-suppression
+effort_estimate: medium
+---
+
+# TASK-108: Wire freshness detectors into monitor with cascade suppression
+
+## Problem Statement
+
+The four freshness detectors exist as isolated classes after TASK-104 through
+TASK-107. This ticket wires them into the polling loop and implements the
+deterministic cascade suppression logic that prevents a scheduler failure from
+generating four separate BugCases and four Slack notifications.
+
+---
+
+## Context
+
+### Current monitor structure
+
+`monitor.py` has:
+- `BugOpsMonitor.__init__()` — instantiates settings, store (None until run),
+  and `signal_sources` list (currently `LLMTraceCostSignalSource` and
+  `RailwayLogSignalSource`)
+- `BugOpsMonitor.run()` — initializes MongoDB, sets `self.store`, loops calling
+  `_poll_signals()`
+- `BugOpsMonitor._poll_signals()` — iterates `self.signal_sources`, calls
+  `source.collect()`, calls `store.process_alert_event()` for each event, sends
+  Slack for new cases
+- `BugOpsMonitor.stop()` — sets `self.running = False`
+
+The existing `_poll_signals()` flow for `LLMTraceCostSignalSource` must not change.
+Freshness detectors use a separate polling path — do not mix them into the existing
+`collect()` / `process_alert_event()` flow.
+
+### Cascade suppression processing order (must not vary)
+
+```
+1. Detector's check_failure(db) returns True
+2. Check open upstream BugCase: DependencyGraph.get_upstream_nodes(root_subsystem)
+   → For each upstream node (nearest first):
+     call store.find_open_case_by_root_subsystem(upstream_node)
+     If found: call store.attach_observation_to_case(
+         case_id, last_seen_at=now, affected_subsystems=[signal.root_subsystem]
+     )
+     Log suppression. Stop. No new BugCase. No notification.
+3. Check open BugCase with same dedupe_key:
+   call store.find_open_case_by_dedupe_key(dedupe_key)
+   If found: call store.attach_observation_to_case(case_id, last_seen_at=now)
+   Log attachment. Stop. No new BugCase. No notification.
+4. Create new BugCase via store.create_case_direct(BugCaseCreate(...))
+   Send notification per TASK-111 routing rules.
+```
+
+Upstream-wins is unconditional regardless of downstream severity or observation count.
+
+### `detection_type` assignment
+
+The monitor tracks whether the current poll is the first poll since startup
+(`is_first_poll: bool`). When creating a new BugCase in Step 4:
+- If `is_first_poll`: `detection_type = "startup"`
+- Else: `detection_type = "runtime"`
+
+Set `is_first_poll = False` after the first complete poll cycle finishes.
+
+### New store method needed: `find_open_case_by_root_subsystem()`
+
+Add this to `store.py` as part of this ticket:
+
+```python
+async def find_open_case_by_root_subsystem(self, root_subsystem: str) -> Optional[BugCase]:
+    """Find an open BugCase by root_subsystem."""
+    doc = await self.cases_collection.find_one({
+        "root_subsystem": root_subsystem,
+        "status": "open"
+    })
+    if doc:
+        doc = _normalize_mongo_doc(doc)
+        return BugCase(**doc)
+    return None
+```
+
+---
+
+## Task
+
+1. Instantiate `DependencyGraph` once at monitor startup
+2. Instantiate all four freshness detectors once at startup
+3. Add `_poll_freshness_detectors()` method to `BugOpsMonitor` — separate from
+   existing `_poll_signals()`
+4. Implement cascade suppression processing order inside `_poll_freshness_detectors()`
+5. Add `find_open_case_by_root_subsystem()` to `store.py`
+6. Call `_poll_freshness_detectors()` from the main loop after `_poll_signals()`
+7. Write integration tests for cascade suppression processing order
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_cascade_suppression.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/signal_sources/__init__.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### Monitor `__init__()` changes
+
+- [ ] Import and instantiate `DependencyGraph` once:
+  `self.dependency_graph = DependencyGraph()`
+- [ ] Import and instantiate all four freshness detectors:
+  ```python
+  from .signal_sources.article_freshness import ArticleFreshnessSignalSource
+  from .signal_sources.signal_freshness import SignalFreshnessSignalSource
+  from .signal_sources.narrative_freshness import NarrativeFreshnessSignalSource
+  from .signal_sources.briefing_freshness import BriefingFreshnessSignalSource
+
+  self.freshness_detectors = [
+      ArticleFreshnessSignalSource(),
+      SignalFreshnessSignalSource(),
+      NarrativeFreshnessSignalSource(),
+      BriefingFreshnessSignalSource(),
+  ]
+  ```
+- [ ] Add `self.is_first_poll: bool = True`
+- [ ] Build detector lookup map for auto-resolution (TASK-109 uses this):
+  `self.detector_by_subsystem = {d.root_subsystem: d for d in self.freshness_detectors}`
+
+### New `_poll_freshness_detectors()` method
+
+For each detector in `self.freshness_detectors`:
+
+```python
+async def _poll_freshness_detectors(self) -> None:
+    db = await mongo_manager.get_async_database()
+    now = datetime.utcnow()
+
+    for detector in self.freshness_detectors:
+        start = time.monotonic()
+        try:
+            failure = await detector.check_failure(db)
+            if not failure:
+                continue
+
+            # Step 2: upstream check
+            upstream_nodes = self.dependency_graph.get_upstream_nodes(detector.root_subsystem)
+            upstream_case = None
+            for node in upstream_nodes:
+                upstream_case = await self.store.find_open_case_by_root_subsystem(node)
+                if upstream_case:
+                    break
+
+            if upstream_case:
+                await self.store.attach_observation_to_case(
+                    upstream_case.case_id,
+                    last_seen_at=now,
+                    affected_subsystems=[detector.root_subsystem],
+                )
+                logger.info(
+                    "Cascade suppression: attached to upstream case",
+                    extra={
+                        "detector": detector.source_type,
+                        "upstream_case_id": upstream_case.case_id,
+                        "upstream_subsystem": upstream_case.root_subsystem,
+                    }
+                )
+                continue
+
+            # Step 3: dedupe check
+            existing = await self.store.find_open_case_by_dedupe_key(detector.dedupe_key)
+            if existing:
+                await self.store.attach_observation_to_case(
+                    existing.case_id, last_seen_at=now
+                )
+                continue
+
+            # Step 4: create new BugCase
+            detection_type = "startup" if self.is_first_poll else "runtime"
+            blast_radius = self.dependency_graph.get_downstream_nodes(detector.root_subsystem)
+            case_create = BugCaseCreate(
+                case_id=f"bc_{detector.root_subsystem}_{int(now.timestamp())}",
+                severity=DETECTOR_SEVERITY[detector.source_type],
+                alert_type=detector.source_type,
+                title=f"{detector.root_subsystem.capitalize()} Freshness Failure",
+                summary=f"No {detector.root_subsystem} output within expected window.",
+                dedupe_key=detector.dedupe_key,
+                source_types=[detector.source_type],
+                root_subsystem=detector.root_subsystem,
+                blast_radius=blast_radius,
+                affected_subsystems=[],
+                first_seen_at=now,
+                last_seen_at=now,
+                observation_count=1,
+                detection_type=detection_type,
+                suggested_manual_check=detector.suggested_manual_check,
+            )
+            new_case = await self.store.create_case_direct(case_create)
+            # Notification is TASK-111's responsibility.
+            # Until TASK-111 is merged, send Slack for High severity:
+            if self.settings.BUGOPS_SLACK_ENABLED:
+                from .slack import send_case_notification
+                await send_case_notification(new_case)
+
+        except Exception as e:
+            logger.error(
+                "Detector run failed",
+                extra={
+                    "detector_name": detector.__class__.__name__,
+                    "error_type": type(e).__name__,
+                    "error_message": str(e),
+                    "duration_ms": int((time.monotonic() - start) * 1000),
+                }
+            )
+
+    # After first complete poll, set is_first_poll = False
+    self.is_first_poll = False
+```
+
+### Main loop change
+
+In `run()`, after `await self._poll_signals()`:
+```python
+await self._poll_freshness_detectors()
+```
+
+### `find_open_case_by_root_subsystem()` in `store.py`
+
+- [ ] Queries `{"root_subsystem": root_subsystem, "status": "open"}`
+- [ ] Returns first match as `BugCase` or `None`
+- [ ] Uses `_normalize_mongo_doc()` before constructing `BugCase`
+
+### Required imports in `monitor.py`
+
+```python
+import time
+from datetime import datetime
+from .dependency_graph import DependencyGraph
+from .models import BugCaseCreate
+from .signal_sources.severity import DETECTOR_SEVERITY
+```
+
+### Test cases in `test_cascade_suppression.py`
+
+Use `AsyncMock` / `MagicMock` pattern from existing test files.
+Mock `self.store`, `self.dependency_graph`, and the detector `check_failure()`.
+
+- [ ] Upstream BugCase exists → `attach_observation_to_case()` called with
+  upstream case ID, no `create_case_direct()` called
+- [ ] No upstream BugCase, same `dedupe_key` open → `attach_observation_to_case()`
+  called with existing case ID, no `create_case_direct()`
+- [ ] No upstream BugCase, no open dedupe key → `create_case_direct()` called
+  with correct fields
+- [ ] `detection_type="startup"` when `is_first_poll=True`
+- [ ] `detection_type="runtime"` when `is_first_poll=False`
+- [ ] `is_first_poll` set to `False` after first complete poll
+- [ ] `blast_radius` populated from `DependencyGraph.get_downstream_nodes()`
+- [ ] `affected_subsystems` populated on upstream case attachment
+- [ ] Detector throws exception → error logged with structured fields, loop
+  continues, other detectors run
+- [ ] Processing order respected: upstream check always before dedupe check
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_cascade_suppression.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All cascade suppression test cases pass
+- [ ] Existing `_poll_signals()` tests pass without modification
+- [ ] Cost-runaway detector behavior unchanged
+
+### Manual Verification
+
+- [ ] Inject a failure for `articles` while an open BugCase exists for
+  `ingestion` — confirm no new BugCase created and `affected_subsystems` updated
+- [ ] Inject a detector exception — confirm the loop continues and other detectors run
+- [ ] Confirm `is_first_poll=True` on first call, `False` on second
+
+---
+
+## Acceptance Criteria
+
+- [ ] All four freshness detectors run in `_poll_freshness_detectors()` each cycle
+- [ ] Cascade suppression order is deterministic: upstream → dedupe → create
+- [ ] `detection_type` is `"startup"` on first poll, `"runtime"` thereafter
+- [ ] `blast_radius` populated at BugCase creation
+- [ ] `find_open_case_by_root_subsystem()` added to `store.py`
+- [ ] Detector failures isolated — do not halt loop
+- [ ] Existing `_poll_signals()` / cost-runaway behavior unchanged
+- [ ] All test cases pass
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-100A, TASK-100B, TASK-101, TASK-102, TASK-103,
+  TASK-104, TASK-105, TASK-106, TASK-107
+- Blocks: TASK-108A, TASK-109
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-108a-startup-detection.md
+++ b/docs/sprints/sprint-020/tickets/task-108a-startup-detection.md
@@ -1,0 +1,177 @@
+---
+ticket_id: TASK-108A
+title: Implement startup detection semantics
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-108a-startup-detection
+effort_estimate: medium
+---
+
+# TASK-108A: Implement startup detection semantics
+
+## Problem Statement
+
+TASK-108 wires detectors into the polling loop with `is_first_poll` tracking,
+but the startup detection behavior requires additional specification and testing.
+If BugOps restarts while production is already broken, the operator needs to know
+immediately — not after the first "healthy" cycle that never comes. This ticket
+formalizes and tests the startup detection path end-to-end.
+
+---
+
+## Context
+
+TASK-108 adds `self.is_first_poll = True` to `BugOpsMonitor.__init__()` and sets
+`detection_type = "startup"` on BugCases created during the first poll. After the
+first complete poll cycle `is_first_poll` is set to `False`.
+
+This ticket adds:
+1. Explicit tests for startup vs runtime detection_type assignment
+2. Confirmation that cascade suppression applies normally to startup-detected failures
+   (a startup articles failure still suppresses into a startup ingestion BugCase if
+   one exists — not a special code path, just a test coverage gap to close)
+3. Confirmation that no healthy baseline is required before a startup BugCase is
+   created — the first poll fires immediately
+
+Key behavioral constraints from the sprint doc:
+- BugOps does not require observing a healthy-to-unhealthy transition before
+  creating a BugCase
+- Startup-created BugCases send Slack notifications (same as runtime BugCases)
+- Downstream startup failures cascade-suppress into upstream startup BugCases
+- Subsequent polls use `detection_type="runtime"` regardless of whether the
+  startup failure is still ongoing
+
+---
+
+## Task
+
+1. Verify `is_first_poll` logic in `monitor.py` is correct after TASK-108
+2. Add startup detection test file
+3. No new production code needed if TASK-108 implemented correctly — this is
+   primarily a test and verification ticket
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_startup_detection.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+  (only if gaps found during test writing — document any changes in completion summary)
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### Verify in `monitor.py` (from TASK-108)
+
+- [ ] `self.is_first_poll = True` set in `__init__()`
+- [ ] `detection_type = "startup" if self.is_first_poll else "runtime"` in
+  `_poll_freshness_detectors()` before `create_case_direct()` call
+- [ ] `self.is_first_poll = False` set after the loop over all detectors completes
+  (not inside the loop, not per-detector)
+- [ ] If `is_first_poll` is set `False` inside the loop, fix it — it must remain
+  `True` for the entire first poll so all detectors in that poll create startup cases
+
+### Test cases in `test_startup_detection.py`
+
+Mock pattern: instantiate `BugOpsMonitor`, mock `self.store`, mock all detector
+`check_failure()` to return `True`, mock `dependency_graph` to return empty lists
+(no cascade), mock `create_case_direct()` to return a fake `BugCase`.
+
+- [ ] First poll: all detectors create BugCases with `detection_type="startup"`
+- [ ] Second poll: all detectors create BugCases with `detection_type="runtime"`
+- [ ] `is_first_poll` is `True` at monitor init and `False` after first poll completes
+- [ ] Startup BugCase creation still triggers Slack notification (same as runtime)
+- [ ] Startup failure cascade-suppresses into upstream startup BugCase: if articles
+  failure fires on first poll and an ingestion BugCase was also created on first
+  poll (same cycle), articles attaches to ingestion rather than creating a second
+  BugCase
+- [ ] Ongoing failure (failure present on poll 1 and poll 2): poll 1 creates
+  startup BugCase, poll 2 attaches as observation (dedupe check), does not create
+  a second runtime BugCase
+- [ ] No "healthy baseline required" — first poll creates BugCase immediately if
+  failure condition is met, without any prior observation
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_startup_detection.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All test cases pass
+- [ ] TASK-108 cascade suppression tests still pass
+
+### Manual Verification
+
+- [ ] In dev, stop article ingestion, restart BugOps monitor — confirm a
+  `detection_type="startup"` BugCase appears in MongoDB on the first poll
+- [ ] Let the monitor run through a second poll with ingestion still stopped —
+  confirm no second BugCase created (observation attached to existing startup case)
+- [ ] Restart ingestion — confirm auto-resolution eventually resolves the startup case
+
+---
+
+## Acceptance Criteria
+
+- [ ] `is_first_poll` is `True` for the entire first poll (all detectors in poll 1
+  see `is_first_poll=True`)
+- [ ] `is_first_poll` is `False` for all subsequent polls
+- [ ] Startup BugCases have `detection_type="startup"`
+- [ ] Runtime BugCases have `detection_type="runtime"`
+- [ ] No healthy baseline required before startup BugCase creation
+- [ ] Cascade suppression applies normally to startup failures
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Ensures operators are notified of active production failures immediately on
+BugOps restart, not only when new failures begin.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-108
+- Blocks: TASK-109 (auto-resolution must handle startup-type BugCases)
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-109-auto-resolution.md
+++ b/docs/sprints/sprint-020/tickets/task-109-auto-resolution.md
@@ -1,0 +1,280 @@
+---
+ticket_id: TASK-109
+title: Implement auto-resolution with Recovery Window
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-109-auto-resolution
+effort_estimate: medium
+---
+
+# TASK-109: Implement auto-resolution with Recovery Window
+
+## Problem Statement
+
+BugCases currently require manual close. If a production failure self-heals
+overnight, the operator wakes up to an open BugCase that no longer reflects
+reality. Auto-resolution closes cases when the system recovers, without operator
+intervention.
+
+---
+
+## Context
+
+Auto-resolution is based on outcome recovery, not component health. A BugCase
+does not resolve because a worker is healthy — it resolves because the artifact
+that was missing is being produced again.
+
+Each freshness detector exposes `check_recovery(db) -> bool` (TASK-104 to TASK-107).
+The auto-resolution loop calls this each polling cycle for every open freshness BugCase.
+
+### Recovery model
+
+```
+1. Recovery condition met, recovery_candidate_at is None
+   → set recovery_candidate_at = now
+
+2. Recovery condition met, recovery_candidate_at is set
+   → elapsed = now - recovery_candidate_at
+   → if elapsed >= Recovery Window: resolve the BugCase
+   → else: no action (waiting for window to elapse)
+
+3. Recovery condition NOT met, recovery_candidate_at is set
+   → clear recovery_candidate_at = None
+   → BugCase remains open, no new BugCase, no notification
+
+4. Recovery condition NOT met, recovery_candidate_at is None
+   → no action
+```
+
+### Key invariants from sprint spec
+
+- **Auto-resolution does NOT send a Slack notification.** Resolution is silent.
+- **Manually closed cases (`status = "closed"`) are never auto-resolved.** Skip them.
+- **Muted/snoozed cases resolve normally.** `muted_until` and `snoozed_until`
+  affect notifications only — do not block resolution.
+- **BugCases resolve as a unit.** No partial resolution.
+- **Failure recurrence before window elapses:** clear `recovery_candidate_at`,
+  BugCase stays open, no new BugCase created, no Slack sent.
+
+### Detector lookup
+
+TASK-108 adds `self.detector_by_subsystem` to the monitor:
+`{d.root_subsystem: d for d in self.freshness_detectors}`.
+Use this map to find the right detector for each open BugCase.
+
+### Dedupe key pattern for freshness BugCases
+
+Freshness BugCase dedupe keys follow the format `detector_type:subsystem`
+(e.g. `"article_freshness:articles"`). The auto-resolution loop identifies
+freshness BugCases by checking if `dedupe_key` contains `":"`.
+
+---
+
+## Task
+
+1. Add `_run_auto_resolution()` method to `BugOpsMonitor` in `monitor.py`
+2. Call it from the main loop after `_poll_freshness_detectors()`
+3. Add `resolve_case()`, `update_recovery_candidate()`, and
+   `get_open_freshness_cases()` to `BugOpsStore`
+4. Write unit tests for recovery lifecycle
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_auto_resolution.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### `_run_auto_resolution()` in `monitor.py`
+
+```python
+async def _run_auto_resolution(self) -> None:
+    db = await mongo_manager.get_async_database()
+    now = datetime.utcnow()
+    recovery_window = timedelta(minutes=self.settings.BUGOPS_RECOVERY_WINDOW_MINUTES)
+
+    open_cases = await self.store.get_open_freshness_cases()
+
+    for case in open_cases:
+        # Skip manually closed cases (terminal state)
+        if case.status == CaseStatus.CLOSED:
+            continue
+
+        # Find the right detector
+        detector = self.detector_by_subsystem.get(case.root_subsystem)
+        if detector is None:
+            logger.warning(f"No detector found for root_subsystem={case.root_subsystem}")
+            continue
+
+        try:
+            recovered = await detector.check_recovery(db)
+        except Exception as e:
+            logger.error(f"Recovery check failed for case {case.case_id}: {e}")
+            continue
+
+        if recovered:
+            if case.recovery_candidate_at is None:
+                # First healthy observation
+                await self.store.update_recovery_candidate(case.case_id, now)
+            else:
+                elapsed = now - case.recovery_candidate_at
+                if elapsed >= recovery_window:
+                    # Window elapsed — resolve
+                    await self.store.resolve_case(case.case_id)
+                    logger.info(f"BugCase auto-resolved: case_id={case.case_id}")
+                    # No Slack notification on resolution
+        else:
+            if case.recovery_candidate_at is not None:
+                # Failure recurred before window elapsed
+                await self.store.update_recovery_candidate(case.case_id, None)
+                logger.info(
+                    f"Recovery candidate cleared (failure recurred): case_id={case.case_id}"
+                )
+```
+
+### Main loop change in `run()`
+
+```python
+while self.running:
+    await self._poll_signals()
+    await self._poll_freshness_detectors()
+    await self._run_auto_resolution()
+    await asyncio.sleep(self.settings.BUGOPS_POLL_INTERVAL_SECONDS)
+```
+
+### New store methods
+
+**`resolve_case(case_id: str) -> BugCase`**
+- [ ] `$set`: `{"status": "resolved", "resolved_at": datetime.utcnow(), "recovery_candidate_at": None, "updated_at": datetime.utcnow()}`
+- [ ] Uses `find_one_and_update` with `return_document=True`
+- [ ] Queries by `{"case_id": case_id}`
+- [ ] Normalizes with `_normalize_mongo_doc()`
+- [ ] Returns updated `BugCase`
+- [ ] Raises `ValueError(f"Case {case_id} not found")` if not found
+
+**`update_recovery_candidate(case_id: str, recovery_candidate_at: Optional[datetime]) -> BugCase`**
+- [ ] `$set`: `{"recovery_candidate_at": recovery_candidate_at, "updated_at": datetime.utcnow()}`
+- [ ] `recovery_candidate_at` can be `None` (clears the field)
+- [ ] Uses `find_one_and_update` with `return_document=True`
+- [ ] Queries by `{"case_id": case_id}`
+- [ ] Normalizes, returns `BugCase`
+
+**`get_open_freshness_cases() -> list[BugCase]`**
+- [ ] Queries: `{"status": "open", "dedupe_key": {"$regex": ":"}}`
+- [ ] Returns list of `BugCase` objects (empty list if none)
+- [ ] Uses `.find().to_list(None)` pattern
+
+### Configuration
+
+```python
+BUGOPS_RECOVERY_WINDOW_MINUTES: int = 10
+```
+
+Add to `core/config.py`.
+
+### Test cases in `test_auto_resolution.py`
+
+Use mock `store` and mock detector `check_recovery()`.
+
+- [ ] Recovery condition met for first time → `update_recovery_candidate()` called
+  with `now`, case stays open
+- [ ] Recovery condition met, `recovery_candidate_at` set, window NOT elapsed →
+  case stays open, no resolve call
+- [ ] Recovery condition met, `recovery_candidate_at` set, window elapsed →
+  `resolve_case()` called
+- [ ] Recovery condition met then fails before window elapses →
+  `update_recovery_candidate(case_id, None)` called, case stays open
+- [ ] No Slack notification sent on auto-resolution (mock Slack and assert not called)
+- [ ] Manually closed case (`status = "closed"`) skipped — `check_recovery()` not called
+- [ ] Muted case (`muted_until` in future) resolves normally when window elapses
+- [ ] Snoozed case (`snoozed_until` in future) resolves normally when window elapses
+- [ ] Detector not found for `root_subsystem` → warning logged, case skipped
+- [ ] `check_recovery()` raises exception → error logged, loop continues with
+  next case
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_auto_resolution.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All recovery lifecycle test cases pass
+- [ ] Existing bugops tests pass
+
+### Manual Verification
+
+- [ ] Observe a BugCase enter `recovery_candidate_at` state and hold through
+  the window before `status` transitions to `resolved`
+- [ ] Observe `recovery_candidate_at` clear when failure recurs before window
+- [ ] Confirm no Slack message fires on auto-resolution
+
+---
+
+## Acceptance Criteria
+
+- [ ] Auto-resolution loop runs after each poll cycle
+- [ ] `recovery_candidate_at` set on first healthy observation
+- [ ] BugCase resolves after Recovery Window elapses without re-violation
+- [ ] `recovery_candidate_at` clears when failure recurs before window
+- [ ] No Slack notification on auto-resolution
+- [ ] Manually closed cases never evaluated
+- [ ] Muted/snoozed cases resolve normally
+- [ ] All store methods use correct atomic MongoDB operations
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Operators no longer need to manually close self-healing failures.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-104, TASK-105, TASK-106, TASK-107, TASK-108, TASK-108A
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-110-flapping-protection.md
+++ b/docs/sprints/sprint-020/tickets/task-110-flapping-protection.md
@@ -1,0 +1,166 @@
+---
+ticket_id: TASK-110
+title: Implement flapping protection
+priority: medium
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-110-flapping-protection
+effort_estimate: small
+---
+
+# TASK-110: Implement flapping protection
+
+## Problem Statement
+
+A BugCase that oscillates rapidly between healthy and failed states will produce a stream of `recovery_candidate_at` set/clear cycles. Without flapping protection this generates noise and prevents auto-resolution from ever stabilizing. Flapping protection detects this pattern, suspends auto-resolution, and escalates to the operator.
+
+---
+
+## Context
+
+TASK-109 already increments `flap_count` and clears `recovery_candidate_at` when a failure recurs before the Recovery Window elapses. This ticket adds the threshold check on top of that: when `flap_count` exceeds the configurable threshold within the flap window, the BugCase is marked as flapping, auto-resolution is suspended, and a single Slack notification is sent.
+
+The `flap_count` and `flapping` fields are already on the BugCase model (added in TASK-100).
+
+Only an operator action can clear the `flapping` flag. Auto-resolution does not run while `flapping = True`.
+
+---
+
+## Task
+
+1. Add flapping threshold check to the auto-resolution loop in `monitor.py`
+2. Add `mark_case_flapping()` store method
+3. Send a single Slack notification when flapping is detected
+4. Block auto-resolution for BugCases with `flapping = True`
+5. Write unit tests for flapping detection and escalation
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_flapping.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### Flapping threshold check (in auto-resolution loop, after `increment_flap_count()`)
+
+- [ ] After incrementing `flap_count`, retrieve the updated BugCase
+- [ ] If `flap_count >= BUGOPS_FLAP_COUNT_THRESHOLD` AND `flapping` is currently `False`: call `store.mark_case_flapping(case_id)` and send flapping notification
+- [ ] If `flapping` is already `True`: skip the threshold check (already escalated)
+
+### Flap window enforcement
+
+- [ ] `flap_count` tracks total oscillations — for Sprint 020, no time-window decay is implemented. The threshold is evaluated against the cumulative count.
+- [ ] Time-window decay (resetting `flap_count` after `BUGOPS_FLAP_WINDOW_MINUTES` of stability) is deferred. Record this as a known limitation in the completion summary.
+
+### Auto-resolution block
+
+- [ ] In the auto-resolution loop, skip any BugCase where `flapping = True`
+- [ ] Log a structured message when a flapping case is skipped: `"Skipping auto-resolution: case is flapping"`
+
+### New store method: `mark_case_flapping(case_id: str) -> BugCase`
+
+- [ ] Sets `flapping = True`
+- [ ] Sets `updated_at = datetime.utcnow()`
+- [ ] Does not change `status`
+- [ ] Returns updated BugCase
+
+### Flapping notification
+
+- [ ] Send a Slack notification with message indicating the BugCase requires manual review due to flapping
+- [ ] Include: `case_id`, `root_subsystem`, `flap_count`, current `severity`
+- [ ] Send only once (the `mark_case_flapping()` call is the gate — it only fires when transitioning from `False` to `True`)
+
+### Configuration
+
+```text
+BUGOPS_FLAP_COUNT_THRESHOLD=3
+BUGOPS_FLAP_WINDOW_MINUTES=30
+```
+
+Add to `src/crypto_news_aggregator/core/config.py`. Note: `BUGOPS_FLAP_WINDOW_MINUTES` is defined for future use — it is not enforced in Sprint 020.
+
+### Test cases required
+
+- [ ] `flap_count` reaches threshold → `flapping` set to `True`, notification sent
+- [ ] `flapping = True` → auto-resolution loop skips the case
+- [ ] Flapping notification is sent exactly once (not re-sent on subsequent cycles)
+- [ ] `flap_count` below threshold → no flapping, auto-resolution continues normally
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_flapping.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All test cases pass
+- [ ] Existing auto-resolution tests from TASK-109 still pass
+
+### Manual Verification
+
+- [ ] Force `flap_count` to threshold via repeated oscillation in dev — confirm `flapping` is set and Slack notification fires once
+- [ ] Confirm auto-resolution loop skips the flapping case on subsequent cycles
+
+---
+
+## Acceptance Criteria
+
+- [ ] Flapping is detected when `flap_count >= BUGOPS_FLAP_COUNT_THRESHOLD`
+- [ ] `flapping = True` blocks auto-resolution
+- [ ] Flapping Slack notification sent exactly once per flapping transition
+- [ ] `mark_case_flapping()` is idempotent (calling it on an already-flapping case is safe)
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Prevents auto-resolution noise loops and escalates unstable BugCases to operator attention.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-109
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-111-notification-contract.md
+++ b/docs/sprints/sprint-020/tickets/task-111-notification-contract.md
@@ -1,0 +1,348 @@
+---
+ticket_id: TASK-111
+title: Implement Slack notification contract for BugCase state changes
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-111-notification-contract
+effort_estimate: medium
+---
+
+# TASK-111: Implement Slack notification contract for BugCase state changes
+
+## Problem Statement
+
+The existing `send_case_notification()` in `slack.py` sends a Slack message for
+any BugCase passed to it. Sprint 020 requires structured routing: only Critical
+and High BugCases notify immediately; Medium logs digest intent; Low is silent.
+Repeated observations on an open BugCase do not re-notify. Muted/snoozed BugCases
+suppress delivery. This ticket replaces the current unconditional send with a
+routing-aware notification function.
+
+---
+
+## Context
+
+### Current `slack.py`
+
+`send_case_notification(case: BugCase) -> bool` — sends a Slack message using
+`httpx.AsyncClient`, reads webhook URL and enable flag from settings, returns
+`True`/`False`. `_build_slack_message(case: BugCase) -> dict` — builds the
+payload.
+
+Both functions exist and work. This ticket modifies `slack.py` to add routing
+logic and a new message format, and modifies `monitor.py` to call the new
+routing-aware function instead of calling `send_case_notification()` directly.
+
+### What triggers a notification
+
+```
+✅ New Critical BugCase created
+✅ New High BugCase created
+✅ Critical or High BugCase reopened (status: resolved → open)
+✅ Severity escalation on existing BugCase
+❌ Repeated observation attached to existing BugCase
+❌ observation_count increase
+❌ last_seen_at update
+❌ recovery_candidate_at set or cleared
+❌ Auto-resolution (status → resolved)
+❌ Manual close
+❌ Medium BugCase creation (log digest intent only)
+❌ Low BugCase creation (log only)
+```
+
+### Notification event types
+
+```
+bugcase_created
+bugcase_reopened
+severity_escalated
+suppression_summary   (TASK-112A)
+```
+
+### Deduplication
+
+A BugCase creation notification is sent at most once per BugCase. Check
+`notification_count > 0` on the existing BugCase before sending — if already
+notified, skip unless it's an escalation or reopen.
+
+### Throttle
+
+Max 1 notification per BugCase per `BUGOPS_NOTIFICATION_THROTTLE_MINUTES`. Compare
+`now - last_notified_at`. Escalation and reopen bypass throttle.
+
+### Mute/snooze check
+
+If `muted_until > now` or `snoozed_until > now`: suppress delivery, still update
+`last_notified_at` (so throttle window resets), record attempt as `suppressed`.
+
+### Slack message schema (all notification types)
+
+The `_build_slack_message()` function must produce a payload including:
+
+```
+event_type
+severity
+title
+bugcase_id        (was: case_id)
+status
+root_subsystem
+affected_subsystems
+summary
+first_seen_at
+last_seen_at
+observation_count
+dedupe_key
+detection_type
+suggested_manual_check
+suppression_status    (sent | suppressed | not_applicable)
+```
+
+### Message format — BugCase created (High/Critical)
+
+```
+🚨 HIGH — Article Freshness Failure
+
+Case:           bc_articles_1234567890
+Detection:      startup
+Root subsystem: articles
+Affected:       signals, narratives, briefings
+Summary:        No articles inserted for 42 minutes while article activity was expected.
+First seen:     2026-06-11 19:21 UTC
+Last seen:      2026-06-11 19:21 UTC
+Observations:   1
+Suggested check: Check RSS ingestion health and recent fetch attempts.
+```
+
+### Message format — Case reopened
+
+```
+🔄 CASE REOPENED
+
+Case:         bc_articles_1234567890
+Severity:     High
+Root:         articles
+Summary:      Article freshness recovered but failed again.
+Reopen count: 1
+```
+
+### What must NOT appear in messages
+
+- Raw logs, stack traces, large JSON payloads
+- Full database records
+- LLM-generated analysis
+- Evidence Pack or Investigation contents
+
+---
+
+## Task
+
+1. Add `route_and_send_notification()` to `slack.py` — routing-aware wrapper
+2. Update `_build_slack_message()` to include the full Sprint 020 schema
+3. Add `update_notification_state()` store method to `store.py`
+4. Update `monitor.py` to call `route_and_send_notification()` instead of
+   `send_case_notification()` directly
+5. Write unit tests for routing decisions
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_notification_routing.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/slack.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### New `route_and_send_notification()` in `slack.py`
+
+```python
+async def route_and_send_notification(
+    case: BugCase,
+    event_type: str,
+    store,   # BugOpsStore — passed in to avoid circular import
+) -> str:
+    """
+    Route and send notification based on BugCase severity and event type.
+    Returns: "sent" | "suppressed" | "skipped" | "failed"
+    """
+```
+
+Routing logic:
+- [ ] If `case.severity` is `AlertSeverity.CRITICAL` or `AlertSeverity.HIGH`:
+  proceed to mute/snooze check
+- [ ] If `case.severity` is `AlertSeverity.WARNING` (Medium): log digest intent,
+  update `last_notified_at`, return `"skipped"`
+- [ ] If `case.severity` is `AlertSeverity.INFO` (Low): log only, return `"skipped"`
+
+Deduplication check (for `event_type == "bugcase_created"` only):
+- [ ] If `case.notification_count > 0` and `event_type == "bugcase_created"`:
+  return `"skipped"` — already notified for this case creation
+
+Throttle check (skip for `bugcase_reopened` and `severity_escalated`):
+- [ ] If `case.last_notified_at` is not None:
+  `elapsed = now - case.last_notified_at`
+  If `elapsed < timedelta(minutes=BUGOPS_NOTIFICATION_THROTTLE_MINUTES)` and
+  `event_type not in ("bugcase_reopened", "severity_escalated")`: return `"skipped"`
+
+Mute/snooze check:
+- [ ] If `case.muted_until and case.muted_until > now`: send suppressed, update
+  `last_notified_at`, return `"suppressed"`
+- [ ] If `case.snoozed_until and case.snoozed_until > now`: same
+
+Send:
+- [ ] Call `send_case_notification(case)` (existing function)
+- [ ] If successful: call `store.update_notification_state(case.case_id, now)`,
+  return `"sent"`
+- [ ] If failed: return `"failed"` (TASK-111A handles attempt persistence)
+
+Medium digest stub:
+```python
+logger.info(
+    f"[DIGEST-PENDING] BugCase {case.case_id} queued for digest "
+    f"(severity=medium, event_type={event_type})"
+)
+```
+
+### Update `_build_slack_message()` in `slack.py`
+
+Update to include all Sprint 020 fields:
+- [ ] `event_type` field
+- [ ] `root_subsystem` field (from `case.root_subsystem`)
+- [ ] `affected_subsystems` field (from `case.affected_subsystems`, comma-joined)
+- [ ] `first_seen_at` field
+- [ ] `last_seen_at` field
+- [ ] `observation_count` field
+- [ ] `dedupe_key` field
+- [ ] `detection_type` field
+- [ ] `suppression_status` field
+- [ ] Match the message format examples in the Context section above
+- [ ] Keep `case_id` field for backward compatibility AND add `bugcase_id` alias
+- [ ] Do not add raw logs, stack traces, or JSON payloads
+
+### New store method: `update_notification_state(case_id: str, last_notified_at: datetime) -> BugCase`
+
+- [ ] `$set`: `{"last_notified_at": last_notified_at, "updated_at": datetime.utcnow()}`
+- [ ] `$inc`: `{"notification_count": 1}`
+- [ ] Uses `find_one_and_update` with `return_document=True`
+- [ ] Queries by `{"case_id": case_id}`
+- [ ] Returns updated `BugCase`
+
+### Monitor change
+
+In `_poll_freshness_detectors()`, replace:
+```python
+if self.settings.BUGOPS_SLACK_ENABLED:
+    from .slack import send_case_notification
+    await send_case_notification(new_case)
+```
+With:
+```python
+if self.settings.BUGOPS_SLACK_ENABLED:
+    from .slack import route_and_send_notification
+    await route_and_send_notification(new_case, "bugcase_created", self.store)
+```
+
+### Configuration
+
+```python
+BUGOPS_NOTIFICATION_THROTTLE_MINUTES: int = 60
+```
+
+### Test cases in `test_notification_routing.py`
+
+- [ ] Critical BugCase + `bugcase_created` → `send_case_notification()` called
+- [ ] High BugCase + `bugcase_created` → `send_case_notification()` called
+- [ ] Medium BugCase → no `send_case_notification()`, digest intent logged
+- [ ] Low BugCase → no `send_case_notification()`, log only
+- [ ] High BugCase, `notification_count > 0`, `event_type="bugcase_created"` →
+  `"skipped"` (already notified)
+- [ ] Same BugCase within throttle window, `event_type="bugcase_created"` →
+  `"skipped"`
+- [ ] Same BugCase after throttle window → `send_case_notification()` called
+- [ ] `event_type="bugcase_reopened"` → bypasses throttle, notification sent
+- [ ] `event_type="severity_escalated"` → bypasses throttle, notification sent
+- [ ] Muted BugCase (`muted_until` in future) → `"suppressed"`, `update_notification_state()` called
+- [ ] Snoozed BugCase → same as muted
+- [ ] Auto-resolution does NOT call `route_and_send_notification()` (test
+  `_run_auto_resolution()` does not trigger notification)
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_notification_routing.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All routing test cases pass
+- [ ] Existing cost-runaway detector notification tests pass unchanged
+- [ ] Existing `test_slack_notification.py` tests still pass (backward compat)
+
+### Manual Verification
+
+- [ ] Trigger a High freshness BugCase — confirm exactly one Slack message
+- [ ] Trigger repeated observations on same open BugCase — confirm no additional
+  Slack messages
+- [ ] Confirm no Slack fires on auto-resolution
+
+---
+
+## Acceptance Criteria
+
+- [ ] Critical and High BugCases send Slack on creation (`bugcase_created`)
+- [ ] Medium logs digest intent, Low logs only — no Slack for either
+- [ ] `bugcase_created` notifications deduplicate on `notification_count`
+- [ ] Throttle prevents re-notification within window
+- [ ] Reopen and severity escalation bypass throttle
+- [ ] Muted/snoozed suppress delivery but update `last_notified_at`
+- [ ] Auto-resolution does not send Slack
+- [ ] `update_notification_state()` added to store
+- [ ] All test cases pass
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-100A, TASK-100B, TASK-100C
+- Blocks: TASK-111A, TASK-112A
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-111-notification-routing.md
+++ b/docs/sprints/sprint-020/tickets/task-111-notification-routing.md
@@ -1,0 +1,214 @@
+---
+ticket_id: TASK-111
+title: Update notification routing for Sprint 020
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-111-notification-routing
+effort_estimate: medium
+---
+
+# TASK-111: Update notification routing for Sprint 020
+
+## Problem Statement
+
+Sprint 018's notification logic sends a Slack message for every new BugAlertEvent. Sprint 020 requires a more structured routing model: deduplication prevents repeated alerts for the same open BugCase, throttling prevents notification storms, and routing varies by severity. Without this, the four freshness detectors will produce noisy alerts on every polling cycle.
+
+---
+
+## Context
+
+Notification routing in Sprint 020 is driven by BugCase state changes, not raw detector observations. The routing decision happens in `monitor.py` or a dedicated notification module, using the `last_notified_at` and `notification_count` fields added to BugCase in TASK-100.
+
+**Medium (Digest) and Low (Stored only) are stubbed in this sprint.** Implement the routing decision and log the intent; actual digest batching and aggregation are deferred.
+
+`muted_until` and `snoozed_until` on BugCase suppress notifications but do not block BugCase creation or auto-resolution.
+
+The existing `slack.py` module is modified, not replaced.
+
+---
+
+## Task
+
+1. Implement severity-based routing logic (Critical/High → immediate Slack, Medium → log digest intent, Low → log only)
+2. Implement deduplication: no re-notification for repeated observations unless escalation conditions met
+3. Implement throttle: at most one notification per BugCase per throttle window (except escalation)
+4. Implement mute/snooze check before sending any notification
+5. Implement reopen notification (ignores throttle)
+6. Write unit tests for routing decisions
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_notification_routing.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/slack.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### Routing table
+
+| Severity | Trigger | Action |
+|---|---|---|
+| Critical | BugCase created | Immediate Slack |
+| Critical | Severity escalation | Immediate Slack (bypass throttle) |
+| High | BugCase created | Immediate Slack |
+| High | Severity escalation | Immediate Slack (bypass throttle) |
+| Medium | BugCase created | Log digest intent (stub) |
+| Low | BugCase created | Log only, no notification |
+
+### Deduplication rules — do NOT re-notify if
+
+- [ ] An open BugCase with the same `dedupe_key` already exists (i.e. this is an observation attachment, not a new case)
+- [ ] UNLESS any of these escalation conditions are true:
+  - Severity increased on the existing BugCase
+  - A new subsystem was added to `affected_subsystems`
+  - The BugCase reopened after resolution
+
+### Throttle
+
+- [ ] At most one notification per BugCase per `BUGOPS_NOTIFICATION_THROTTLE_MINUTES` window
+- [ ] Compare `now - last_notified_at` before sending; if within window, skip
+- [ ] Escalation events (severity increase, new subsystem, reopen) bypass the throttle
+- [ ] Flapping notification (TASK-110) bypasses the throttle
+
+### Mute/snooze check
+
+- [ ] Before sending any notification, check `muted_until` and `snoozed_until`
+- [ ] If `muted_until > now` or `snoozed_until > now`: log suppressed notification, do not send
+- [ ] Still update `last_notified_at` even when suppressed, so throttle window resets correctly — this prevents a burst of notifications when mute expires
+
+### Reopen notification
+
+- [ ] When a resolved BugCase reopens (status transitions from `resolved` to `open`): send notification regardless of throttle state
+- [ ] Use current BugCase severity for the reopen message
+
+### Notification sent — update BugCase
+
+- [ ] After sending (or deciding to send) a notification: update `last_notified_at = now` and increment `notification_count` via a store method
+
+### New store method: `update_notification_state(case_id, last_notified_at) -> BugCase`
+
+- [ ] Sets `last_notified_at` to provided value
+- [ ] Uses `$inc` to increment `notification_count` by 1
+- [ ] Returns updated BugCase
+
+### Slack message content (for new BugCase notifications)
+
+- [ ] `case_id`
+- [ ] `severity`
+- [ ] `root_subsystem`
+- [ ] `blast_radius` (list of affected downstream subsystems)
+- [ ] `first_seen_at`
+- [ ] One-line summary (e.g. "Article ingestion stalled — no articles in last 60 minutes")
+
+### Medium digest stub
+
+- [ ] When severity is Medium: log `"[DIGEST-PENDING] BugCase {case_id} would be included in digest"` at INFO level
+- [ ] Do not send Slack
+- [ ] Still update `last_notified_at`
+
+### Configuration
+
+```text
+BUGOPS_NOTIFICATION_THROTTLE_MINUTES=60
+```
+
+Add to `src/crypto_news_aggregator/core/config.py`.
+
+### Test cases required
+
+- [ ] Critical BugCase created → Slack sent
+- [ ] High BugCase created → Slack sent
+- [ ] Medium BugCase created → no Slack, digest intent logged
+- [ ] Low BugCase created → no Slack, log only
+- [ ] Same dedupe_key observation on open case → no notification
+- [ ] Same dedupe_key observation but severity increased → notification sent (throttle bypassed)
+- [ ] Same BugCase within throttle window → no notification
+- [ ] Same BugCase after throttle window → notification sent
+- [ ] Muted BugCase → notification suppressed, `last_notified_at` still updated
+- [ ] Snoozed BugCase → notification suppressed, `last_notified_at` still updated
+- [ ] Reopen notification sent regardless of throttle state
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_notification_routing.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All routing test cases pass
+- [ ] Existing cost-runaway detector notification behavior is unchanged
+
+### Manual Verification
+
+- [ ] Trigger a High freshness BugCase — confirm exactly one Slack message
+- [ ] Trigger repeated observations on the same open BugCase — confirm no additional Slack messages
+- [ ] Mute a BugCase and trigger a new observation — confirm no Slack
+
+---
+
+## Acceptance Criteria
+
+- [ ] Critical and High BugCases send immediate Slack on creation
+- [ ] Medium logs digest intent, Low logs only — no Slack for either
+- [ ] Repeated observations on an open BugCase do not re-notify
+- [ ] Escalation events (severity increase, new subsystem, reopen) bypass deduplication and throttle
+- [ ] Throttle prevents more than one notification per BugCase per throttle window
+- [ ] Muted/snoozed BugCases suppress notification but still update `last_notified_at`
+- [ ] `notification_count` increments correctly
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Transforms alert behavior from noisy (one Slack per detector observation) to signal-rich (one Slack per new failure, silence for repeated observations of the same open issue).
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100
+- Can run in parallel with TASK-103 through TASK-107
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-111a-notification-attempts.md
+++ b/docs/sprints/sprint-020/tickets/task-111a-notification-attempts.md
@@ -1,0 +1,263 @@
+---
+ticket_id: TASK-111A
+title: Persist notification attempt records
+priority: high
+severity: medium
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-111a-notification-attempts
+effort_estimate: small
+---
+
+# TASK-111A: Persist notification attempt records
+
+## Problem Statement
+
+When a Slack notification fails, there is currently no record of the attempt.
+If BugOps sends 10 notifications and 3 fail silently, there is no way to audit
+which BugCases never reached the operator. Persisting every attempt independently
+of the BugCase lifecycle creates an auditable trail.
+
+---
+
+## Context
+
+### Schema
+
+```
+notification_id     string (generated)
+bugcase_id          string
+event_type          string (bugcase_created | bugcase_reopened | severity_escalated | suppression_summary)
+channel             string ("slack")
+status              string (sent | failed | suppressed | skipped)
+attempted_at        datetime
+error_type          string | null
+error_message       string | null
+suppressed_reason   string | null
+```
+
+### Status values
+
+```
+sent       — Slack webhook accepted (HTTP 2xx)
+failed     — Slack webhook failed, timed out, or raised an exception
+suppressed — Deploy suppression was active OR case was muted/snoozed
+skipped    — Routing rules did not require notification (Medium/Low severity, dedupe, throttle)
+```
+
+Sprint 020 does not need to persist `skipped` records unless implementation cost
+is low. `sent`, `failed`, and `suppressed` must be persisted.
+
+### Failure behavior invariant
+
+```
+Slack send fails
+→ record status: failed
+→ log error
+→ BugCase remains created
+→ monitor continues polling
+```
+
+Notification failure must never block BugCase creation, detection, or
+auto-resolution.
+
+### Collection
+
+`notification_attempts` — indexes already added by TASK-101:
+- `notification_attempts_bugcase_id`
+- `notification_attempts_attempted_at`
+
+---
+
+## Task
+
+1. Add `NotificationAttempt` and `NotificationAttemptCreate` models to `models.py`
+2. Add `create_notification_attempt()` to `BugOpsStore`
+3. Update `route_and_send_notification()` in `slack.py` to persist an attempt
+   record for every `sent`, `failed`, and `suppressed` outcome
+4. Write unit tests
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_notification_attempts.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/slack.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Implementation Requirements
+
+### `NotificationAttemptCreate` model in `models.py`
+
+```python
+class NotificationAttemptCreate(BaseModel):
+    notification_id: str
+    bugcase_id: str
+    event_type: str
+    channel: str = "slack"
+    status: str   # sent | failed | suppressed | skipped
+    attempted_at: datetime = Field(default_factory=datetime.utcnow)
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    suppressed_reason: Optional[str] = None
+
+class NotificationAttempt(NotificationAttemptCreate):
+    id: Optional[str] = Field(default=None, alias="_id")
+    class Config:
+        populate_by_name = True
+```
+
+### `create_notification_attempt()` in `store.py`
+
+- [ ] Add `self.notification_attempts_collection = db["notification_attempts"]`
+  to `BugOpsStore.__init__()`
+- [ ] Add method:
+  ```python
+  async def create_notification_attempt(
+      self, attempt: NotificationAttemptCreate
+  ) -> NotificationAttempt:
+  ```
+- [ ] Follows same insert pattern as `create_alert_event()`:
+  `model_dump()` → `insert_one()` → set `_id` → `_normalize_mongo_doc()` → return model
+- [ ] Must not raise on insert failure — wrap in try/except, log error, return None
+  (do not propagate storage errors up to the caller)
+
+### Update `route_and_send_notification()` in `slack.py`
+
+After each outcome, persist an attempt record:
+
+For `"sent"`:
+```python
+await store.create_notification_attempt(NotificationAttemptCreate(
+    notification_id=f"notif_{case.case_id}_{int(now.timestamp())}",
+    bugcase_id=case.case_id,
+    event_type=event_type,
+    status="sent",
+))
+```
+
+For `"failed"` (Slack send raised exception):
+```python
+await store.create_notification_attempt(NotificationAttemptCreate(
+    notification_id=f"notif_{case.case_id}_{int(now.timestamp())}",
+    bugcase_id=case.case_id,
+    event_type=event_type,
+    status="failed",
+    error_type=type(e).__name__,
+    error_message=str(e),
+))
+```
+
+For `"suppressed"` (mute/snooze or deploy suppression):
+```python
+await store.create_notification_attempt(NotificationAttemptCreate(
+    notification_id=f"notif_{case.case_id}_{int(now.timestamp())}",
+    bugcase_id=case.case_id,
+    event_type=event_type,
+    status="suppressed",
+    suppressed_reason="muted" | "snoozed" | "deploy_suppression",
+))
+```
+
+`store` is already passed into `route_and_send_notification()` as a parameter
+(added in TASK-111).
+
+### Test cases in `test_notification_attempts.py`
+
+- [ ] Successful Slack send → attempt record created with `status="sent"`
+- [ ] Slack send fails (mock raises exception) → attempt record created with
+  `status="failed"`, `error_type` and `error_message` populated
+- [ ] Muted BugCase → attempt record created with `status="suppressed"`,
+  `suppressed_reason="muted"`
+- [ ] Deploy suppression active → attempt record created with
+  `status="suppressed"`, `suppressed_reason="deploy_suppression"`
+- [ ] `create_notification_attempt()` storage failure does not propagate —
+  mock `insert_one` to raise, confirm `route_and_send_notification()` does not
+  re-raise
+- [ ] `NotificationAttemptCreate` can be instantiated with required fields only
+- [ ] `notification_id` is unique per attempt (timestamp-based uniqueness sufficient)
+
+### Configuration
+
+No new environment variables required for this ticket.
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_notification_attempts.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All test cases pass
+- [ ] Existing notification routing tests (TASK-111) pass
+
+### Manual Verification
+
+- [ ] Trigger a High BugCase in dev → confirm a document appears in
+  `notification_attempts` with `status="sent"`
+- [ ] Force a Slack failure (invalid webhook URL) → confirm `status="failed"`
+  document in `notification_attempts` and BugCase still created
+
+---
+
+## Acceptance Criteria
+
+- [ ] `NotificationAttemptCreate` and `NotificationAttempt` models exist
+- [ ] `create_notification_attempt()` added to store
+- [ ] Attempt records created for `sent`, `failed`, and `suppressed` outcomes
+- [ ] Storage failure in `create_notification_attempt()` does not propagate
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Creates an auditable trail of notification delivery. Operators can query
+`notification_attempts` to see which BugCases never reached them.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-101 (indexes), TASK-111 (routing function to instrument)
+- Blocks: TASK-112A (suppression summary also creates attempt records)
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-112-deploy-suppression.md
+++ b/docs/sprints/sprint-020/tickets/task-112-deploy-suppression.md
@@ -1,0 +1,259 @@
+---
+ticket_id: TASK-112
+title: Implement global deploy suppression
+priority: medium
+severity: low
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-112-deploy-suppression
+effort_estimate: small
+---
+
+# TASK-112: Implement global deploy suppression
+
+## Problem Statement
+
+During planned deploys, BugOps will correctly detect transient failures as the
+system restarts. Without suppression, every deploy generates a stream of BugCase
+notifications. Operators need a way to suppress notifications for a known
+maintenance window without losing case visibility or auto-resolution.
+
+---
+
+## Context
+
+### Suppression mechanism
+
+A single environment variable:
+
+```
+BUGOPS_SUPPRESSED_UNTIL=<ISO-8601 timestamp>
+```
+
+If current time is before `BUGOPS_SUPPRESSED_UNTIL`, suppression is active.
+If the variable is empty, invalid, or in the past, suppression is inactive.
+No separate `BUGOPS_SUPPRESSION_ACTIVE` boolean. The timestamp IS the gate.
+
+This replaces the two-variable design (`BUGOPS_SUPPRESSION_ACTIVE` + 
+`BUGOPS_SUPPRESSION_EXPIRES_AT`) from the original ticket.
+
+### Suppression invariant
+
+```
+BugCases are created normally ✅
+BugCases are updated normally ✅
+Slack notifications are not sent ✅
+notification_attempts recorded as suppressed ✅ (TASK-111A)
+auto-resolution runs normally ✅
+reopen logic runs normally ✅
+```
+
+### Individual BugCase mute/snooze
+
+`muted_until` and `snoozed_until` on BugCase are already checked in
+`route_and_send_notification()` (TASK-111). This ticket adds the global
+suppression check that runs before the per-case check.
+
+The `mute_case()` and `snooze_case()` store methods are implemented here for
+use by future operator tooling (CLI or UI). No API endpoints. No Slack UI.
+
+### Suppression expiry summary
+
+When suppression expires, send one Slack summary for unresolved Critical and High
+BugCases active during the window. This is TASK-112A — not implemented here.
+This ticket only detects expiry and hands off to TASK-112A.
+
+---
+
+## Task
+
+1. Add `BUGOPS_SUPPRESSED_UNTIL` to `core/config.py`
+2. Add suppression check to `route_and_send_notification()` in `slack.py`
+3. Add suppression state tracking to `BugOpsMonitor` — detect when suppression
+   transitions from active to inactive
+4. Add `mute_case()` and `snooze_case()` store methods
+5. Write unit tests
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_deploy_suppression.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/slack.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+```
+
+---
+
+## Implementation Requirements
+
+### Configuration
+
+```python
+BUGOPS_SUPPRESSED_UNTIL: str = ""
+# ISO-8601 timestamp. If current time is before this value, notifications
+# are suppressed. Empty string = suppression inactive.
+```
+
+### Suppression check helper in `slack.py` or `monitor.py`
+
+```python
+def is_suppression_active(settings) -> bool:
+    """Return True if global deploy suppression is currently active."""
+    raw = settings.BUGOPS_SUPPRESSED_UNTIL
+    if not raw:
+        return False
+    try:
+        from datetime import datetime, timezone
+        suppressed_until = datetime.fromisoformat(raw)
+        # Ensure timezone-aware comparison
+        now = datetime.now(timezone.utc)
+        if suppressed_until.tzinfo is None:
+            suppressed_until = suppressed_until.replace(tzinfo=timezone.utc)
+        return now < suppressed_until
+    except (ValueError, TypeError):
+        return False  # Invalid timestamp = suppression inactive
+```
+
+### Update `route_and_send_notification()` in `slack.py`
+
+Add global suppression check as the FIRST check, before mute/snooze:
+
+```python
+if is_suppression_active(settings):
+    logger.info(
+        f"[SUPPRESSED] Notification suppressed during maintenance window: "
+        f"case_id={case.case_id}"
+    )
+    # Still update last_notified_at so throttle resets correctly
+    await store.update_notification_state(case.case_id, now)
+    # Persist attempt record (TASK-111A)
+    await store.create_notification_attempt(NotificationAttemptCreate(
+        notification_id=f"notif_{case.case_id}_{int(now.timestamp())}",
+        bugcase_id=case.case_id,
+        event_type=event_type,
+        status="suppressed",
+        suppressed_reason="deploy_suppression",
+    ))
+    return "suppressed"
+```
+
+### Suppression expiry tracking in `monitor.py`
+
+Add `self._suppression_was_active: bool = False` to `__init__()`.
+
+In the main loop, check each cycle:
+```python
+currently_suppressed = is_suppression_active(self.settings)
+if self._suppression_was_active and not currently_suppressed:
+    # Suppression just expired — trigger TASK-112A summary
+    await self._send_suppression_expiry_summary()
+self._suppression_was_active = currently_suppressed
+```
+
+`_send_suppression_expiry_summary()` is a stub returning immediately until TASK-112A.
+
+### New store methods
+
+**`mute_case(case_id: str, muted_until: datetime) -> BugCase`**
+- [ ] `$set`: `{"muted_until": muted_until, "updated_at": datetime.utcnow()}`
+- [ ] `find_one_and_update` with `return_document=True`, query by `{"case_id": case_id}`
+- [ ] Returns `BugCase`
+
+**`snooze_case(case_id: str, snoozed_until: datetime) -> BugCase`**
+- [ ] `$set`: `{"snoozed_until": snoozed_until, "updated_at": datetime.utcnow()}`
+- [ ] Same pattern as `mute_case()`
+- [ ] Returns `BugCase`
+
+No API endpoints. These are called by operator tooling only.
+
+### Test cases in `test_deploy_suppression.py`
+
+- [ ] `BUGOPS_SUPPRESSED_UNTIL` set to future timestamp → `is_suppression_active()` returns `True`
+- [ ] `BUGOPS_SUPPRESSED_UNTIL` set to past timestamp → returns `False`
+- [ ] `BUGOPS_SUPPRESSED_UNTIL` empty string → returns `False`
+- [ ] `BUGOPS_SUPPRESSED_UNTIL` invalid string → returns `False` (no exception)
+- [ ] Suppression active → notification suppressed, BugCase still created
+- [ ] Suppression active → auto-resolution still runs (mock `_run_auto_resolution()`
+  and confirm it's called even when suppressed)
+- [ ] Suppression expires (was active, now inactive) → `_send_suppression_expiry_summary()` called
+- [ ] `mute_case()` sets `muted_until` correctly
+- [ ] `snooze_case()` sets `snoozed_until` correctly
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_deploy_suppression.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All test cases pass
+- [ ] Existing notification routing tests (TASK-111) pass
+
+### Manual Verification
+
+- [ ] Set `BUGOPS_SUPPRESSED_UNTIL` to a timestamp 5 minutes in the future in Railway,
+  trigger a detection condition — confirm BugCase created but no Slack fires
+- [ ] Let the timestamp expire — confirm suppression deactivates on next cycle
+
+---
+
+## Acceptance Criteria
+
+- [ ] `BUGOPS_SUPPRESSED_UNTIL` is the single suppression control (no boolean flag)
+- [ ] Global suppression suppresses notifications without blocking BugCase creation
+  or auto-resolution
+- [ ] Invalid or empty `BUGOPS_SUPPRESSED_UNTIL` → suppression inactive (no crash)
+- [ ] Expiry detection triggers `_send_suppression_expiry_summary()` stub
+- [ ] `mute_case()` and `snooze_case()` store methods exist
+- [ ] All test cases pass
+
+---
+
+## Impact
+
+Eliminates notification noise during planned deploys without losing case visibility.
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-100, TASK-111, TASK-111A
+- Blocks: TASK-112A
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-112a-suppression-expiry-summary.md
+++ b/docs/sprints/sprint-020/tickets/task-112a-suppression-expiry-summary.md
@@ -1,0 +1,236 @@
+---
+ticket_id: TASK-112A
+title: Send deploy suppression expiry summary
+priority: medium
+severity: low
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-112a-suppression-expiry-summary
+effort_estimate: small
+---
+
+# TASK-112A: Send deploy suppression expiry summary
+
+## Problem Statement
+
+When deploy suppression expires, the operator may have missed multiple BugCase
+notifications. Without a summary, they have no way to know what happened during
+the maintenance window without manually querying MongoDB. One summary message on
+expiry gives them the full picture.
+
+---
+
+## Context
+
+TASK-112 adds suppression expiry detection and a stub method
+`_send_suppression_expiry_summary()` in `monitor.py`. This ticket implements
+that method.
+
+### Summary trigger conditions
+
+Send summary if ALL of:
+1. Suppression was active during a window
+2. One or more Critical or High BugCases were created or updated during the
+   suppression window
+3. At least one of those BugCases is still unresolved when suppression expires
+
+Do NOT send if all suppressed BugCases auto-resolved before suppression ended.
+
+### Summary format
+
+```
+Deploy suppression ended
+
+2 unresolved BugCases were active during suppression:
+
+- HIGH Article Freshness Failure — bc_articles_1234567890
+- HIGH Briefing Freshness Failure — bc_briefings_1234567891
+```
+
+### What the summary must NOT include
+
+- Individual suppressed notification replays
+- Raw logs, stack traces, JSON payloads
+- More than the summary format above
+
+---
+
+## Task
+
+1. Implement `_send_suppression_expiry_summary()` in `monitor.py`
+2. Add `get_cases_active_during_window()` store method
+3. Update `slack.py` to add `send_suppression_summary()` function
+4. Write unit tests
+
+---
+
+## Files to Create
+
+```text
+src/tests/bugops/test_suppression_expiry_summary.py
+```
+
+---
+
+## Files to Modify
+
+```text
+src/crypto_news_aggregator/bugops/monitor.py
+src/crypto_news_aggregator/bugops/store.py
+src/crypto_news_aggregator/bugops/slack.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+src/crypto_news_aggregator/bugops/models.py
+src/crypto_news_aggregator/bugops/signal_sources/llm_traces.py
+src/crypto_news_aggregator/bugops/dependency_graph.py
+src/crypto_news_aggregator/core/config.py
+```
+
+---
+
+## Implementation Requirements
+
+### `_send_suppression_expiry_summary()` in `monitor.py`
+
+The monitor needs to know when suppression started to query for cases active
+during that window. Add `self._suppression_started_at: Optional[datetime] = None`
+to `__init__()`. Set it to `now` when `_suppression_was_active` transitions from
+`False` to `True` in the main loop.
+
+```python
+async def _send_suppression_expiry_summary(self) -> None:
+    """Send one Slack summary of unresolved Critical/High cases from the
+    suppression window."""
+    if not self.settings.BUGOPS_SLACK_ENABLED:
+        return
+
+    suppression_start = self._suppression_started_at or datetime.utcnow()
+
+    cases = await self.store.get_cases_active_during_window(
+        window_start=suppression_start,
+        severities=["critical", "high"],
+    )
+
+    unresolved = [c for c in cases if c.status == CaseStatus.OPEN]
+
+    if not unresolved:
+        logger.info("Suppression expired — all cases auto-resolved, no summary needed")
+        return
+
+    from .slack import send_suppression_summary
+    await send_suppression_summary(unresolved)
+
+    # Reset suppression tracking
+    self._suppression_started_at = None
+```
+
+### New store method: `get_cases_active_during_window()`
+
+```python
+async def get_cases_active_during_window(
+    self,
+    window_start: datetime,
+    severities: list[str],
+) -> list[BugCase]:
+    """Return BugCases with matching severity created or updated during window."""
+```
+
+- [ ] Queries: `{"severity": {"$in": severities}, "created_at": {"$gte": window_start}}`
+- [ ] Returns list of `BugCase` objects
+- [ ] Uses `.find().to_list(None)` pattern with `_normalize_mongo_doc()`
+
+### New `send_suppression_summary()` in `slack.py`
+
+```python
+async def send_suppression_summary(cases: list[BugCase]) -> bool:
+    """Send a single Slack summary of cases active during suppression window."""
+```
+
+- [ ] Reads webhook URL and BUGOPS_SLACK_ENABLED from settings
+- [ ] Builds summary message matching the format in Context section
+- [ ] Posts to webhook via `httpx.AsyncClient`
+- [ ] Returns `True`/`False`
+- [ ] Logs success/failure
+
+### Monitor loop update (from TASK-112)
+
+In the main loop in `monitor.py`, update the expiry detection to also track
+suppression start:
+
+```python
+currently_suppressed = is_suppression_active(self.settings)
+if currently_suppressed and not self._suppression_was_active:
+    # Suppression just became active
+    self._suppression_started_at = datetime.utcnow()
+if self._suppression_was_active and not currently_suppressed:
+    # Suppression just expired
+    await self._send_suppression_expiry_summary()
+self._suppression_was_active = currently_suppressed
+```
+
+### Test cases in `test_suppression_expiry_summary.py`
+
+- [ ] Unresolved Critical/High cases exist during window → `send_suppression_summary()` called with those cases
+- [ ] All cases auto-resolved before expiry → `send_suppression_summary()` NOT called
+- [ ] No cases during window → `send_suppression_summary()` NOT called
+- [ ] Medium/Low cases excluded from summary (only Critical and High)
+- [ ] Summary message format matches spec (check field presence, not exact string)
+- [ ] `BUGOPS_SLACK_ENABLED=false` → no Slack call even if unresolved cases exist
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/test_suppression_expiry_summary.py -v
+pytest src/tests/bugops/ -v
+```
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] All test cases pass
+- [ ] TASK-112 deploy suppression tests still pass
+
+### Manual Verification
+
+- [ ] Set `BUGOPS_SUPPRESSED_UNTIL` to a time 2 minutes in the future, let a
+  freshness failure trigger and create a BugCase, wait for suppression to expire,
+  confirm one Slack summary message arrives listing the unresolved case
+- [ ] Repeat with auto-resolution enabled and fast Recovery Window — confirm no
+  summary if the case resolves before suppression expires
+
+---
+
+## Acceptance Criteria
+
+- [ ] Summary sent when unresolved Critical/High cases exist at expiry
+- [ ] No summary if all cases resolved
+- [ ] Summary format matches spec
+- [ ] Individual suppressed notifications not replayed
+- [ ] `get_cases_active_during_window()` added to store
+- [ ] All test cases pass
+
+---
+
+## Related Tickets
+
+- Depends on: TASK-111, TASK-111A, TASK-112
+- Blocks: TASK-113
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/docs/sprints/sprint-020/tickets/task-113-sprint020-docs.md
+++ b/docs/sprints/sprint-020/tickets/task-113-sprint020-docs.md
@@ -1,0 +1,216 @@
+---
+ticket_id: TASK-113
+title: Update Sprint 020 docs and success criteria
+priority: low
+severity: low
+status: OPEN
+date_created: 2025-01-01
+branch: task/bugops-113-sprint020-docs
+effort_estimate: small
+---
+
+# TASK-113: Update Sprint 020 docs and success criteria
+
+## Problem Statement
+
+Sprint 020 scope changed from the original plan. The sprint doc, success criteria,
+and inline documentation must reflect the final implemented scope before Sprint 021
+begins. Sprint 021 does not start until Sprint 020 success criteria are fully met
+and documented.
+
+---
+
+## Context
+
+This is a documentation-only ticket. No production code changes.
+
+### What changed from original scope
+
+- TASK-110 (flapping detection) removed — Recovery Window repeated-failure
+  handling is sufficient; dedicated flapping not implemented
+- TASK-100A added (canonical subsystem enum)
+- TASK-100B added (deterministic severity mapping)
+- TASK-100C added (Slack webhook Railway config)
+- TASK-108A added (startup detection)
+- TASK-111A added (notification attempt persistence)
+- TASK-112A added (suppression expiry summary)
+- TASK-113 added (this ticket)
+- Suppression mechanism changed: single `BUGOPS_SUPPRESSED_UNTIL` timestamp
+  variable replaces `BUGOPS_SUPPRESSION_ACTIVE` + `BUGOPS_SUPPRESSION_EXPIRES_AT`
+- `detection_type` field added to BugCase model
+- `reopen_count` field added to BugCase model
+- `observation_count` default changed from 0 to 1
+- Railway log ingestion explicitly deferred to Sprint 021
+- RuntimeExceptionSignalSource explicitly out of scope
+
+---
+
+## Task
+
+1. Update `sprint-020-bugops-outcome-freshness.md` — ticket table, scope,
+   success criteria, key decisions
+2. Update inline comments in `models.py` where noted
+3. Update `signal_sources/__init__.py` to export the four new detectors
+
+---
+
+## Files to Create
+
+```text
+(none)
+```
+
+---
+
+## Files to Modify
+
+```text
+sprint-020-bugops-outcome-freshness.md (or wherever the sprint doc lives)
+src/crypto_news_aggregator/bugops/signal_sources/__init__.py
+```
+
+---
+
+## Do Not Modify
+
+```text
+(any production logic files)
+```
+
+---
+
+## Implementation Requirements
+
+### Sprint doc updates
+
+**Ticket table:** confirm all 18 tickets are listed with correct status after
+sprint completion.
+
+**Success criteria — remove:**
+```
+Flapping protection activates and notifies correctly under rapid oscillation
+```
+
+**Success criteria — confirm present:**
+```
+A BugCase does not auto-resolve if the failure condition recurs during the Recovery Window
+Active failures present at BugOps startup create BugCases with detection_type=startup
+Startup-created Critical and High BugCases send Slack notifications
+Slack messages include severity, root_subsystem, affected_subsystems, summary,
+  first_seen_at, last_seen_at, observation_count, dedupe_key, detection_type,
+  and suggested_manual_check
+Slack send failure records a failed notification attempt and does not block
+  BugCase creation
+Deploy suppression suppresses notification delivery without suppressing BugCase
+  creation or updates
+Suppression expiry sends one summary for unresolved Critical and High BugCases
+  active during suppression
+Canonical subsystem names used consistently across all components
+Railway log ingestion and runtime exception monitoring are not implemented in Sprint 020
+```
+
+**Key decisions — add:**
+```
+Flapping detection deferred | Recovery Window handles practical oscillation;
+  no evidence Backdrop needs dedicated flapping yet | TASK-110 removed
+
+Railway log ingestion deferred to Sprint 021 | Log access requires validation
+  of programmatic Railway API access; does not affect outcome freshness detection
+
+Startup detection creates BugCases for active failures | Operator needs to know
+  if production is broken when BugOps starts | TASK-108A added; detection_type
+  field added to BugCase model
+
+Suppression mechanism simplified to single timestamp variable | Two-variable
+  design (active bool + expires timestamp) replaced with BUGOPS_SUPPRESSED_UNTIL
+  ISO timestamp | Simpler to reason about; no risk of boolean/timestamp mismatch
+```
+
+**Out of scope — confirm these entries exist:**
+```
+Railway log ingestion
+RuntimeExceptionSignalSource
+Runtime exception monitoring from Railway logs
+Slack interactive UI, buttons, slash commands, or acknowledgement actions
+Dedicated flapping detection with manual escalation
+```
+
+### `signal_sources/__init__.py` update
+
+Export the four new detector classes so TASK-108 imports cleanly:
+
+```python
+from .article_freshness import ArticleFreshnessSignalSource
+from .signal_freshness import SignalFreshnessSignalSource
+from .narrative_freshness import NarrativeFreshnessSignalSource
+from .briefing_freshness import BriefingFreshnessSignalSource
+from .severity import DETECTOR_SEVERITY
+
+__all__ = [
+    "ArticleFreshnessSignalSource",
+    "SignalFreshnessSignalSource",
+    "NarrativeFreshnessSignalSource",
+    "BriefingFreshnessSignalSource",
+    "DETECTOR_SEVERITY",
+]
+```
+
+### Commands to Run
+
+```bash
+pytest src/tests/bugops/ -v
+```
+
+(Confirm full suite still passes after doc/export changes.)
+
+---
+
+## Verification
+
+### Automated Verification
+
+- [ ] Full bugops test suite passes
+
+### Manual Verification
+
+- [ ] Sprint doc ticket table has 18 tickets, all with correct status
+- [ ] Flapping criterion absent from success criteria
+- [ ] Recovery Window repeated-failure criterion present
+- [ ] Railway log and RuntimeExceptionSignalSource explicitly out of scope
+- [ ] `signal_sources/__init__.py` exports all four detectors
+
+---
+
+## Acceptance Criteria
+
+- [ ] Sprint doc reflects final Sprint 020 scope
+- [ ] Removed success criteria: flapping
+- [ ] Added success criteria: startup detection, Slack contract, notification
+  attempts, suppression expiry, canonical subsystems, Railway out of scope
+- [ ] Four new key decisions documented
+- [ ] `signal_sources/__init__.py` exports the four new detectors
+- [ ] Full bugops test suite passes
+
+---
+
+## Impact
+
+Closes Sprint 020 formally. Required before Sprint 021 begins.
+
+---
+
+## Related Tickets
+
+- Depends on: all other Sprint 020 tickets
+- Blocks: Sprint 021
+
+---
+
+## Completion Summary
+
+- Branch:
+- Commit:
+- Changes made:
+- Tests run:
+- Manual verification:
+- Deviations from plan:

--- a/src/crypto_news_aggregator/bugops/models.py
+++ b/src/crypto_news_aggregator/bugops/models.py
@@ -78,6 +78,20 @@ class BugCaseCreate(BaseModel):
     resolved_at: Optional[datetime] = None
     closed_at: Optional[datetime] = None
     deterministic_report: Optional[str] = None
+    root_subsystem: Optional[str] = None
+    affected_subsystems: list[str] = Field(default_factory=list)
+    blast_radius: list[str] = Field(default_factory=list)
+    observation_count: int = 1
+    first_seen_at: Optional[datetime] = None
+    last_seen_at: Optional[datetime] = None
+    recovery_candidate_at: Optional[datetime] = None
+    resolution_type: Optional[str] = None  # reserved: real_issue | false_positive | duplicate | operator_error | expected_idle
+    detection_type: Optional[str] = None  # startup | runtime | reopen
+    reopen_count: int = 0
+    muted_until: Optional[datetime] = None
+    snoozed_until: Optional[datetime] = None
+    last_notified_at: Optional[datetime] = None
+    notification_count: int = 0
 
 
 class BugCase(BugCaseCreate):

--- a/tests/bugops/test_bugops_models.py
+++ b/tests/bugops/test_bugops_models.py
@@ -119,6 +119,7 @@ def test_bug_case_create_valid():
     case = BugCaseCreate(
         case_id="case_1",
         severity=AlertSeverity.HIGH,
+        alert_type="cost_runaway",
         title="Cost Runaway Case",
         summary="Multiple cost runaway alerts",
         dedupe_key="cost_runaway_1",
@@ -136,6 +137,7 @@ def test_bug_case_create_default_status():
     case = BugCaseCreate(
         case_id="case_1",
         severity=AlertSeverity.WARNING,
+        alert_type="test",
         title="Test",
         summary="Test",
         dedupe_key="test_1",
@@ -149,6 +151,7 @@ def test_bug_case_create_default_alert_ids():
     case = BugCaseCreate(
         case_id="case_1",
         severity=AlertSeverity.WARNING,
+        alert_type="test",
         title="Test",
         summary="Test",
         dedupe_key="test_1",
@@ -164,6 +167,7 @@ def test_bug_case_manual_only_lifecycle():
         case_id="case_1",
         status=CaseStatus.OPEN,
         severity=AlertSeverity.HIGH,
+        alert_type="test",
         title="Test",
         summary="Test",
         dedupe_key="test_1",
@@ -176,6 +180,7 @@ def test_bug_case_manual_only_lifecycle():
         case_id="case_1",
         status=CaseStatus.RESOLVED,
         severity=AlertSeverity.HIGH,
+        alert_type="test",
         title="Test",
         summary="Test",
         dedupe_key="test_1",
@@ -188,9 +193,114 @@ def test_bug_case_manual_only_lifecycle():
         case_id="case_1",
         status=CaseStatus.CLOSED,
         severity=AlertSeverity.HIGH,
+        alert_type="test",
         title="Test",
         summary="Test",
         dedupe_key="test_1",
         source_types=["llm_traces"],
     )
     assert case_closed.status == CaseStatus.CLOSED
+
+
+def test_bug_case_sprint020_fields_with_defaults():
+    """Test that Sprint 020 fields are present with correct defaults."""
+    case = BugCaseCreate(
+        case_id="case_1",
+        severity=AlertSeverity.HIGH,
+        alert_type="freshness",
+        title="Article Freshness Failure",
+        summary="No articles inserted",
+        dedupe_key="article_freshness:articles",
+        source_types=["freshness_detector"],
+    )
+    assert case.observation_count == 1
+    assert case.reopen_count == 0
+    assert case.root_subsystem is None
+    assert case.affected_subsystems == []
+    assert case.blast_radius == []
+    assert case.first_seen_at is None
+    assert case.last_seen_at is None
+    assert case.recovery_candidate_at is None
+    assert case.resolution_type is None
+    assert case.detection_type is None
+    assert case.muted_until is None
+    assert case.snoozed_until is None
+    assert case.last_notified_at is None
+    assert case.notification_count == 0
+
+
+def test_bug_case_sprint020_fields_with_values():
+    """Test that Sprint 020 fields can be set with values."""
+    now = datetime.utcnow()
+    case = BugCaseCreate(
+        case_id="case_1",
+        severity=AlertSeverity.HIGH,
+        alert_type="freshness",
+        title="Article Freshness Failure",
+        summary="No articles inserted",
+        dedupe_key="article_freshness:articles",
+        source_types=["freshness_detector"],
+        root_subsystem="articles",
+        affected_subsystems=["signals", "narratives"],
+        blast_radius=["signals", "narratives", "briefings"],
+        observation_count=3,
+        first_seen_at=now,
+        last_seen_at=now,
+        detection_type="startup",
+        reopen_count=1,
+    )
+    assert case.root_subsystem == "articles"
+    assert case.affected_subsystems == ["signals", "narratives"]
+    assert case.blast_radius == ["signals", "narratives", "briefings"]
+    assert case.observation_count == 3
+    assert case.first_seen_at == now
+    assert case.last_seen_at == now
+    assert case.detection_type == "startup"
+    assert case.reopen_count == 1
+
+
+def test_bug_case_detection_type_values():
+    """Test detection_type enum values."""
+    for detection_type in ["startup", "runtime", "reopen"]:
+        case = BugCaseCreate(
+            case_id="case_1",
+            severity=AlertSeverity.HIGH,
+            alert_type="freshness",
+            title="Test",
+            summary="Test",
+            dedupe_key="test",
+            source_types=["detector"],
+            detection_type=detection_type,
+        )
+        assert case.detection_type == detection_type
+
+
+def test_bug_case_read_model_inherits_sprint020_fields():
+    """Test that BugCase (read model) inherits all Sprint 020 fields from BugCaseCreate."""
+    now = datetime.utcnow()
+    case_data = {
+        "case_id": "case_1",
+        "severity": AlertSeverity.HIGH,
+        "alert_type": "freshness",
+        "title": "Article Freshness",
+        "summary": "No articles",
+        "dedupe_key": "article_freshness:articles",
+        "source_types": ["detector"],
+        "root_subsystem": "articles",
+        "affected_subsystems": ["signals"],
+        "blast_radius": ["signals", "narratives"],
+        "observation_count": 2,
+        "first_seen_at": now,
+        "last_seen_at": now,
+        "detection_type": "startup",
+        "reopen_count": 1,
+    }
+    case = BugCase(**case_data)
+    assert case.root_subsystem == "articles"
+    assert case.affected_subsystems == ["signals"]
+    assert case.blast_radius == ["signals", "narratives"]
+    assert case.observation_count == 2
+    assert case.first_seen_at == now
+    assert case.last_seen_at == now
+    assert case.detection_type == "startup"
+    assert case.reopen_count == 1


### PR DESCRIPTION
## Summary

Extends the BugCase model with 14 new fields required for Sprint 020 outcome freshness detection:
- Subsystem tracking: root_subsystem, affected_subsystems, blast_radius
- Observation tracking: observation_count (default 1), first_seen_at, last_seen_at
- Recovery tracking: recovery_candidate_at
- Resolution metadata: resolution_type (reserved for future)
- Detection metadata: detection_type (startup|runtime|reopen), reopen_count
- Operator flags: muted_until, snoozed_until (notification-only)
- Notification tracking: last_notified_at, notification_count

All fields optional or have defaults. BugCase inherits via Pydantic. No breaking changes to existing code.

## Test Plan

- ✅ All 15 model tests pass (11 existing + 4 new Sprint 020 tests)
- ✅ All 10 cost-runaway detector tests pass (CLAUDE.md requirement)
- ✅ BugCase read model inheritance verified
- ✅ Test fixtures updated only for pre-existing required alert_type field
- ✅ observation_count defaults to 1 (verified)
- ✅ detection_type accepts startup|runtime|reopen (verified)

## Test Execution

```
poetry run pytest tests/bugops/test_bugops_models.py tests/bugops/test_llm_traces_cost_source.py -v
Result: 25 passed
```

## Implementation Notes

- detection_type remains Optional at schema level for backward compatibility; Sprint 020 detectors enforce non-null via store/detector creation logic
- Ticket-specified path `src/tests/bugops/` does not exist; actual path is `tests/bugops/`
- No modifications to store.py, monitor.py, llm_traces.py, or config.py per CLAUDE.md
