### PR TITLE
task(bugops): TASK-100B add deterministic severity mapping for Sprint 020 detectors

### DIFF
--- a/docs/sprints/sprint-020/sprint-020-bugops-outcome-freshness.md
+++ b/docs/sprints/sprint-020/sprint-020-bugops-outcome-freshness.md
@@ -60,7 +60,7 @@ This sprint does not implement Evidence Packs, Investigations, Tickets, Railway 
 |----|-----------|--------------------------------------------------------------------|----------|-----|--------|
 | 1  | TASK-100  | Extend BugCase model with Sprint 020 fields                        | ✅ DONE  | S   | S      |
 | 2  | TASK-100A | Add canonical BugOps subsystem enum                                | ✅ DONE  | S   | S      |
-| 3  | TASK-100B | Add deterministic severity mapping for Sprint 020 detectors        | 🔲 OPEN  | S   |        |
+| 3  | TASK-100B | Add deterministic severity mapping for Sprint 020 detectors        | ✅ DONE  | S   | S      |
 | 4  | TASK-101  | Add MongoDB indexes for BugOps collections                         | 🔲 OPEN  | S   |        |
 | 5  | TASK-102  | Add `create_case_direct()` and `attach_observation_to_case()`      | 🔲 OPEN  | S   |        |
 | 6  | TASK-103  | Implement DependencyGraph v1                                       | 🔲 OPEN  | S   |        |
@@ -934,3 +934,18 @@ Neither sprint begins until Sprint 020 success criteria are fully met.
 **Next:**
 - TASK-100B: Deterministic severity mapping
 - TASK-101: MongoDB indexes
+
+### Session 2 (2026-06-12)
+
+**Completed:**
+- TASK-100B: Added deterministic severity mapping for Sprint 020 detectors
+  - Created `DETECTOR_SEVERITY` dict in signal_sources/severity.py with 4 freshness detectors → High severity
+  - Keys: article_freshness, signal_freshness, narrative_freshness, briefing_freshness (raw detector strings)
+  - Severity assigned deterministically at detection time, not computed dynamically
+  - Test coverage: 6 tests verifying all detectors present and all assigned High severity
+  - All 33 tests pass (6 new + 27 existing model tests)
+  - Branch: `task/bugops-100b-severity-mapping`, commit: 7f607e2
+
+**Next:**
+- TASK-101: MongoDB indexes for BugOps collections
+- TASK-102: create_case_direct() and attach_observation_to_case() store methods

--- a/src/crypto_news_aggregator/bugops/signal_sources/severity.py
+++ b/src/crypto_news_aggregator/bugops/signal_sources/severity.py
@@ -1,0 +1,14 @@
+"""Sprint 020 freshness detector severity mapping.
+
+Assigns deterministic severity to freshness detectors at detection time.
+Severity is not computed dynamically from observation count or blast radius.
+"""
+
+from crypto_news_aggregator.bugops.models import AlertSeverity
+
+DETECTOR_SEVERITY = {
+    "article_freshness": AlertSeverity.HIGH,
+    "signal_freshness": AlertSeverity.HIGH,
+    "narrative_freshness": AlertSeverity.HIGH,
+    "briefing_freshness": AlertSeverity.HIGH,
+}

--- a/tests/bugops/test_severity_mapping.py
+++ b/tests/bugops/test_severity_mapping.py
@@ -1,0 +1,40 @@
+"""Tests for Sprint 020 freshness detector severity mapping."""
+
+import pytest
+from crypto_news_aggregator.bugops.signal_sources.severity import DETECTOR_SEVERITY
+from crypto_news_aggregator.bugops.models import AlertSeverity
+
+
+def test_detector_severity_has_all_four_detectors():
+    """Test that DETECTOR_SEVERITY includes all four freshness detectors."""
+    assert len(DETECTOR_SEVERITY) == 4
+    assert "article_freshness" in DETECTOR_SEVERITY
+    assert "signal_freshness" in DETECTOR_SEVERITY
+    assert "narrative_freshness" in DETECTOR_SEVERITY
+    assert "briefing_freshness" in DETECTOR_SEVERITY
+
+
+def test_article_freshness_severity_is_high():
+    """Test ArticleFreshness detector severity is High."""
+    assert DETECTOR_SEVERITY["article_freshness"] == AlertSeverity.HIGH
+
+
+def test_signal_freshness_severity_is_high():
+    """Test SignalFreshness detector severity is High."""
+    assert DETECTOR_SEVERITY["signal_freshness"] == AlertSeverity.HIGH
+
+
+def test_narrative_freshness_severity_is_high():
+    """Test NarrativeFreshness detector severity is High."""
+    assert DETECTOR_SEVERITY["narrative_freshness"] == AlertSeverity.HIGH
+
+
+def test_briefing_freshness_severity_is_high():
+    """Test BriefingFreshness detector severity is High."""
+    assert DETECTOR_SEVERITY["briefing_freshness"] == AlertSeverity.HIGH
+
+
+def test_all_detectors_have_high_severity():
+    """Test that all Sprint 020 freshness detectors have High severity."""
+    for detector_name, severity in DETECTOR_SEVERITY.items():
+        assert severity == AlertSeverity.HIGH, f"{detector_name} should have High severity"


### PR DESCRIPTION
## Summary
- Created `DETECTOR_SEVERITY` mapping in `signal_sources/severity.py`
- All four freshness detectors (article, signal, narrative, briefing) assigned High severity
- Severity assigned deterministically at detection time, not computed dynamically
- 6 tests verify all detectors and severity levels

## Acceptance Criteria
✅ Each freshness detector produces High severity BugCases
✅ Severity is not computed dynamically from observation count or blast radius
✅ Notification routing can depend on this severity mapping

## Testing
✅ All 6 new tests pass
✅ All 27 existing model tests still pass